### PR TITLE
Main readme changes + moving away module specific stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ func main() {
 It's common for a service to handle many different workloads. For example, a
 service may expose RPC endpoints and also ingest Kafka messages.
 
-In uberfx, there is a simpler model where we create a single binary,
+In UberFX, there is a simpler model where we create a single binary,
 but turn its modules on and off based on roles which are specified via the
 commmand line.
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Then running the above example will result in **Port is 3000**
 
 ## License
 
-See [LICENSE.txt](LICENSE.txt)
+[MIT](LICENSE.txt)
 
 [doc]: https://godoc.org/go.uber.org/fx
 [doc-img]: https://godoc.org/go.uber.org/fx?status.svg

--- a/modules/rpc/README.md
+++ b/modules/rpc/README.md
@@ -1,0 +1,42 @@
+# RPC Module
+
+The RPC module wraps [YARPC](https://github.com/yarpc/yarpc-go) and exposes
+creators for both JSON- and Thrift-encoded messages.
+
+This module works in a way that's pretty similar to existing RPC projects:
+
+* Create an IDL file and run the appropriate tools on it (e.g. **thriftrw**) to
+  generate the service and handler interfaces
+
+* Implement the service interface handlers as method receivers on a struct
+
+* Implement a top-level function, conforming to the
+  `rpc.CreateThriftServiceFunc` signature (`uberfx/modules/rpc/thrift.go` that
+  returns a `[]transport.Registrant` YARPC implementation from the handler:
+
+```go
+func NewMyServiceHandler(svc service.Host) ([]transport.Registrant, error) {
+  return myservice.New(&MyServiceHandler{}), nil
+}
+```
+
+* Pass that method into the module initialization:
+
+```go
+func main() {
+  svc, err := service.WithModules(
+    rpc.ThriftModule(
+      rpc.CreateThriftServiceFunc(NewMyServiceHandler),
+      modules.WithRoles("service"),
+    ),
+  ).Build()
+
+  if err != nil {
+    log.Fatal("Could not initialize service: ", err)
+  }
+
+  svc.Start(true)
+}
+```
+
+This will spin up the service.

--- a/modules/uhttp/README.md
+++ b/modules/uhttp/README.md
@@ -1,0 +1,38 @@
+# HTTP Module
+
+The HTTP module is built on top of [Gorilla Mux](https://github.com/gorilla/mux),
+but the details of that are abstracted away through `uhttp.RouteHandler`.
+
+```go
+package main
+
+import (
+  "io"
+  "net/http"
+
+  "go.uber.org/fx/modules/uhttp"
+  "go.uber.org/fx/service"
+)
+
+func main() {
+  service, err := service.WithModules(
+    uhttp.New(registerHTTP),
+  ).Build()
+
+  if err != nil {
+    log.Fatal("Could not initialize service: ", err)
+  }
+
+  service.Start(true)
+}
+
+func registerHTTP(service service.Host) []uhttp.RouteHandler {
+  handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    io.WriteString(w, "Hello, world")
+  })
+
+  return []uhttp.RouteHandler{
+    uhttp.NewRouteHandler("/", handleHome)
+  }
+}
+```


### PR DESCRIPTION
I feel like readmes about the modules do not belong in the main wiki and are much better placed in their respective sections.