### PR TITLE
Fix bench target

### DIFF
--- a/.build/flags.mk
+++ b/.build/flags.mk
@@ -1,5 +1,6 @@
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
+BENCH_PKGS ?= $(shell go list ./... | grep -v /vendor/)
 # Many Go tools take file globs or directories as arguments instead of packages.
 PKG_FILES ?= *.go core service examples internal modules
 FILES_TO_FORMAT ?= *.go core service internal modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.out
 *.html
 *.coverprofile
+*.pprof
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ coveralls: $(COV_REPORT)
 .PHONY: bench
 BENCH ?= .
 bench:
-	$(ECHO_V)$(foreach pkg,$(BENCH_PKGS),go test -run="^$$" $(BENCH_FLAGS) $(pkg);)
+	$(ECHO_V)$(foreach pkg,$(BENCH_PKGS),go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) $(pkg);)
 
 include $(SUPPORT_FILES)/lint.mk
 include $(SUPPORT_FILES)/licence.mk

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ coveralls: $(COV_REPORT)
 .PHONY: bench
 BENCH ?= .
 bench:
-	$(ECHO_V)$(foreach pkg,$(PKGS),go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) $(pkg);)
+	$(ECHO_V)$(foreach pkg,$(BENCH_PKGS),go test -run="^$$" $(BENCH_FLAGS) $(pkg);)
 
 include $(SUPPORT_FILES)/lint.mk
 include $(SUPPORT_FILES)/licence.mk


### PR DESCRIPTION
Unclear why `glide nv` is not working correctly for our use case, I suspect it's due to the fact that we have many nested packages.

In the meantime, this fixes `make bench`