### PR TITLE
Un-stutter exported config interfaces

### DIFF
--- a/core/config/README.md
+++ b/core/config/README.md
@@ -33,14 +33,14 @@ For example, if you were to implement a ZooKeeper-backed
 `Provider`, you'd likely need to specify (via YAML or environment
 variables) where your ZooKeeper nodes live.
 
-## ConfigurationValue
+## Value
 
-`ConfigurationValue` is the return type of every configuration providers'
+`Value` is the return type of every configuration providers'
 `GetValue(key string)` method. Under the hood, we use the empty interface
 (`interface{}`) since we don't necessarily know the structure of your
 configuration ahead of time.
 
-You can use a `ConfigurationValue` for two main purposes:
+You can use a `Value` for two main purposes:
 
 * Get a single value out of configuration.
 

--- a/core/config/README.md
+++ b/core/config/README.md
@@ -9,16 +9,16 @@ In UberFx, we try very hard to make configuring UberFx convenient. Users can:
 * Get components working with minimal configuration
 * Override any field if the default doesn't make sense for their use case
 
-## ConfigurationProvider
+## Provider
 
-`ConfigurationProvider` is the interface for anything that can provide values.
+`Provider` is the interface for anything that can provide values.
 We provide a few reference implementations (environment and YAML), but you are
 free to register your own providers via `config.RegisterProviders()` and
 `config.RegisterDynamicProviders`.
 
 ### Static configuration providers
 
-Static configuration providers conform to the `ConfigurationProvider` interface
+Static configuration providers conform to the `Provider` interface
 and are bootstraped first. Use these for simple providers such as file-backed or
 environment-based configuration providers.
 
@@ -26,11 +26,11 @@ environment-based configuration providers.
 
 Dynamic configuration providers frequently need some bootstrap configuration to
 be useful, so UberFx treats them specially. Dynamic configuration providers
-conform to the `ConfigurationProvider` interface, but they're instantianted
-**after** the Static `ConfigurationProvider`s on order to read bootstarp values.
+conform to the `Provider` interface, but they're instantianted
+**after** the Static `Provider`s on order to read bootstarp values.
 
 For example, if you were to implement a ZooKeeper-backed
