### PR TITLE
Added benchmarks for logging

### DIFF
--- a/core/ulog/log_benchmark_test.go
+++ b/core/ulog/log_benchmark_test.go
@@ -40,11 +40,16 @@ func logfields() []interface{} {
 	}
 }
 
+func discardedLogger() zap.Logger {
+	return zap.New(
+		zap.NewJSONEncoder(),
+		zap.DiscardOutput,
+	)
+}
+
 func BenchmarkUlogWithoutFields(b *testing.B) {
 	log := Logger()
-	log.SetLogger(zap.New(
-		zap.NewJSONEncoder(),
-		zap.DiscardOutput))
+	log.SetLogger(discardedLogger())
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -55,10 +60,7 @@ func BenchmarkUlogWithoutFields(b *testing.B) {
 
 func BenchmarkUlogWithFields(b *testing.B) {
 	log := Logger()
-	log.SetLogger(zap.New(
-		zap.NewJSONEncoder(),
-		zap.DiscardOutput,
-	))
+	log.SetLogger(discardedLogger())
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -69,10 +71,7 @@ func BenchmarkUlogWithFields(b *testing.B) {
 
 func BenchmarkUlogLiteWithFields(b *testing.B) {
 	log := Logger()
-	log.SetLogger(zap.New(
-		zap.NewJSONEncoder(),
-		zap.DiscardOutput,
-	))
+	log.SetLogger(discardedLogger())
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -97,10 +96,7 @@ func BenchmarkUlogTextEncoderWithFields(b *testing.B) {
 
 func BenchmarkUlogWithFieldsPreset(b *testing.B) {
 	log := Logger(logfields())
-	log.SetLogger(zap.New(
-		zap.NewJSONEncoder(),
-		zap.DiscardOutput,
-	))
+	log.SetLogger(discardedLogger())
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/core/ulog/log_benchmark_test.go
+++ b/core/ulog/log_benchmark_test.go
@@ -27,19 +27,6 @@ import (
 	"github.com/uber-go/zap"
 )
 
-func logfields() []interface{} {
-	return []interface{}{
-		"int", 123,
-		"int64", 123,
-		"float", 123.123,
-		"string", "four!",
-		"bool", true,
-		"time", time.Unix(0, 0),
-		"duration", time.Second,
-		"another string", "done!",
-	}
-}
-
 func discardedLogger() zap.Logger {
 	return zap.New(
 		zap.NewJSONEncoder(),
@@ -58,13 +45,59 @@ func BenchmarkUlogWithoutFields(b *testing.B) {
 	})
 }
 
-func BenchmarkUlogWithFields(b *testing.B) {
+func BenchmarkUlogWithFieldsLogIFace(b *testing.B) {
 	log := Logger()
 	log.SetLogger(discardedLogger())
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			log.Info("Ulog message", logfields()...)
+			log.Info("Ulog message",
+				"int", 123,
+				"int64", 123,
+				"float", 123.123,
+				"string", "four!",
+				"bool", true,
+				"time", time.Unix(0, 0),
+				"duration", time.Second,
+				"another string", "done!")
+		}
+	})
+}
+
+func BenchmarkUlogWithFieldsBaseLoggerStruct(b *testing.B) {
+	log := Logger()
+	log.SetLogger(discardedLogger())
+	base := log.(*baselogger)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			base.Info("Ulog message",
+				"int", 123,
+				"int64", 123,
+				"float", 123.123,
+				"string", "four!",
+				"bool", true,
+				"time", time.Unix(0, 0),
+				"duration", time.Second,
+				"another string", "done!")
+		}
+	})
+}
+
+func BenchmarkUlogWithFieldsZapLogger(b *testing.B) {
+	log := discardedLogger()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Info("Ulog message",
+				zap.Int("int", 123),
+				zap.Int64("int64", 123),
+				zap.Float64("float", 123.123),
+				zap.String("string", "four!"),
+				zap.Bool("bool", true),
+				zap.Time("time", time.Unix(0, 0)),
+				zap.Duration("duration", time.Second),
+				zap.String("another string", "done!"))
 		}
 	})
 }
@@ -80,22 +113,16 @@ func BenchmarkUlogLiteWithFields(b *testing.B) {
 	})
 }
 
-func BenchmarkUlogTextEncoderWithFields(b *testing.B) {
-	log := Logger()
-	log.SetLogger(zap.New(
-		zap.NewTextEncoder(),
-		zap.DiscardOutput,
-	))
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			log.Info("Ulog message", logfields()...)
-		}
-	})
-}
-
 func BenchmarkUlogWithFieldsPreset(b *testing.B) {
-	log := Logger(logfields())
+	log := Logger(
+		"int", 123,
+		"int64", 123,
+		"float", 123.123,
+		"string", "four!",
+		"bool", true,
+		"time", time.Unix(0, 0),
+		"duration", time.Second,
+		"another string", "done!")
 	log.SetLogger(discardedLogger())
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/core/ulog/log_benchmark_test.go
+++ b/core/ulog/log_benchmark_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ulog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/uber-go/zap"
+)
+
+func logfields() []interface{} {
+	return []interface{}{
+		"int", 123,
+		"int64", 123,
+		"float", 123.123,
+		"string", "four!",
+		"bool", true,
+		"time", time.Unix(0, 0),
+		"duration", time.Second,
+		"another string", "done!",
+	}
+}
+
+func BenchmarkUlogWithoutFields(b *testing.B) {
+	log := Logger()
+	log.SetLogger(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DiscardOutput))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Info("Ulog message")
+		}
+	})
+}
+
+func BenchmarkUlogWithFields(b *testing.B) {
+	log := Logger()
+	log.SetLogger(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Info("Ulog message", logfields()...)
+		}
+	})
+}
+
+func BenchmarkUlogLiteWithFields(b *testing.B) {
+	log := Logger()
+	log.SetLogger(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Info("Ulog message", "integer", 123, "string", "string")
+		}
+	})
+}
+
+func BenchmarkUlogTextEncoderWithFields(b *testing.B) {
+	log := Logger()
+	log.SetLogger(zap.New(
+		zap.NewTextEncoder(),
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Info("Ulog message", logfields()...)
+		}
+	})
+}
+
+func BenchmarkUlogWithFieldsPreset(b *testing.B) {
+	log := Logger(logfields())
+	log.SetLogger(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			log.Info("Ulog message")
+		}
+	})
+}


### PR DESCRIPTION
bash-3.2$ go test -bench=. -benchmem
BenchmarkUlogWithoutFields-8                	 5000000	       242 ns/op	      48 B/op	       1 allocs/op
BenchmarkUlogWithFieldsLogIFace-8           	 1000000	      1149 ns/op	    1309 B/op	      20 allocs/op
BenchmarkUlogWithFieldsBaseLoggerStruct-8   	 2000000	      1071 ns/op	    1052 B/op	      19 allocs/op
BenchmarkUlogWithFieldsZapLogger-8          	 3000000	       577 ns/op	     513 B/op	       1 allocs/op
BenchmarkUlogLiteWithFields-8               	 3000000	       601 ns/op	     361 B/op	       8 allocs/op
BenchmarkUlogWithFieldsPreset-8             	 2000000	       902 ns/op	     819 B/op	       3 allocs/op
PASS
ok  	go.uber.org/fx/core/ulog	13.243s
