### PR TITLE
PopulateStruct to keep empty slice as nil

### DIFF
--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -11,6 +11,10 @@ dependencies:
 	$(ECHO_V)go install ./vendor/github.com/golang/lint/golint
 	@echo "Installing errcheck..."
 	$(ECHO_V)go install ./vendor/github.com/kisielk/errcheck
+	@echo "Installing thriftrw..."
+	$(ECHO_V)go install ./vendor/go.uber.org/thriftrw
+	@echo "Installing thriftrw-plugin-yarpc..."
+	$(ECHO_V)go install ./vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
 
 GOCOV := gocov
 OVERALLS := overalls

--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -11,10 +11,6 @@ dependencies:
 	$(ECHO_V)go install ./vendor/github.com/golang/lint/golint
 	@echo "Installing errcheck..."
 	$(ECHO_V)go install ./vendor/github.com/kisielk/errcheck
-	@echo "Installing thriftrw..."
-	$(ECHO_V)go install ./vendor/go.uber.org/thriftrw
-	@echo "Installing thriftrw-plugin-yarpc..."
-	$(ECHO_V)go install ./vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
 
 GOCOV := gocov
 OVERALLS := overalls

--- a/core/config/value.go
+++ b/core/config/value.go
@@ -466,7 +466,9 @@ func (cv ConfigurationValue) getValueStruct(key string, target interface{}) (int
 					break
 				}
 			}
-			fieldValue.Set(destSlice)
+			if destSlice.Len() > 0 {
+				fieldValue.Set(destSlice)
+			}
 		}
 
 	}

