### PR TITLE
Update to latest md-to-godoc

### DIFF
--- a/.build/check_license.sh
+++ b/.build/check_license.sh
@@ -12,7 +12,7 @@ run_uber_licence() {
     bin="./node_modules/uber-licence/bin/licence"
   fi
 
-  readonly local output=$("$bin" --file "*.go" | sed "s/^fix //" | grep -v "\bdoc.go$")
+  readonly local output=$("$bin" --file "*.go" | sed "s/^fix //")
   if [ -z "$output" ]; then
     exit 0
   fi
@@ -44,7 +44,7 @@ do
         echo "${file} is missing license header."
         (( ERROR_COUNT++ ))
     fi
-done < <(git ls-files "*\.go" | grep -v "\bdoc.go$")
+done < <(git ls-files "*\.go")
 set -e
 
 exit $ERROR_COUNT

--- a/core/config/README.md
+++ b/core/config/README.md
@@ -72,7 +72,7 @@ If the underlying value cannot be converted to the requested type, `As*` will
 ## PopulateStruct
 
 `PopulateStruct` is akin to `json.Unmarshal()` in that it takes a pointer to a
-custom struct and fills in the fields. It returns a `true`` if the requested
+custom struct and fills in the fields. It returns a `true` if the requested
 fields were found and populated properly, and `false` otherwise.
 
 For example, say we have the following YAML file:

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -1,104 +1,127 @@
-/*
-Package config is the Configuration Package.
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
-At a high level, configuration is any data that is used in an application but
-not part of the application itself. Any reasonably complex system needs to
-have knobs to tune, and not everything can have intelligent defaults.
-
-In UberFx, we try very hard to make configuring UberFx convenient. Users can:
-
-
-• Get components working with minimal configuration
-
-• Override any field if the default doesn't make sense for their use case
-
-
-Provider
-
-Provider is the interface for anything that can provide values.
-We provide a few reference implementations (environment and YAML), but you are
-free to register your own providers via config.RegisterProviders() and
-config.RegisterDynamicProviders.
-
-Static configuration providers
-
-Static configuration providers conform to the Provider interface
-and are bootstraped first. Use these for simple providers such as file-backed or
-environment-based configuration providers.
-
-Dynamic Configuration Providers
-
-Dynamic configuration providers frequently need some bootstrap configuration to
-be useful, so UberFx treats them specially. Dynamic configuration providers
-conform to the Provider interface, but they're instantianted
-**after** the Static Providers on order to read bootstarp values.
-
-For example, if you were to implement a ZooKeeper-backed
-Provider, you'd likely need to specify (via YAML or environment
-variables) where your ZooKeeper nodes live.
-
-Value
-
-Value is the return type of every configuration providers'
-GetValue(key string) method. Under the hood, we use the empty interface
-(interface{}) since we don't necessarily know the structure of your
-configuration ahead of time.
-
-You can use a Value for two main purposes:
-
-
-• Get a single value out of configuration.
-
-
-For example, if we have a YAML configuration like so:
-
-  one:
-    two: hello
-
-You could access the value using "dotted notation":
-
-  foo := provider.GetValue("one.two").AsString()
-  fmt.Println(foo)
-  // Output: hello
-
-
-• Populate a struct (PopulateStruct(&myStruct))
-
-
-The As* method has two variants: TryAs* and As*. The former is a
-two-value return, similar to a type assertion, where the user checks if the second
-bool is true before using the value.
-
-The As* methods are similar to the Must* pattern in the standard library.
-If the underlying value cannot be converted to the requested type, As* will
-panic.
-
-PopulateStruct
-
-PopulateStruct is akin to json.Unmarshal() in that it takes a pointer to a
-custom struct and fills in the fields. It returns a trueif the requested
-fields were found and populated properly, andfalse` otherwise.
-
-For example, say we have the following YAML file:
-
-  hello:
-    world: yes
-    number: 42
-
-We could deserialize into our custom type with the following code:
-
-  type myConfig struct {
-    World  string
-    Number int
-  }
-
-  m := myConfig{}
-  provider.GetValue("hello").Populate(&m)
-  fmt.Println(m.World)
-  // Output: yes
-
-Note that any fields you wish to deserialize into must be exported, just like
-json.Unmarshal and friends.
-
-*/
+// Package config is the Configuration Package.
+//
+// At a high level, configuration is any data that is used in an application but
+// not part of the application itself. Any reasonably complex system needs to
+// have knobs to tune, and not everything can have intelligent defaults.
+//
+//
+// In UberFx, we try very hard to make configuring UberFx convenient. Users can:
+//
+// • Get components working with minimal configuration
+//
+// • Override any field if the default doesn't make sense for their use case
+//
+// Provider
+//
+// Provider is the interface for anything that can provide values.
+// We provide a few reference implementations (environment and YAML), but you are
+// free to register your own providers via
+// config.RegisterProviders() and
+// config.RegisterDynamicProviders.
+//
+// Static configuration providers
+//
+// Static configuration providers conform to theProvider interface
+// and are bootstraped first. Use these for simple providers such as file-backed or
+// environment-based configuration providers.
+//
+//
+// Dynamic Configuration Providers
+//
+// Dynamic configuration providers frequently need some bootstrap configuration to
+// be useful, so UberFx treats them specially. Dynamic configuration providers
+// conform to the
+// Provider interface, but they're instantianted
+// **after** the StaticProviders on order to read bootstarp values.
+//
+// For example, if you were to implement a ZooKeeper-backed
+// Provider, you'd likely need to specify (via YAML or environment
+// variables) where your ZooKeeper nodes live.
+//
+//
+// Value
+//
+// Value is the return type of every configuration providers'
+// GetValue(key string) method. Under the hood, we use the empty interface
+// (
+// interface{}) since we don't necessarily know the structure of your
+// configuration ahead of time.
+//
+//
+// You can use aValue for two main purposes:
+//
+// • Get a single value out of configuration.
+//
+// For example, if we have a YAML configuration like so:
+//
+//   one:
+//     two: hello
+//
+// You could access the value using "dotted notation":
+//
+//   foo := provider.GetValue("one.two").AsString()
+//   fmt.Println(foo)
+//   // Output: hello
+//
+// • Populate a struct (PopulateStruct(&myStruct))
+//
+// TheAs* method has two variants:TryAs* andAs*. The former is a
+// two-value return, similar to a type assertion, where the user checks if the second
+// bool is true before using the value.
+//
+// TheAs* methods are similar to theMust* pattern in the standard library.
+// If the underlying value cannot be converted to the requested type,
+// As* will
+// panic.
+//
+// PopulateStruct
+//
+// PopulateStruct is akin tojson.Unmarshal() in that it takes a pointer to a
+// custom struct and fills in the fields. It returns a
+// true if the requested
+// fields were found and populated properly, and
+// false otherwise.
+//
+// For example, say we have the following YAML file:
+//
+//   hello:
+//     world: yes
+//     number: 42
+//
+// We could deserialize into our custom type with the following code:
+//
+//   type myConfig struct {
+//     World  string
+//     Number int
+//   }
+//
+//   m := myConfig{}
+//   provider.GetValue("hello").Populate(&m)
+//   fmt.Println(m.World)
+//   // Output: yes
+//
+// Note that any fields you wish to deserialize into must be exported, just like
+// json.Unmarshal and friends.
+//
+//
 package config

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -52,7 +52,7 @@
 // be useful, so UberFx treats them specially. Dynamic configuration providers
 // conform to the
 // Provider interface, but they're instantianted
-// **after** the StaticProviders on order to read bootstarp values.
+//  **after** the StaticProviders on order to read bootstarp values.
 //
 // For example, if you were to implement a ZooKeeper-backed
 // Provider, you'd likely need to specify (via YAML or environment

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,15 +1,37 @@
-/*
-Package core is the Framework Core.
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
-The core package contains the nuts and bolts useful to have in a fully-fledged
-service, but are not specific to an instance of a service or even the idea of a
-service.
-
-If, for example, you just want use the configuration logic from UberFx, you
-could import go.uber.org/core/config and use it in a stand-alone CLI app.
-
-It is separate from the service package, which contains logic specifically to
-a running service.
-
-*/
+// Package core is the Framework Core.
+//
+// The core package contains the nuts and bolts useful to have in a fully-fledged
+// service, but are not specific to an instance of a service or even the idea of a
+// service.
+//
+//
+// If, for example, you just want use the configuration logic from UberFx, you
+// could import
+// go.uber.org/core/config and use it in a stand-alone CLI app.
+//
+// It is separate from theservice package, which contains logic specifically to
+// a running service.
+//
+//
+//
 package core

--- a/doc.go
+++ b/doc.go
@@ -1,226 +1,246 @@
-/*
-Package fx is the UberFx Service Framework.
-
-GoDoc (https://godoc.org/go.uber.org/fx)
-Coverage Status (https://coveralls.io/github/uber-go/fx?branch=master)
-Build Status (https://travis-ci.org/uber-go/fx)
-Report Card (https://goreportcard.com/report/github.com/uber-go/fx)
-
-Status
-
-Pre-ALPHA. API Changes are **highly likely**.
-
-Abstract
-
-This framework is a flexible, modularized basis for building robust and
-performant services at Uber with the minimum amount of developer code.
-
-Service Model
-
-A service is a container for a set of **modules**, controlling their lifecycle.
-Service can have any number of modules that are responsible for a specific type
-of functionality, such as a Kafka message ingestion, exposing an HTTP server, or
-a set of RPC service endpoints.
-
-The core service is responsible for loading basic configuration and starting and
-stopping a set of these modules.  Each module gets a reference to the service to
-access standard values such as the Service name or basic configuration.
-
-Service Core
-
-This model results in a simple, consistent way to start a service.  For example,
-in the case of a simple TChannel Service, main.go might look like this:
-
-  package main
-
-  import (
-    "go.uber.org/fx/core/config"
-    "go.uber.org/fx/modules/rpc"
-    "go.uber.org/fx/service"
-  )
-
-  func main() {
-    // Create the service object
-    svc, err := service.WithModules(
-      // The list of module creators for this service, in this case
-      // creates a Thrift RPC module called "keyvalue"
-      rpc.ThriftModule(
-        rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
-        modules.WithName("keyvalue"),
-      ),
-    ).Build()
-
-    if err != nil {
-      log.Fatal("Could not initialize service: ", err)
-    }
-
-    // Start the service, with "true" meaning:
-    // * Wait for service exit
-    // * Report a non-zero exit code if shutdown is caused by an error
-    svc.Start(true)
-  }
-
-Roles
-
-It's common for a service to handle many different workloads. For example, a
-service may expose RPC endpoints and also ingest Kafka messages.
-
-In UberFX, there is a simpler model where we create a single binary,
-but turn its modules on and off based on roles which are specified via the
-command line.
-
-For example, imagine we wanted a "worker" and a "service" role that handled
-Kafka and TChannel, respectively:
-
-  func main() {
-    svc, err := service.WithModules(
-      kafka.Module("kakfa_topic1", []string{"worker"}),
-      rpc.ThriftModule(
-        rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
-        modules.WithName("keyvalue"),
-        modules.WithRoles("service"),
-      ),
-    ).Build()
-
-    if err != nil {
-      log.Fatal("Could not initialize service: ", err)
-    }
-
-    svc.Start(true)
-  }
-
-Which then allows us to set the roles either via a command line variable:
-
-export CONFIG__roles__0=worker
-
-Or via the service parameters, we would activate in the following ways:
-
-
-• ./myservice or ./myservice --roles "service,worker": Runs all modules
-
-• ./myservice --roles "worker": Runs only the **Kakfa** module
-
-• Etc...
-
-
-Modules
-
-Modules are pluggable components that provide an encapsulated set of
-functionality that is managed by the service.
-
-Implemented modules:
-
-
-• HTTP server
-
-• TChannel server
-
-
-Planned modules:
-
-
-• Kafka ingester
-
-• Delayed jobs
-
-
-Module Configuration
-
-Modules are given named keys by the developer for the purpose of looking up
-their configuration. This naming is arbitrary and only needs to be unique
-across modules and exists because it's possible that a service may have multiple
-modules of the same type, such as multiple Kafka ingesters.
-
-  modules:
-    yarpc:
-      bind: :28941
-      advertiseName: kvserver
-    http:
-      port: 8080
-      timeout: 60s
-
-In this example, a module named: "rpc" would lookup it's advertise name as
-modules.rpc.advertiseName.
-
-Metrics
-
-UberFx exposes a simple, consistent way to track metrics and is built on top of
-Tally (https://github.com/uber-go/tally).
-
-Internally, this uses a pluggable mechanism for reporting these values, so they
-can be reported to M3, logging, etc., at the service owner's discretion.
-By default the metrics are not reported (using a tally.NoopScope)
-
-Configuration
-
-UberFx introduces a simplified configuration model that provides a consistent
-interface to configuration from pluggable configuration sources. This interface
-defines methods for accessing values directly or into strongly
-typed structs.
-
-The configuration system wraps a set of *providers* that each know how to get
-values from an underlying source:
-
-
-• Static YAML configuration
-
-• Environment variables
-
-
-So by stacking these providers, we can have a priority system for defining
-configuration that can be overridden by higher priority providers. For example,
-the static YAML configuration would be the lowest priority and those values
-should be overridden by values specified as environment variables.
-
-As an example, imagine a YAML config that looks like:
-
-  foo:
-    bar:
-      boo: 1
-      baz: hello
-
-  stuff:
-    server:
-      port: 8081
-      greeting: Hello There!
-
-UberFx Config allows direct key access, such as foo.bar.baz:
-
-  cfg := svc.Config()
-  if value := cfg.GetValue("foo.bar.baz"); value.HasValue() {
-    fmt.Printf("Say %s", value.AsString()) // "Say hello"
-  }
-
-Or via a strongly typed structure, even as a nest value, such as:
-
-  type myStuff struct {
-    Port     int    `yaml:"port" default:"8080"`
-    Greeting string `yaml:"greeting"`
-  }
-
-  // ....
-
-  target := &myStuff{}
-  cfg := svc.Config()
-  if !cfg.GetValue("stuff.server").PopulateStruct(target) {
-    // fail, we didn't find it.
-  }
-
-  fmt.Printf("Port is: %v", target.Port)
-
-Prints **Port is 8081**
-
-This model respects priority of providers to allow overriding of individual
-values.  In this example, we override the server port via an environment
-variable:
-
-  export CONFIG__stuff__server__port=3000
-
-Then running the above example will result in **Port is 3000**
-
-License
-
-MIT (LICENSE.txt)
-
-*/
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package fx is the UberFx Service Framework.
+//
+// Status
+//
+// Pre-ALPHA. API Changes are**highly likely**.
+//
+// Abstract
+//
+// This framework is a flexible, modularized basis for building robust and
+// performant services at Uber with the minimum amount of developer code.
+//
+//
+// Service Model
+//
+// A service is a container for a set of**modules**, controlling their lifecycle.
+// Service can have any number of modules that are responsible for a specific type
+// of functionality, such as a Kafka message ingestion, exposing an HTTP server, or
+// a set of RPC service endpoints.
+//
+//
+// The core service is responsible for loading basic configuration and starting and
+// stopping a set of these modules.  Each module gets a reference to the service to
+// access standard values such as the Service name or basic configuration.
+//
+//
+// Service Core
+//
+// This model results in a simple, consistent way to start a service.  For example,
+// in the case of a simple TChannel Service,
+// main.go might look like this:
+//
+//   package main
+//
+//   import (
+//     "go.uber.org/fx/core/config"
+//     "go.uber.org/fx/modules/rpc"
+//     "go.uber.org/fx/service"
+//   )
+//
+//   func main() {
+//     // Create the service object
+//     svc, err := service.WithModules(
+//       // The list of module creators for this service, in this case
+//       // creates a Thrift RPC module called "keyvalue"
+//       rpc.ThriftModule(
+//         rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+//         modules.WithName("keyvalue"),
+//       ),
+//     ).Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     // Start the service, with "true" meaning:
+//     // * Wait for service exit
+//     // * Report a non-zero exit code if shutdown is caused by an error
+//     svc.Start(true)
+//   }
+//
+// Roles
+//
+// It's common for a service to handle many different workloads. For example, a
+// service may expose RPC endpoints and also ingest Kafka messages.
+//
+//
+// In UberFX, there is a simpler model where we create a single binary,
+// but turn its modules on and off based on roles which are specified via the
+// command line.
+//
+//
+// For example, imagine we wanted a "worker" and a "service" role that handled
+// Kafka and TChannel, respectively:
+//
+//
+//   func main() {
+//     svc, err := service.WithModules(
+//       kafka.Module("kakfa_topic1", []string{"worker"}),
+//       rpc.ThriftModule(
+//         rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+//         modules.WithName("keyvalue"),
+//         modules.WithRoles("service"),
+//       ),
+//     ).Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     svc.Start(true)
+//   }
+//
+// Which then allows us to set the roles either via a command line variable:
+//
+// export CONFIG__roles__0=worker
+//
+// Or via the service parameters, we would activate in the following ways:
+//
+// • ./myservice or./myservice --roles "service,worker": Runs all modules
+//
+// • ./myservice --roles "worker": Runs only the**Kakfa** module
+//
+// • Etc...
+//
+// Modules
+//
+// Modules are pluggable components that provide an encapsulated set of
+// functionality that is managed by the service.
+//
+//
+// Implemented modules:
+//
+// • HTTP server
+//
+// • TChannel server
+//
+// Planned modules:
+//
+// • Kafka ingester
+//
+// • Delayed jobs
+//
+// Module Configuration
+//
+// Modules are given named keys by the developer for the purpose of looking up
+// their configuration. This naming is arbitrary and only needs to be unique
+// across modules and exists because it's possible that a service may have multiple
+// modules of the same type, such as multiple Kafka ingesters.
+//
+//
+//   modules:
+//     yarpc:
+//       bind: :28941
+//       advertiseName: kvserver
+//     http:
+//       port: 8080
+//       timeout: 60s
+//
+// In this example, a module named: "rpc" would lookup it's advertise name as
+// modules.rpc.advertiseName.
+//
+// Metrics
+//
+// UberFx exposes a simple, consistent way to track metrics and is built on top of
+// Tally (https://github.com/uber-go/tally).
+//
+// Internally, this uses a pluggable mechanism for reporting these values, so they
+// can be reported to M3, logging, etc., at the service owner's discretion.
+// By default the metrics are not reported (using a
+// tally.NoopScope)
+//
+// Configuration
+//
+// UberFx introduces a simplified configuration model that provides a consistent
+// interface to configuration from pluggable configuration sources. This interface
+// defines methods for accessing values directly or into strongly
+// typed structs.
+//
+//
+// The configuration system wraps a set of*providers* that each know how to get
+// values from an underlying source:
+//
+//
+// • Static YAML configuration
+//
+// • Environment variables
+//
+// So by stacking these providers, we can have a priority system for defining
+// configuration that can be overridden by higher priority providers. For example,
+// the static YAML configuration would be the lowest priority and those values
+// should be overridden by values specified as environment variables.
+//
+//
+// As an example, imagine a YAML config that looks like:
+//
+//   foo:
+//     bar:
+//       boo: 1
+//       baz: hello
+//
+//   stuff:
+//     server:
+//       port: 8081
+//       greeting: Hello There!
+//
+// UberFx Config allows direct key access, such asfoo.bar.baz:
+//
+//   cfg := svc.Config()
+//   if value := cfg.GetValue("foo.bar.baz"); value.HasValue() {
+//     fmt.Printf("Say %s", value.AsString()) // "Say hello"
+//   }
+//
+// Or via a strongly typed structure, even as a nest value, such as:
+//
+//   type myStuff struct {
+//     Port     int    `yaml:"port" default:"8080"`
+//     Greeting string `yaml:"greeting"`
+//   }
+//
+//   // ....
+//
+//   target := &myStuff{}
+//   cfg := svc.Config()
+//   if !cfg.GetValue("stuff.server").PopulateStruct(target) {
+//     // fail, we didn't find it.
+//   }
+//
+//   fmt.Printf("Port is: %v", target.Port)
+//
+// Prints**Port is 8081**
+//
+// This model respects priority of providers to allow overriding of individual
+// values.  In this example, we override the server port via an environment
+// variable:
+//
+//
+//   export CONFIG__stuff__server__port=3000
+//
+// Then running the above example will result in**Port is 3000**
+//
+// License
+//
+// MIT (LICENSE.txt)
+//
+//
 package fx

--- a/doc.go
+++ b/doc.go
@@ -22,7 +22,7 @@
 //
 // Status
 //
-// Pre-ALPHA. API Changes are**highly likely**.
+// Pre-ALPHA. API Changes are **highly likely**.
 //
 // Abstract
 //
@@ -32,7 +32,7 @@
 //
 // Service Model
 //
-// A service is a container for a set of**modules**, controlling their lifecycle.
+// A service is a container for a set of **modules**, controlling their lifecycle.
 // Service can have any number of modules that are responsible for a specific type
 // of functionality, such as a Kafka message ingestion, exposing an HTTP server, or
 // a set of RPC service endpoints.
@@ -118,7 +118,7 @@
 //
 // • ./myservice or./myservice --roles "service,worker": Runs all modules
 //
-// • ./myservice --roles "worker": Runs only the**Kakfa** module
+// • ./myservice --roles "worker": Runs only the **Kakfa** module
 //
 // • Etc...
 //
@@ -177,7 +177,7 @@
 // typed structs.
 //
 //
-// The configuration system wraps a set of*providers* that each know how to get
+// The configuration system wraps a set of *providers* that each know how to get
 // values from an underlying source:
 //
 //
@@ -227,7 +227,7 @@
 //
 //   fmt.Printf("Port is: %v", target.Port)
 //
-// Prints**Port is 8081**
+// Prints **Port is 8081**
 //
 // This model respects priority of providers to allow overriding of individual
 // values.  In this example, we override the server port via an environment
@@ -236,7 +236,7 @@
 //
 //   export CONFIG__stuff__server__port=3000
 //
-// Then running the above example will result in**Port is 3000**
+// Then running the above example will result in **Port is 3000**
 //
 // License
 //

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 14974dac5026a608854ec42d45484d99755a2c63f59e1abfebfc762b20adf8f0
-updated: 2016-11-09T12:13:19.402532325-08:00
+hash: 70f5a1723eadc49c68937aa7fb789167f285baa29e6a55057d644e31a30bd537
+updated: 2016-11-09T22:37:22.262007964-08:00
 imports:
 - name: github.com/apache/thrift
   version: 74c99ba38b02288daf05229cdf34e60261d2d01e
@@ -40,12 +40,8 @@ imports:
 - name: github.com/uber/tchannel-go
   version: 4a23f3aae76694b21107f118ece763a61b98ea07
   subpackages:
-  - atomic
   - relay
-  - thrift
-  - thrift/gen-go/meta
   - tnet
-  - trace/thrift/gen-go/tcollector
   - trand
   - typed
 - name: go.uber.org/thriftrw
@@ -58,7 +54,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: e029a7a3ac9ee87ba2a7ecc28bb4258416ad8d59
+  version: 1f469341223bdbdca34a0902ad20354eae15caba
   subpackages:
   - encoding/raw
   - encoding/thrift
@@ -76,7 +72,7 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: golang.org/x/net
-  version: 55a3084c9119aeb9ba2437d595b0a7e9cb635da9
+  version: 9ef22118a4b25863aa94546daffbc0a18feaafb3
   subpackages:
   - context
 - name: gopkg.in/yaml.v2

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ccf2d446d11e5e2daa4ea867c5c9ca11155a17ac5eda6e53bbf49e620e33f9ed
-updated: 2016-11-09T22:44:53.365387523-08:00
+hash: b222221d039c919348507d7a06673c643974e16707aed8f07ec8c7274ce4a50f
+updated: 2016-11-09T23:53:35.71862965-08:00
 imports:
 - name: github.com/apache/thrift
   version: 74c99ba38b02288daf05229cdf34e60261d2d01e
@@ -111,7 +111,7 @@ testImports:
 - name: github.com/russross/blackfriday
   version: 52676fb0053ff19b59451b2aed2a1b8de7d89592
 - name: github.com/sectioneight/md-to-godoc
-  version: ac8c3af3d0f95ef8321b1f0c951bf054bf6175ca
+  version: 250dd48c18f8f2bfc4db9f3c145d1f9f0352525d
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/stretchr/testify

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 70f5a1723eadc49c68937aa7fb789167f285baa29e6a55057d644e31a30bd537
-updated: 2016-11-09T22:37:22.262007964-08:00
+hash: ccf2d446d11e5e2daa4ea867c5c9ca11155a17ac5eda6e53bbf49e620e33f9ed
+updated: 2016-11-09T22:44:53.365387523-08:00
 imports:
 - name: github.com/apache/thrift
   version: 74c99ba38b02288daf05229cdf34e60261d2d01e
@@ -45,7 +45,7 @@ imports:
   - trand
   - typed
 - name: go.uber.org/thriftrw
-  version: e64354195130301f448ccb83483e4ff0cf3d37ba
+  version: 4b6ad6e796868b8066e22774636768235a064935
   subpackages:
   - envelope
   - internal/envelope/exception
@@ -111,7 +111,7 @@ testImports:
 - name: github.com/russross/blackfriday
   version: 52676fb0053ff19b59451b2aed2a1b8de7d89592
 - name: github.com/sectioneight/md-to-godoc
-  version: b2154631a41e9d76c25588601522965a387c1316
+  version: ac8c3af3d0f95ef8321b1f0c951bf054bf6175ca
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -41,7 +41,7 @@ testImport:
 - package: github.com/axw/gocov
 - package: github.com/go-playground/overalls
 - package: github.com/sectioneight/md-to-godoc
-  version: ac8c3af3d0f95ef8321b1f0c951bf054bf6175ca
+  version: master
 # specified manually since we don't import md-to-godoc
 - package: github.com/russross/blackfriday
   version: 2

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: go.uber.org/yarpc
   version: dev
 - package: go.uber.org/thriftrw
-  version: dev
+  version: e64354195130301f448ccb83483e4ff0cf3d37ba
 - package: github.com/go-validator/validator
   version: v2
 - package: github.com/pkg/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: go.uber.org/yarpc
   version: dev
 - package: go.uber.org/thriftrw
-  version: e64354195130301f448ccb83483e4ff0cf3d37ba
+  version: 4b6ad6e796868b8066e22774636768235a064935
 - package: github.com/go-validator/validator
   version: v2
 - package: github.com/pkg/errors
@@ -41,6 +41,7 @@ testImport:
 - package: github.com/axw/gocov
 - package: github.com/go-playground/overalls
 - package: github.com/sectioneight/md-to-godoc
+  version: ac8c3af3d0f95ef8321b1f0c951bf054bf6175ca
 # specified manually since we don't import md-to-godoc
 - package: github.com/russross/blackfriday
   version: 2

--- a/modules/rpc/doc.go
+++ b/modules/rpc/doc.go
@@ -1,46 +1,64 @@
-/*
-Package rpc is the RPC Module.
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
-The RPC module wraps YARPC (https://github.com/yarpc/yarpc-go) and exposes
-creators for both JSON- and Thrift-encoded messages.
-
-This module works in a way that's pretty similar to existing RPC projects:
-
-
-• Create an IDL file and run the appropriate tools on it (e.g. **thriftrw**) to
-generate the service and handler interfaces
-
-• Implement the service interface handlers as method receivers on a struct
-
-• Implement a top-level function, conforming to the
-rpc.CreateThriftServiceFunc signature (uberfx/modules/rpc/thrift.go that
-returns a []transport.Registrant YARPC implementation from the handler:
-
-
-  func NewMyServiceHandler(svc service.Host) ([]transport.Registrant, error) {
-    return myservice.New(&MyServiceHandler{}), nil
-  }
-
-
-• Pass that method into the module initialization:
-
-
-  func main() {
-    svc, err := service.WithModules(
-      rpc.ThriftModule(
-        rpc.CreateThriftServiceFunc(NewMyServiceHandler),
-        modules.WithRoles("service"),
-      ),
-    ).Build()
-
-    if err != nil {
-      log.Fatal("Could not initialize service: ", err)
-    }
-
-    svc.Start(true)
-  }
-
-This will spin up the service.
-
-*/
+// Package rpc is the RPC Module.
+//
+// The RPC module wrapsYARPC (https://github.com/yarpc/yarpc-go) and exposes
+// creators for both JSON- and Thrift-encoded messages.
+//
+//
+// This module works in a way that's pretty similar to existing RPC projects:
+//
+// • Create an IDL file and run the appropriate tools on it (e.g.**thriftrw**) to
+// generate the service and handler interfaces
+//
+//
+// • Implement the service interface handlers as method receivers on a struct
+//
+// • Implement a top-level function, conforming to the
+// rpc.CreateThriftServiceFunc signature (uberfx/modules/rpc/thrift.go that
+// returns a
+// []transport.Registrant YARPC implementation from the handler:
+//
+//   func NewMyServiceHandler(svc service.Host) ([]transport.Registrant, error) {
+//     return myservice.New(&MyServiceHandler{}), nil
+//   }
+//
+// • Pass that method into the module initialization:
+//
+//   func main() {
+//     svc, err := service.WithModules(
+//       rpc.ThriftModule(
+//         rpc.CreateThriftServiceFunc(NewMyServiceHandler),
+//         modules.WithRoles("service"),
+//       ),
+//     ).Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     svc.Start(true)
+//   }
+//
+// This will spin up the service.
+//
+//
 package rpc

--- a/modules/rpc/doc.go
+++ b/modules/rpc/doc.go
@@ -26,7 +26,7 @@
 //
 // This module works in a way that's pretty similar to existing RPC projects:
 //
-// • Create an IDL file and run the appropriate tools on it (e.g.**thriftrw**) to
+// • Create an IDL file and run the appropriate tools on it (e.g. **thriftrw**) to
 // generate the service and handler interfaces
 //
 //

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -1,40 +1,60 @@
-/*
-Package uhttp is the HTTP Module.
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
-The HTTP module is built on top of Gorilla Mux (https://github.com/gorilla/mux),
-but the details of that are abstracted away through uhttp.RouteHandler.
-
-  package main
-
-  import (
-    "io"
-    "net/http"
-
-    "go.uber.org/fx/modules/uhttp"
-    "go.uber.org/fx/service"
-  )
-
-  func main() {
-    service, err := service.WithModules(
-      uhttp.New(registerHTTP),
-    ).Build()
-
-    if err != nil {
-      log.Fatal("Could not initialize service: ", err)
-    }
-
-    service.Start(true)
-  }
-
-  func registerHTTP(service service.Host) []uhttp.RouteHandler {
-    handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-      io.WriteString(w, "Hello, world")
-    })
-
-    return []uhttp.RouteHandler{
-      uhttp.NewRouteHandler("/", handleHome)
-    }
-  }
-
-*/
+// Package uhttp is the HTTP Module.
+//
+// The HTTP module is built on top ofGorilla Mux (https://github.com/gorilla/mux),
+// but the details of that are abstracted away through
+// uhttp.RouteHandler.
+//
+//   package main
+//
+//   import (
+//     "io"
+//     "net/http"
+//
+//     "go.uber.org/fx/modules/uhttp"
+//     "go.uber.org/fx/service"
+//   )
+//
+//   func main() {
+//     service, err := service.WithModules(
+//       uhttp.New(registerHTTP),
+//     ).Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     service.Start(true)
+//   }
+//
+//   func registerHTTP(service service.Host) []uhttp.RouteHandler {
+//     handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//       io.WriteString(w, "Hello, world")
+//     })
+//
+//     return []uhttp.RouteHandler{
+//       uhttp.NewRouteHandler("/", handleHome)
+//     }
+//   }
+//
+//
 package uhttp


### PR DESCRIPTION
This adds license headers automatically and fixes a variety of formatting issues, as well as uses `//` comments instead of `/*` which is more idiomatic Go.

i had to pin thriftrw due to a breaking change in the dev branch. Hopefully we can unpin that soon.