### PR TITLE
Don't run coverage on tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - make test
 
 after_success:
-   - make coveralls
+   - '[ "${TRAVIS_GO_VERSION}" -ne "tip" ] && make coveralls'


### PR DESCRIPTION
Our tip builds are re-running the tests on `make coveralls` for some reason, causing 3+ minute delays in travis results. Plus, we only really want the coverage info from a single version since it will be more consistent that way.

On tip:

![image](https://cloud.githubusercontent.com/assets/97087/20097441/4c0e57c6-a563-11e6-8960-01514fe22048.png)