--- a/core/config/yaml_test.go
+++ b/core/config/yaml_test.go
@@ -131,14 +131,18 @@ emptystruct:
   nonexist: true
 `)
 
-func TestPopulateMismatchedStruct(t *testing.T) {
-	provider := NewProviderGroup("global", NewYAMLProviderFromBytes(emptyyaml))
+func TestMatchEmptyStruct(t *testing.T) {
+	provider := NewProviderGroup("global", NewYAMLProviderFromBytes([]byte(``)))
 	es := emptystruct{}
+	provider.GetValue("emptystruct").PopulateStruct(&es)
 	empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
 	assert.True(t, reflect.DeepEqual(empty, es))
+}
 
-	provider = NewProviderGroup("global", NewYAMLProviderFromBytes([]byte(``)))
-	es = emptystruct{}
+func TestMatchPopulatedEmptyStruct(t *testing.T) {
+	provider := NewProviderGroup("global", NewYAMLProviderFromBytes(emptyyaml))
+	es := emptystruct{}
 	provider.GetValue("emptystruct").PopulateStruct(&es)
+	empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
 	assert.True(t, reflect.DeepEqual(empty, es))
 }

--- a/core/config/yaml_test.go
+++ b/core/config/yaml_test.go
@@ -23,6 +23,7 @@ package config
 import (
 	"bytes"
 	"io/ioutil"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,4 +120,25 @@ func TestYamlNode_Callbacks(t *testing.T) {
 	p := NewYAMLProviderFromFiles(false, nil)
 	assert.NoError(t, p.RegisterChangeCallback("test", nil))
 	assert.NoError(t, p.UnregisterChangeCallback("token"))
+}
+
+type emptystruct struct {
+	Slice []string
+}
+
+var emptyyaml = []byte(`
+emptystruct:
+  nonexist: true
+`)
+
+func TestPopulateMismatchedStruct(t *testing.T) {
+	provider := NewProviderGroup("global", NewYAMLProviderFromBytes(emptyyaml))
+	es := emptystruct{}
+	empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
+	assert.True(t, reflect.DeepEqual(empty, es))
+
+	provider = NewProviderGroup("global", NewYAMLProviderFromBytes([]byte(``)))
+	es = emptystruct{}
+	provider.GetValue("emptystruct").PopulateStruct(&es)
+	assert.True(t, reflect.DeepEqual(empty, es))
 }

--- a/examples/keyvalue/Makefile
+++ b/examples/keyvalue/Makefile
@@ -1,9 +1,4 @@
-.PHONY: deps
-deps:
-	$(ECHO_V)which thriftrw > /dev/null || go get -u go.uber.org/thriftrw
-	$(ECHO_V)which thriftrw-plugin-yarpc > /dev/null || go get -u go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
-
-kv/types.go: kv.thrift deps
+kv/types.go: kv.thrift
 	$(ECHO_V)go generate
 
 server/server: $(wildcard server/*.go) kv/types.go

--- a/examples/keyvalue/Makefile
+++ b/examples/keyvalue/Makefile
@@ -1,4 +1,11 @@
-kv/types.go: kv.thrift
+.PHONY: deps
+deps:
+	@echo "Installing thriftrw..."
+	$(ECHO_V)go install ../../vendor/go.uber.org/thriftrw
+	@echo "Installing thriftrw-plugin-yarpc..."
+	$(ECHO_V)go install ../../vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
+
+kv/types.go: kv.thrift deps
 	$(ECHO_V)go generate
 
 server/server: $(wildcard server/*.go) kv/types.go

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
-hash: 07a85faa8ece4bd16fa206a870d04a98b74f1bb7c9b15d64c6866a1ce017dfb7
-updated: 2016-10-27T12:07:34.245239247-07:00
+hash: 42ff2b1ac9a75d5734d4141b56ac8c19fbd3679dfd479b34b3f43f416151af9f
+updated: 2016-11-01T16:30:17.314051732-07:00
 imports:
+- name: github.com/anmitsu/go-shlex
+  version: 53a3d8a8a362cca54fd6825caf2216aa6d8139fc
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/go-validator/validator
   version: 0a9835d809fb647a62611d30cb792e0b5dd65b11
-- name: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
-  subpackages:
-  - gomock
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+- name: github.com/jessevdk/go-flags
+  version: a8cab0163d48558ffd77076c9c99388529766f63
 - name: github.com/opentracing/opentracing-go
   version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
@@ -58,9 +58,8 @@ imports:
   - transport/internal
   - transport/tchannel
   - transport/tchannel/internal
-  - transport/transporttest
 - name: golang.org/x/net
-  version: b626cca987fa6333e5dd25baa0fd61708c145011
+  version: 541150ac4f433e755f5663eba5d888c2fa347343
   subpackages:
   - context
   - context/ctxhttp
@@ -72,7 +71,7 @@ testImports:
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/go-playground/overalls

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
-hash: 42ff2b1ac9a75d5734d4141b56ac8c19fbd3679dfd479b34b3f43f416151af9f
-updated: 2016-11-01T16:30:17.314051732-07:00
+hash: 71f1d9b5c524519f1f095322420065386eb8959b7602dd0376382c866d37b011
+updated: 2016-11-01T17:03:32.355802091-07:00
 imports:
-- name: github.com/anmitsu/go-shlex
-  version: 53a3d8a8a362cca54fd6825caf2216aa6d8139fc
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/go-validator/validator
@@ -11,8 +9,6 @@ imports:
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
-- name: github.com/jessevdk/go-flags
-  version: a8cab0163d48558ffd77076c9c99388529766f63
 - name: github.com/opentracing/opentracing-go
   version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
@@ -59,13 +55,15 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: golang.org/x/net
-  version: 541150ac4f433e755f5663eba5d888c2fa347343
+  version: 4bb47a1098b37d69980d96237e2ae4ff56bb5a95
   subpackages:
   - context
   - context/ctxhttp
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports:
+- name: github.com/anmitsu/go-shlex
+  version: 53a3d8a8a362cca54fd6825caf2216aa6d8139fc
 - name: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
   subpackages:
@@ -80,6 +78,8 @@ testImports:
   version: 3390df4df2787994aea98de825b964ac7944b817
   subpackages:
   - golint
+- name: github.com/jessevdk/go-flags
+  version: a8cab0163d48558ffd77076c9c99388529766f63
 - name: github.com/kisielk/errcheck
   version: 9c1292e1c962175f76516859f4a88aabd86dc495
 - name: github.com/kisielk/gotool

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,6 +13,8 @@ import:
   version: dev
 - package: go.uber.org/thriftrw
   version: dev
+- package: github.com/anmitsu/go-shlex
+- package: github.com/jessevdk/go-flags
 - package: github.com/go-validator/validator
   version: v2
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,10 +10,9 @@ import:
 - package: github.com/uber-go/atomic
   version: ^1.0.0
 - package: go.uber.org/yarpc
-# TODO: Use stable branch for yarpc
-  version: 5cb0df4c43be85f526cfe84352983966a83db29d
+  version: dev
 - package: go.uber.org/thriftrw
-  version: 6aa07c0009457cc6c7ff5497695f1581ad184350
+  version: dev
 - package: github.com/go-validator/validator
   version: v2
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,8 +13,6 @@ import:
   version: dev
 - package: go.uber.org/thriftrw
   version: dev
-- package: github.com/anmitsu/go-shlex
-- package: github.com/jessevdk/go-flags
 - package: github.com/go-validator/validator
   version: v2
 
@@ -23,6 +21,8 @@ testImport:
   version: 3fe2afc9e626f32e91aff6eddb78b14743446865
   subpackages:
   - cover
+- package: github.com/anmitsu/go-shlex
+- package: github.com/jessevdk/go-flags
 - package: github.com/mattn/goveralls
 # Necessary for goveralls
 - package: github.com/pborman/uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
 # TODO: Use stable branch for yarpc
   version: 5cb0df4c43be85f526cfe84352983966a83db29d
 - package: go.uber.org/thriftrw
-  version: dev
+  version: 6aa07c0009457cc6c7ff5497695f1581ad184350
 - package: github.com/go-validator/validator
   version: v2
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,8 @@ import:
 - package: github.com/uber-go/atomic
   version: ^1.0.0
 - package: go.uber.org/yarpc
-  version: dev
+# TODO: Use stable branch for yarpc
+  version: 5cb0df4c43be85f526cfe84352983966a83db29d
 - package: go.uber.org/thriftrw
   version: dev
 - package: github.com/go-validator/validator


### PR DESCRIPTION
GFM-59

If a key with a slice value is not present in the *.yaml file, PopulateStruct with the parent key populates the said slice as empty slice rather than nil. PR to set fieldValue only when destSlice is not empty, and keep nil otherwise. 

Added test to evaluate the inconsistent behavior. Without the change, first assertion would fail, since empty slice != nil
