### PR TITLE
Fix travis-ci badge path in the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,5 +312,5 @@ providers to supply override values to the component.
 [doc-img]: https://godoc.org/go.uber.org/fx?status.svg
 [cov]: https://coveralls.io/github/uber-go/uberfx?branch=master
 [cov-img]: https://coveralls.io/repos/github/uber-go/uberfx/badge.svg?branch=master
-[ci]: https://travis-ci.org/uber-go/uberfx
-[ci-img]: https://travis-ci.org/uber-go/uberfx.svg?branch=master
+[ci]: https://travis-ci.org/uber-go/fx
+[ci-img]: https://travis-ci.org/uber-go/fx.svg?branch=master


### PR DESCRIPTION
Fixing this
![image](https://cloud.githubusercontent.com/assets/816680/19918640/311de9fa-a08a-11e6-847d-b6bd58082bff.png)
