### PR TITLE
Bench improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ benchbase:
 benchcmp:
 	$(ECHO_V)which benchcmp >/dev/null || go get -u golang.org/x/tools/cmd/benchcmp
 	$(ECHO_V)test -s $(BASELINE_BENCH_FILE) || \
-		$(call die,Baseline benchmark file missing. Check out master and run \'make bench\')
+		$(call die,Baseline benchmark file missing. Check out master and run \'make benchbase\')
 	$(ECHO_V)test -s $(BENCH_FILE) || \
 		$(call label,No current benchmark file. Will generate) ;\
 	benchcmp $(BASELINE_BENCH_FILE) $(BENCH_FILE)

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,14 @@ BENCH_FILE ?= .bench/new.txt
 .PHONY: bench
 bench:
 	@$(call label,Running benchmarks)
+	$(ECHO_V)rm $(BENCH_FILE)
 	$(ECHO_V)$(foreach pkg,$(BENCH_PKGS),go test -bench=. -run="^$$" $(BENCH_FLAGS) $(pkg) | \
-		tee $(BENCH_FILE);)
+		tee -a $(BENCH_FILE);)
 
 BASELINE_BENCH_FILE=.bench/old.txt
 .PHONY: benchbase
 benchbase:
-	$(ECHO_V)if [ -z "$(IGNORE_BASELINE_CHECK)" ] && [ -z "$(git diff master)" ]; then \
+	$(ECHO_V)if [ -z $(IGNORE_BASELINE_CHECK) ] && [ -z "$(git diff master)" ]; then \
 		echo "$(ERROR_STYLE)Can't record baseline with code changes off master." ; \
 		echo "Check out master and try again$(COLOR_RESET)"; \
 		exit 1; \
@@ -92,8 +93,7 @@ benchcmp:
 		$(call die,Baseline benchmark file missing. Check out master and run \'make bench\')
 	$(ECHO_V)test -s $(BENCH_FILE) || \
 		$(call label,No current benchmark file. Will generate) ;\
-		$(MAKE) bench
-	$(ECHO_V)benchcmp $(BASELINE_BENCH_FILE) $(BENCH_FILE)
+	benchcmp $(BASELINE_BENCH_FILE) $(BENCH_FILE)
 
 .PHONY: benchreset
 benchreset:

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,13 @@ bench:
 	$(ECHO_V)$(foreach pkg,$(BENCH_PKGS),go test -bench=. -run="^$$" $(BENCH_FLAGS) $(pkg) | \
 		tee -a $(BENCH_FILE);)
 
-BASELINE_BENCH_FILE=.bench/old.txt
+BASELINE_BENCH_FILE = .bench/old.txt
+# Git diffs can be quote noisy, and contain all sorts of special characters, this just checks
+# if there is anything in the output at all, which is what we want
+GIT_DIFF = $(firstword $(shell git diff master))
 .PHONY: benchbase
 benchbase:
-	$(ECHO_V)if [ -z $(IGNORE_BASELINE_CHECK) ] && [ -z "$(git diff master)" ]; then \
+	$(ECHO_V)if [ -z "$(IGNORE_BASELINE_CHECK)" ] && [ -n "$(GIT_DIFF)" ]; then \
 		echo "$(ERROR_STYLE)Can't record baseline with code changes off master." ; \
 		echo "Check out master and try again$(COLOR_RESET)"; \
 		exit 1; \

--- a/core/ulog/log.go
+++ b/core/ulog/log.go
@@ -250,7 +250,6 @@ func (l *baselogger) fieldsConversion(keyvals ...interface{}) []zap.Field {
 	}
 	for idx := 0; idx < len(keyvals); idx += 2 {
 		if key, ok := keyvals[idx].(string); ok {
-			key = keyvals[idx].(string)
 			switch value := keyvals[idx+1].(type) {
 			case bool:
 				fields = append(fields, zap.Bool(key, value))


### PR DESCRIPTION
I must have been drunk or something when I set this up originally, but these were done wrong. Now it actually appends all the bench results into the same file, rather than truncating it every time.

Benchcmp also doesn't run `make bench` anymore, it just uses the result of it. 

Also fixes improper setup for `IGNORE_BASELINE_CHECK` flag, it was not really handled correctly before.

Also removes a redundant cast