-`ConfigurationProvider`, you'd likely need to specify (via YAML or environment
+`Provider`, you'd likely need to specify (via YAML or environment
 variables) where your ZooKeeper nodes live.
 
 ## ConfigurationValue

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -75,14 +75,14 @@ func getResolver() FileResolver {
 
 // YamlProvider returns function to create Yaml based configuration provider
 func YamlProvider() ProviderFunc {
-	return func() (ConfigurationProvider, error) {
+	return func() (Provider, error) {
 		return NewYAMLProviderFromFiles(false, getResolver(), getConfigFiles()...), nil
 	}
 }
 
 // EnvProvider returns function to create environment based config provider
 func EnvProvider() ProviderFunc {
-	return func() (ConfigurationProvider, error) {
+	return func() (Provider, error) {
 		return NewEnvProvider(defaultEnvPrefix, nil), nil
 	}
 }
@@ -116,10 +116,10 @@ func GetEnvironmentPrefix() string {
 }
 
 // ProviderFunc is used to create config providers on configuration initialization
-type ProviderFunc func() (ConfigurationProvider, error)
+type ProviderFunc func() (Provider, error)
 
 // DynamicProviderFunc is used to create config providers on configuration initialization
-type DynamicProviderFunc func(config ConfigurationProvider) (ConfigurationProvider, error)
+type DynamicProviderFunc func(config Provider) (Provider, error)
 
 // RegisterProviders registers configuration providers for the global config
 func RegisterProviders(providerFuncs ...ProviderFunc) {
@@ -129,7 +129,7 @@ func RegisterProviders(providerFuncs ...ProviderFunc) {
 }
 
 // RegisterDynamicProviders registers dynamic config providers for the global config
-// Dynamic provider initialization needs access to ConfigurationProvider for accessing necessary
+// Dynamic provider initialization needs access to Provider for accessing necessary
 // information for bootstrap, such as port number,keys, endpoints etc.
 func RegisterDynamicProviders(dynamicProviderFuncs ...DynamicProviderFunc) {
 	_setupMux.Lock()
@@ -150,9 +150,9 @@ func UnregisterProviders() {
 	_dynamicProviderFuncs = nil
 }
 
-// Load creates a ConfigurationProvider for use in a service
-func Load() ConfigurationProvider {
-	var static []ConfigurationProvider
+// Load creates a Provider for use in a service
+func Load() Provider {
+	var static []Provider
 	for _, providerFunc := range _staticProviderFuncs {
 		cp, err := providerFunc()
 		if err != nil {
@@ -162,7 +162,7 @@ func Load() ConfigurationProvider {
 	}
 	baseCfg := NewProviderGroup("global", static...)
 
-	var dynamic = make([]ConfigurationProvider, 0, 2)
+	var dynamic = make([]Provider, 0, 2)
 	for _, providerFunc := range _dynamicProviderFuncs {
 		cp, err := providerFunc(baseCfg)
 		if err != nil {

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -267,7 +267,7 @@ func TestRegisteredProvidersInitialization(t *testing.T) {
 	RegisterProviders(StaticProvider(map[string]interface{}{
 		"hello": "world",
 	}))
-	RegisterDynamicProviders(func(dynamic ConfigurationProvider) (ConfigurationProvider, error) {
+	RegisterDynamicProviders(func(dynamic Provider) (Provider, error) {
 		return NewStaticProvider(map[string]interface{}{
 			"dynamic": "provider",
 		}), nil
@@ -282,7 +282,7 @@ func TestRegisteredProvidersInitialization(t *testing.T) {
 }
 
 func TestNilProvider(t *testing.T) {
-	RegisterProviders(func() (ConfigurationProvider, error) {
+	RegisterProviders(func() (Provider, error) {
 		return nil, fmt.Errorf("error creating Provider")
 	})
 	assert.Panics(t, func() { Load() }, "Can't initialize with nil provider")
@@ -293,7 +293,7 @@ func TestNilProvider(t *testing.T) {
 	}()
 
 	UnregisterProviders()
-	RegisterProviders(func() (ConfigurationProvider, error) {
+	RegisterProviders(func() (Provider, error) {
 		return nil, nil
 	})
 	// don't panic on Load

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -37,14 +37,14 @@ For example, if you were to implement a ZooKeeper-backed
 Provider, you'd likely need to specify (via YAML or environment
 variables) where your ZooKeeper nodes live.
 
-ConfigurationValue
+Value
 
-ConfigurationValue is the return type of every configuration providers'
+Value is the return type of every configuration providers'
 GetValue(key string) method. Under the hood, we use the empty interface
 (interface{}) since we don't necessarily know the structure of your
 configuration ahead of time.
 
-You can use a ConfigurationValue for two main purposes:
+You can use a Value for two main purposes:
 
 • Get a single value out of configuration.
 

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -13,16 +13,16 @@ In UberFx, we try very hard to make configuring UberFx convenient. Users can:
 
 
 
-ConfigurationProvider
+Provider
 
-ConfigurationProvider is the interface for anything that can provide values.
+Provider is the interface for anything that can provide values.
 We provide a few reference implementations (environment and YAML), but you are
 free to register your own providers via config.RegisterProviders() and
 config.RegisterDynamicProviders.
 
 Static configuration providers
 
-Static configuration providers conform to the ConfigurationProvider interface
+Static configuration providers conform to the Provider interface
 and are bootstraped first. Use these for simple providers such as file-backed or
 environment-based configuration providers.
 
@@ -30,11 +30,11 @@ Dynamic Configuration Providers
 
 Dynamic configuration providers frequently need some bootstrap configuration to
 be useful, so UberFx treats them specially. Dynamic configuration providers
-conform to the ConfigurationProvider interface, but they're instantianted
-**after** the Static ConfigurationProviders on order to read bootstarp values.
+conform to the Provider interface, but they're instantianted
+**after** the Static Providers on order to read bootstarp values.
 
 For example, if you were to implement a ZooKeeper-backed
-ConfigurationProvider, you'd likely need to specify (via YAML or environment
+Provider, you'd likely need to specify (via YAML or environment
 variables) where your ZooKeeper nodes live.
 
 ConfigurationValue

--- a/core/config/env.go
+++ b/core/config/env.go
@@ -38,7 +38,7 @@ type EnvironmentValueProvider interface {
 	GetValue(key string) (string, bool)
 }
 
-var _ ConfigurationProvider = &envConfigProvider{}
+var _ Provider = &envConfigProvider{}
 
 // foo.bar -> [prefix]__foo__bar
 func toEnvString(prefix string, key string) string {
@@ -46,7 +46,7 @@ func toEnvString(prefix string, key string) string {
 }
 
 // NewEnvProvider creates a configuration provider backed by an environment
-func NewEnvProvider(prefix string, provider EnvironmentValueProvider) ConfigurationProvider {
+func NewEnvProvider(prefix string, provider EnvironmentValueProvider) Provider {
 	e := envConfigProvider{
 		prefix:   prefix,
 		provider: provider,
@@ -71,7 +71,7 @@ func (p envConfigProvider) GetValue(key string) ConfigurationValue {
 	return cv
 }
 
-func (p envConfigProvider) Scope(prefix string) ConfigurationProvider {
+func (p envConfigProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, p)
 }
 

--- a/core/config/env.go
+++ b/core/config/env.go
@@ -62,12 +62,12 @@ func (p envConfigProvider) Name() string {
 	return "env"
 }
 
-func (p envConfigProvider) GetValue(key string) ConfigurationValue {
+func (p envConfigProvider) GetValue(key string) Value {
 	env := toEnvString(p.prefix, key)
 
-	var cv ConfigurationValue
+	var cv Value
 	value, found := p.provider.GetValue(env)
-	cv = NewConfigurationValue(p, key, value, found, String, nil)
+	cv = NewValue(p, key, value, found, String, nil)
 	return cv
 }
 

--- a/core/config/provider.go
+++ b/core/config/provider.go
@@ -25,14 +25,14 @@ import "fmt"
 // ConfigurationChangeCallback is called for updates of configuration data
 type ConfigurationChangeCallback func(key string, provider string, configdata interface{})
 
-// A ConfigurationProvider provides a unified interface to accessing
+// A Provider provides a unified interface to accessing
 // configuration systems.
-type ConfigurationProvider interface {
+type Provider interface {
 	// the Name of the provider (YAML, Env, etc)
 	Name() string
 	// GetValue pulls a config value
 	GetValue(key string) ConfigurationValue
-	Scope(prefix string) ConfigurationProvider
+	Scope(prefix string) Provider
 
 	// A RegisterChangeCallback provides callback registration for config providers.
 	// These callbacks are noop if a dynamic provider is not configured for the service.
@@ -46,13 +46,13 @@ func keyNotFound(key string) error {
 
 // ScopedProvider defines recursive interface of providers based on the prefix
 type ScopedProvider struct {
-	ConfigurationProvider
+	Provider
 
 	prefix string
 }
 
 // NewScopedProvider creates a child provider given a prefix
-func NewScopedProvider(prefix string, provider ConfigurationProvider) ConfigurationProvider {
+func NewScopedProvider(prefix string, provider Provider) Provider {
 	return &ScopedProvider{provider, prefix}
 }
 
@@ -61,10 +61,10 @@ func (sp ScopedProvider) GetValue(key string) ConfigurationValue {
 	if sp.prefix != "" {
 		key = fmt.Sprintf("%s.%s", sp.prefix, key)
 	}
-	return sp.ConfigurationProvider.GetValue(key)
+	return sp.Provider.GetValue(key)
 }
 
 // Scope returns new scoped provider, given a prefix
-func (sp ScopedProvider) Scope(prefix string) ConfigurationProvider {
+func (sp ScopedProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, sp)
 }

--- a/core/config/provider.go
+++ b/core/config/provider.go
@@ -31,7 +31,7 @@ type Provider interface {
 	// the Name of the provider (YAML, Env, etc)
 	Name() string
 	// GetValue pulls a config value
-	GetValue(key string) ConfigurationValue
+	GetValue(key string) Value
 	Scope(prefix string) Provider
 
 	// A RegisterChangeCallback provides callback registration for config providers.
@@ -57,7 +57,7 @@ func NewScopedProvider(prefix string, provider Provider) Provider {
 }
 
 // GetValue returns configuration value
-func (sp ScopedProvider) GetValue(key string) ConfigurationValue {
+func (sp ScopedProvider) GetValue(key string) Value {
 	if sp.prefix != "" {
 		key = fmt.Sprintf("%s.%s", sp.prefix, key)
 	}

--- a/core/config/provider_group.go
+++ b/core/config/provider_group.go
@@ -44,8 +44,8 @@ func (p providerGroup) WithProvider(provider Provider) Provider {
 	}
 }
 
-func (p providerGroup) GetValue(key string) ConfigurationValue {
-	cv := NewConfigurationValue(p, key, nil, false, GetValueType(nil), nil)
+func (p providerGroup) GetValue(key string) Value {
+	cv := NewValue(p, key, nil, false, GetValueType(nil), nil)
 
 	// loop through the providers and return the value defined by the highest priority provider
 	for _, provider := range p.providers {

--- a/core/config/provider_group.go
+++ b/core/config/provider_group.go
@@ -22,25 +22,25 @@ package config
 
 type providerGroup struct {
 	name      string
-	providers []ConfigurationProvider
+	providers []Provider
 }
 
 // NewProviderGroup creates a configuration provider from a group of backends
-func NewProviderGroup(name string, providers ...ConfigurationProvider) ConfigurationProvider {
+func NewProviderGroup(name string, providers ...Provider) Provider {
 	group := providerGroup{
 		name: name,
 	}
 	for _, provider := range providers {
-		group.providers = append([]ConfigurationProvider{provider}, group.providers...)
+		group.providers = append([]Provider{provider}, group.providers...)
 	}
 	return group
 }
 
-// WithProvider updates the current ConfigurationProvider
-func (p providerGroup) WithProvider(provider ConfigurationProvider) ConfigurationProvider {
+// WithProvider updates the current Provider
+func (p providerGroup) WithProvider(provider Provider) Provider {
 	return providerGroup{
 		name:      p.name,
-		providers: append([]ConfigurationProvider{provider}, p.providers...),
+		providers: append([]Provider{provider}, p.providers...),
 	}
 }
 
@@ -83,6 +83,6 @@ func (p providerGroup) UnregisterChangeCallback(token string) error {
 	return nil
 }
 
-func (p providerGroup) Scope(prefix string) ConfigurationProvider {
+func (p providerGroup) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, p)
 }

--- a/core/config/provider_group_test.go
+++ b/core/config/provider_group_test.go
@@ -75,9 +75,9 @@ func (*mockDynamicProvider) Name() string {
 	return "mock"
 }
 
-func (s *mockDynamicProvider) GetValue(key string) ConfigurationValue {
+func (s *mockDynamicProvider) GetValue(key string) Value {
 	val, found := s.data[key]
-	return NewConfigurationValue(s, key, val, found, GetValueType(val), nil)
+	return NewValue(s, key, val, found, GetValueType(val), nil)
 }
 
 func (s *mockDynamicProvider) Scope(prefix string) Provider {

--- a/core/config/provider_group_test.go
+++ b/core/config/provider_group_test.go
@@ -65,7 +65,7 @@ type mockDynamicProvider struct {
 }
 
 // StaticProvider should only be used in tests to isolate config from your environment
-func newMockDynamicProvider(data map[string]interface{}) ConfigurationProvider {
+func newMockDynamicProvider(data map[string]interface{}) Provider {
 	return &mockDynamicProvider{
 		data: data,
 	}
@@ -80,7 +80,7 @@ func (s *mockDynamicProvider) GetValue(key string) ConfigurationValue {
 	return NewConfigurationValue(s, key, val, found, GetValueType(val), nil)
 }
 
-func (s *mockDynamicProvider) Scope(prefix string) ConfigurationProvider {
+func (s *mockDynamicProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, s)
 }
 

--- a/core/config/static_provider.go
+++ b/core/config/static_provider.go
@@ -31,13 +31,13 @@ type staticProvider struct {
 }
 
 type scopedStaticProvider struct {
-	ConfigurationProvider
+	Provider
 
 	prefix string
 }
 
 // NewStaticProvider should only be used in tests to isolate config from your environment
-func NewStaticProvider(data map[string]interface{}) ConfigurationProvider {
+func NewStaticProvider(data map[string]interface{}) Provider {
 	return &staticProvider{
 		data: data,
 	}
@@ -45,7 +45,7 @@ func NewStaticProvider(data map[string]interface{}) ConfigurationProvider {
 
 // StaticProvider returns function to create StaticProvider during configuration initialization
 func StaticProvider(data map[string]interface{}) ProviderFunc {
-	return func() (ConfigurationProvider, error) {
+	return func() (Provider, error) {
 		return NewStaticProvider(data), nil
 	}
 }
@@ -67,7 +67,7 @@ func (s *staticProvider) GetValue(key string) ConfigurationValue {
 	return NewConfigurationValue(s, key, val, found, GetValueType(val), nil)
 }
 
-func (s *staticProvider) Scope(prefix string) ConfigurationProvider {
+func (s *staticProvider) Scope(prefix string) Provider {
 	return newScopedStaticProvider(s, prefix)
 }
 
@@ -81,10 +81,10 @@ func (s *staticProvider) UnregisterChangeCallback(token string) error {
 	return nil
 }
 
-func newScopedStaticProvider(s *staticProvider, prefix string) ConfigurationProvider {
+func newScopedStaticProvider(s *staticProvider, prefix string) Provider {
 	return &scopedStaticProvider{
-		ConfigurationProvider: s,
-		prefix:                prefix,
+		Provider: s,
+		prefix:   prefix,
 	}
 }
 
@@ -92,8 +92,8 @@ func (s *scopedStaticProvider) GetValue(key string) ConfigurationValue {
 	if s.prefix != "" {
 		key = fmt.Sprintf("%s.%s", s.prefix, key)
 	}
-	return s.ConfigurationProvider.GetValue(key)
+	return s.Provider.GetValue(key)
 }
 
-var _ ConfigurationProvider = &staticProvider{}
-var _ ConfigurationProvider = &scopedStaticProvider{}
+var _ Provider = &staticProvider{}
+var _ Provider = &scopedStaticProvider{}

--- a/core/config/static_provider.go
+++ b/core/config/static_provider.go
@@ -54,17 +54,17 @@ func (*staticProvider) Name() string {
 	return "static"
 }
 
-func (s *staticProvider) GetValue(key string) ConfigurationValue {
+func (s *staticProvider) GetValue(key string) Value {
 	s.RLock()
 	defer s.RUnlock()
 
 	if key == "" {
 		// NOTE: This returns access to the underlying map, which does not guarantee
 		// thread-safety. This is only used in the test suite.
-		return NewConfigurationValue(s, key, s.data, true, GetValueType(s.data), nil)
+		return NewValue(s, key, s.data, true, GetValueType(s.data), nil)
 	}
 	val, found := s.data[key]
-	return NewConfigurationValue(s, key, val, found, GetValueType(val), nil)
+	return NewValue(s, key, val, found, GetValueType(val), nil)
 }
 
 func (s *staticProvider) Scope(prefix string) Provider {
@@ -88,7 +88,7 @@ func newScopedStaticProvider(s *staticProvider, prefix string) Provider {
 	}
 }
 
-func (s *scopedStaticProvider) GetValue(key string) ConfigurationValue {
+func (s *scopedStaticProvider) GetValue(key string) Value {
 	if s.prefix != "" {
 		key = fmt.Sprintf("%s.%s", s.prefix, key)
 	}

--- a/core/config/value.go
+++ b/core/config/value.go
@@ -77,8 +77,8 @@ func GetValueType(value interface{}) ValueType {
 	return Invalid
 }
 
-// A ConfigurationValue holds the value of a configuration
-type ConfigurationValue struct {
+// A Value holds the value of a configuration
+type Value struct {
 	root         Provider
 	provider     Provider
 	key          string
@@ -89,17 +89,17 @@ type ConfigurationValue struct {
 	Type         ValueType
 }
 
-// NewConfigurationValue creates a configuration value from a provider and a set
+// NewValue creates a configuration value from a provider and a set
 // of parameters describing the key
-func NewConfigurationValue(
+func NewValue(
 	provider Provider,
 	key string,
 	value interface{},
 	found bool,
 	t ValueType,
 	timestamp *time.Time,
-) ConfigurationValue {
-	cv := ConfigurationValue{
+) Value {
+	cv := Value{
 		provider:     provider,
 		key:          key,
 		value:        value,
@@ -117,7 +117,7 @@ func NewConfigurationValue(
 }
 
 // Source returns a configuration provider's name
-func (cv ConfigurationValue) Source() string {
+func (cv Value) Source() string {
 	if cv.provider == nil {
 		return ""
 	}
@@ -125,7 +125,7 @@ func (cv ConfigurationValue) Source() string {
 }
 
 // LastUpdated returns when the configuration value was last updated
-func (cv ConfigurationValue) LastUpdated() time.Time {
+func (cv Value) LastUpdated() time.Time {
 	if !cv.HasValue() {
 		return time.Time{} // zero value if never updated?
 	}
@@ -134,7 +134,7 @@ func (cv ConfigurationValue) LastUpdated() time.Time {
 
 // WithDefault creates a shallow copy of the current configuration value and
 // sets its default.
-func (cv ConfigurationValue) WithDefault(value interface{}) ConfigurationValue {
+func (cv Value) WithDefault(value interface{}) Value {
 	// TODO: create a "DefaultProvider" and chain that into the bottom of the current provider:
 	//
 	// provider = NewProviderGroup(defaultProvider, cv.provider)
@@ -152,12 +152,12 @@ func (cv ConfigurationValue) WithDefault(value interface{}) ConfigurationValue {
 
 // ChildKeys returns the child keys
 // TODO(ai) what is this and do we need to keep it?
-func (cv ConfigurationValue) ChildKeys() []string {
+func (cv Value) ChildKeys() []string {
 	return nil
 }
 
 // TryAsString attempts to return the configuration value as a string
-func (cv ConfigurationValue) TryAsString() (string, bool) {
+func (cv Value) TryAsString() (string, bool) {
 	v := cv.Value()
 	if val, err := convertValue(v, reflect.TypeOf("")); v != nil && err == nil {
 		return val.(string), true
@@ -166,7 +166,7 @@ func (cv ConfigurationValue) TryAsString() (string, bool) {
 }
 
 // TryAsInt attempts to return the confniguration value as an int
-func (cv ConfigurationValue) TryAsInt() (int, bool) {
+func (cv Value) TryAsInt() (int, bool) {
 	v := cv.Value()
 	if val, err := convertValue(v, reflect.TypeOf(0)); v != nil && err == nil {
 		return val.(int), true
@@ -176,7 +176,7 @@ func (cv ConfigurationValue) TryAsInt() (int, bool) {
 }
 
 // TryAsBool attempts to return the configuration value as a bool
-func (cv ConfigurationValue) TryAsBool() (bool, bool) {
+func (cv Value) TryAsBool() (bool, bool) {
 	v := cv.Value()
 	if val, err := convertValue(v, reflect.TypeOf(true)); v != nil && err == nil {
 		return val.(bool), true
@@ -186,7 +186,7 @@ func (cv ConfigurationValue) TryAsBool() (bool, bool) {
 }
 
 // TryAsFloat attempts to return the configuration value as a float
-func (cv ConfigurationValue) TryAsFloat() (float64, bool) {
+func (cv Value) TryAsFloat() (float64, bool) {
 	f := float64(0)
 	v := cv.Value()
 	if val, err := convertValue(v, reflect.TypeOf(f)); v != nil && err == nil {
@@ -197,7 +197,7 @@ func (cv ConfigurationValue) TryAsFloat() (float64, bool) {
 
 // AsString returns the configuration value as a string, or panics if not
 // string-able
-func (cv ConfigurationValue) AsString() string {
+func (cv Value) AsString() string {
 	s, ok := cv.TryAsString()
 	if !ok {
 		panic(fmt.Sprintf("Can't convert to string: %v", cv.Value()))
@@ -207,7 +207,7 @@ func (cv ConfigurationValue) AsString() string {
 
 // AsInt returns the configuration value as an int, or panics if not
 // int-able
-func (cv ConfigurationValue) AsInt() int {
+func (cv Value) AsInt() int {
 	s, ok := cv.TryAsInt()
 	if !ok {
 		panic(fmt.Sprintf("Can't convert to int: %T %v", cv.Value(), cv.Value()))
@@ -217,7 +217,7 @@ func (cv ConfigurationValue) AsInt() int {
 
 // AsFloat returns the configuration value as an float64, or panics if not
 // float64-able
-func (cv ConfigurationValue) AsFloat() float64 {
+func (cv Value) AsFloat() float64 {
 	s, ok := cv.TryAsFloat()
 	if !ok {
 		panic(fmt.Sprintf("Can't convert to float64: %v", cv.Value()))
@@ -227,7 +227,7 @@ func (cv ConfigurationValue) AsFloat() float64 {
 
 // AsBool returns the configuration value as an bool, or panics if not
 // bool-able
-func (cv ConfigurationValue) AsBool() bool {
+func (cv Value) AsBool() bool {
 	s, ok := cv.TryAsBool()
 	if !ok {
 		panic(fmt.Sprintf("Can't convert to bool: %v", cv.Value()))
@@ -236,19 +236,19 @@ func (cv ConfigurationValue) AsBool() bool {
 }
 
 // IsDefault returns whether the return value is the default.
-func (cv ConfigurationValue) IsDefault() bool {
+func (cv Value) IsDefault() bool {
 	// TODO(ai) what should the semantics be if the provider has a value that's
 	// the same as the default value?
 	return !cv.found && cv.defaultValue != nil
 }
 
 // HasValue returns whether the configuration has a value that can be used
-func (cv ConfigurationValue) HasValue() bool {
+func (cv Value) HasValue() bool {
 	return cv.found || cv.IsDefault()
 }
 
 // Value returns the underlying configuration's value
-func (cv ConfigurationValue) Value() interface{} {
+func (cv Value) Value() interface{} {
 	if cv.found {
 		return cv.value
 	}
@@ -337,7 +337,7 @@ func convertValue(value interface{}, targetType reflect.Type) (interface{}, erro
 }
 
 // PopulateStruct fills in a struct from configuration
-func (cv ConfigurationValue) PopulateStruct(target interface{}) bool {
+func (cv Value) PopulateStruct(target interface{}) bool {
 	if !cv.HasValue() {
 		return false
 	}
@@ -347,14 +347,14 @@ func (cv ConfigurationValue) PopulateStruct(target interface{}) bool {
 	return found
 }
 
-func (cv ConfigurationValue) getGlobalProvider() Provider {
+func (cv Value) getGlobalProvider() Provider {
 	if cv.root == nil {
 		return cv.provider
 	}
 	return cv.root
 }
 
-func (cv ConfigurationValue) getValueStruct(key string, target interface{}) (interface{}, bool, error) {
+func (cv Value) getValueStruct(key string, target interface{}) (interface{}, bool, error) {
 	// walk through the struct and start asking the providers for values at each key.
 	//
 	// - for individual values, we terminate

--- a/core/config/value.go
+++ b/core/config/value.go
@@ -79,8 +79,8 @@ func GetValueType(value interface{}) ValueType {
 
 // A ConfigurationValue holds the value of a configuration
 type ConfigurationValue struct {
-	root         ConfigurationProvider
-	provider     ConfigurationProvider
+	root         Provider
+	provider     Provider
 	key          string
 	value        interface{}
 	found        bool
@@ -92,7 +92,7 @@ type ConfigurationValue struct {
 // NewConfigurationValue creates a configuration value from a provider and a set
 // of parameters describing the key
 func NewConfigurationValue(
-	provider ConfigurationProvider,
+	provider Provider,
 	key string,
 	value interface{},
 	found bool,
@@ -145,7 +145,7 @@ func (cv ConfigurationValue) WithDefault(value interface{}) ConfigurationValue {
 }
 
 // TODO: Support enumerating child keys
-// 1. Add a method on ConfigurationProvider to get the child keys for a given prefix
+// 1. Add a method on Provider to get the child keys for a given prefix
 // 2. Implement in the various providers
 // 3. Merge the list here
 // 4. Return the set of keys.
@@ -347,7 +347,7 @@ func (cv ConfigurationValue) PopulateStruct(target interface{}) bool {
 	return found
 }
 
-func (cv ConfigurationValue) getGlobalProvider() ConfigurationProvider {
+func (cv ConfigurationValue) getGlobalProvider() Provider {
 	if cv.root == nil {
 		return cv.provider
 	}

--- a/core/config/yaml.go
+++ b/core/config/yaml.go
@@ -116,13 +116,13 @@ func (y yamlConfigProvider) Name() string {
 }
 
 // GetValue returns a configuration value by name
-func (y yamlConfigProvider) GetValue(key string) ConfigurationValue {
+func (y yamlConfigProvider) GetValue(key string) Value {
 	node := y.getNode(key)
 
 	if node == nil {
-		return NewConfigurationValue(y, key, nil, false, Invalid, nil)
+		return NewValue(y, key, nil, false, Invalid, nil)
 	}
-	return NewConfigurationValue(y, key, node.value, true, GetValueType(node.value), nil)
+	return NewValue(y, key, node.value, true, GetValueType(node.value), nil)
 }
 
 // Scope returns a scoped configuration provider

--- a/core/config/yaml.go
+++ b/core/config/yaml.go
@@ -35,9 +35,9 @@ type yamlConfigProvider struct {
 	roots []*yamlNode
 }
 
-var _ ConfigurationProvider = &yamlConfigProvider{}
+var _ Provider = &yamlConfigProvider{}
 
-func newYAMLProviderCore(files ...io.ReadCloser) ConfigurationProvider {
+func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 	roots := make([]*yamlNode, len(files))
 
 	for n, v := range files {
@@ -55,7 +55,7 @@ func newYAMLProviderCore(files ...io.ReadCloser) ConfigurationProvider {
 
 // NewYAMLProviderFromFiles creates a configration provider from a set of YAML file
 // names
-func NewYAMLProviderFromFiles(mustExist bool, resolver FileResolver, files ...string) ConfigurationProvider {
+func NewYAMLProviderFromFiles(mustExist bool, resolver FileResolver, files ...string) Provider {
 
 	if resolver == nil {
 		resolver = NewRelativeResolver()
@@ -76,13 +76,13 @@ func NewYAMLProviderFromFiles(mustExist bool, resolver FileResolver, files ...st
 
 // NewYamlProviderFromReader creates a configuration provider from an
 // io.ReadCloser
-func NewYamlProviderFromReader(reader io.ReadCloser) ConfigurationProvider {
+func NewYamlProviderFromReader(reader io.ReadCloser) Provider {
 	return newYAMLProviderCore(reader)
 }
 
 // NewYAMLProviderFromBytes creates a config provider from a byte-backed YAML
 // blob.
-func NewYAMLProviderFromBytes(yaml []byte) ConfigurationProvider {
+func NewYAMLProviderFromBytes(yaml []byte) Provider {
 	reader := bytes.NewReader(yaml)
 	node, err := newyamlNode(ioutil.NopCloser(reader))
 	if err != nil {
@@ -126,7 +126,7 @@ func (y yamlConfigProvider) GetValue(key string) ConfigurationValue {
 }
 
 // Scope returns a scoped configuration provider
-func (y yamlConfigProvider) Scope(prefix string) ConfigurationProvider {
+func (y yamlConfigProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, y)
 }
 

--- a/core/config/yaml_benchmark_test.go
+++ b/core/config/yaml_benchmark_test.go
@@ -129,11 +129,11 @@ func BenchmarkYAMLPopulateStructNestedMultipleFiles(b *testing.B) {
 	}
 }
 
-func providerOneFile() ConfigurationProvider {
+func providerOneFile() Provider {
 	return NewYAMLProviderFromFiles(false, NewRelativeResolver("./testdata"), "benchmark1.yaml")
 }
 
-func providerTwoFiles() ConfigurationProvider {
+func providerTwoFiles() Provider {
 	return NewYAMLProviderFromFiles(
 		false,
 		NewRelativeResolver("./testdata"),

--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -47,7 +47,7 @@ var (
 // service.Host conforms to this, but can't be used directly since it causes an import cycle
 type ScopeInit interface {
 	Name() string
-	Config() config.ConfigurationProvider
+	Config() config.Provider
 }
 
 // ScopeFunc is used during service init time to register the reporter

--- a/core/metrics/metrics_test.go
+++ b/core/metrics/metrics_test.go
@@ -80,14 +80,14 @@ func getScope() tally.RootScope {
 
 type scopeIniter struct {
 	name   string
-	config config.ConfigurationProvider
+	config config.Provider
 }
 
 func (i scopeIniter) Name() string {
 	return i.name
 }
 
-func (i scopeIniter) Config() config.ConfigurationProvider {
+func (i scopeIniter) Config() config.Provider {
 	return i.config
 }
 
@@ -105,6 +105,6 @@ func cleanup() {
 	_frozen = false
 }
 
-func configData(data map[string]interface{}) config.ConfigurationProvider {
+func configData(data map[string]interface{}) config.Provider {
 	return config.NewStaticProvider(data)
 }

--- a/core/testutils/config.go
+++ b/core/testutils/config.go
@@ -26,8 +26,8 @@ import (
 	"go.uber.org/fx/core/config"
 )
 
-// StaticAppData creates a ConfigurationProvider for a valid appID/owner
-func StaticAppData(applicationID *string) config.ConfigurationProvider {
+// StaticAppData creates a Provider for a valid appID/owner
+func StaticAppData(applicationID *string) config.Provider {
 	data := makeValidData(applicationID)
 	return config.NewStaticProvider(data)
 }

--- a/service/core.go
+++ b/service/core.go
@@ -37,7 +37,7 @@ type Host interface {
 	State() State
 	Metrics() tally.Scope
 	Observer() Observer
-	Config() config.ConfigurationProvider
+	Config() config.Provider
 	Items() map[string]interface{}
 	Logger() ulog.Log
 }
@@ -63,7 +63,7 @@ type serviceCore struct {
 	standardConfig serviceConfig
 	roles          []string
 	state          State
-	configProvider config.ConfigurationProvider
+	configProvider config.Provider
 	scopeMux       sync.Mutex
 	scope          tally.RootScope
 	observer       Observer
@@ -109,7 +109,7 @@ func (s *serviceCore) Observer() Observer {
 	return s.observer
 }
 
-func (s *serviceCore) Config() config.ConfigurationProvider {
+func (s *serviceCore) Config() config.Provider {
 	return s.configProvider
 }
 

--- a/service/host.go
+++ b/service/host.go
@@ -363,7 +363,7 @@ func (s *host) transitionState(to State) {
 
 const instanceConfigName = "ServiceConfig"
 
-func loadInstanceConfig(cfg config.ConfigurationProvider, key string, instance interface{}) bool {
+func loadInstanceConfig(cfg config.Provider, key string, instance interface{}) bool {
 	fieldName := instanceConfigName
 	if field, found := util.FindField(instance, &fieldName, nil); found {
 

--- a/service/options.go
+++ b/service/options.go
@@ -31,7 +31,7 @@ import (
 type Option func(Host) error
 
 // WithConfiguration adds configuration to a service host
-func WithConfiguration(config config.ConfigurationProvider) Option {
+func WithConfiguration(config config.Provider) Option {
 	return func(svc Host) error {
 		// TODO(ai) verify type assertion is correct
 		svc2 := svc.(*host)


### PR DESCRIPTION
Removes a massive stutter for `config.ConfigurationProvider`.

I think we've been meaning to do this for a while. Need to fix post #37 merge to rename all the new docs as well.

Private hooks are going to require a rename as well after this is done.