### PR TITLE
Initialize map after nil value check

### DIFF
--- a/core/config/value.go
+++ b/core/config/value.go
@@ -495,10 +495,9 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 				fieldValue.Set(destSlice)
 			}
 		case bucketMap:
-			destMap := reflect.MakeMap(fieldType).Interface()
 			val := global.GetValue(childKey).Value()
-
 			if val != nil {
+				destMap := reflect.MakeMap(fieldType).Interface()
 				// child yamlnode parsed from yaml file is of type map[interface{}]interface{}
 				// type casting here makes sure that we are iterating over a parsed map.
 				v, ok := val.(map[interface{}]interface{})


### PR DESCRIPTION
struct may have a map, but not always defined in the yaml file. initialize the map only when needed. 