### PR TITLE
[DO NOT MERGE] Share custom resources with custom context

### DIFF
--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -21,8 +21,10 @@
 package main
 
 import (
-	"context"
+	gcontext "context"
 	"sync"
+
+	"golang.org/x/net/context"
 
 	"go.uber.org/fx/examples/keyvalue/kv"
 	kvs "go.uber.org/fx/examples/keyvalue/kv/yarpc/keyvalueserver"
@@ -37,12 +39,12 @@ type YarpcHandler struct {
 	items map[string]string
 }
 
-func NewYarpcThriftHandler(svc service.Host) ([]transport.Registrant, error) {
+func NewYarpcThriftHandler(ctx service.Context) ([]transport.Registrant, error) {
 	handler := &YarpcHandler{items: map[string]string{}}
 	return kvs.New(handler), nil
 }
 
-func (h *YarpcHandler) GetValue(ctx context.Context, req yarpc.ReqMeta, key *string) (string, yarpc.ResMeta, error) {
+func (h *YarpcHandler) GetValue(ctx gcontext.Context, req yarpc.ReqMeta, key *string) (string, yarpc.ResMeta, error) {
 	h.RLock()
 	defer h.RUnlock()
 
@@ -53,7 +55,7 @@ func (h *YarpcHandler) GetValue(ctx context.Context, req yarpc.ReqMeta, key *str
 	return "", nil, &kv.ResourceDoesNotExist{Key: *key}
 }
 
-func (h *YarpcHandler) SetValue(ctx context.Context, req yarpc.ReqMeta, key *string, value *string) (yarpc.ResMeta, error) {
+func (h *YarpcHandler) SetValue(ctx gcontext.Context, req yarpc.ReqMeta, key *string, value *string) (yarpc.ResMeta, error) {
 	h.Lock()
 
 	h.items[*key] = *value

--- a/examples/simple/handlers.go
+++ b/examples/simple/handlers.go
@@ -40,7 +40,7 @@ func enforceHeader(r uhttp.Route) uhttp.Route {
 	return r.Headers("X-Uber-FX", "yass")
 }
 
-func registerHTTPers(service service.Host) []uhttp.RouteHandler {
+func registerHTTPers(ctx service.Context) []uhttp.RouteHandler {
 	handler := &exampleHandler{}
 	return []uhttp.RouteHandler{
 		uhttp.NewRouteHandler("/", handler, enforceHeader),

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/yarpc/transport"
 )
 
-func registerJSONers(service service.Host) ([]transport.Registrant, error) {
+func registerJSONers(ctx service.Context) ([]transport.Registrant, error) {
 	return nil, nil
 }
 

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -36,7 +36,7 @@ type ModuleConfig struct {
 type ModuleBase struct {
 	moduleType string
 	name       string
-	host       service.Host
+	ctx        service.Context
 	isRunning  bool
 	roles      []string
 	scope      tally.Scope
@@ -47,22 +47,22 @@ type ModuleBase struct {
 func NewModuleBase(
 	moduleType string,
 	name string,
-	service service.Host,
+	ctx service.Context,
 	roles []string,
 ) *ModuleBase {
 	return &ModuleBase{
 		moduleType: moduleType,
 		name:       name,
-		host:       service,
+		ctx:        ctx,
 		roles:      roles,
-		scope:      service.Metrics().SubScope(name),
-		tracer:     service.Tracer(),
+		scope:      ctx.Metrics().SubScope(name),
+		tracer:     ctx.Tracer(),
 	}
 }
 
-// Host returns the module's service host
-func (mb ModuleBase) Host() service.Host {
-	return mb.host
+// Ctx returns module context
+func (mb ModuleBase) Ctx() service.Context {
+	return mb.ctx
 }
 
 // Roles returns the module's roles

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -57,7 +57,7 @@ func TestNewModuleBase_Tracer(t *testing.T) {
 
 func nmb(moduleType, name string, roles []string) *ModuleBase {
 	host := service.NullHost()
-	ctx := service.NewContext(gcontext.Background(), host, nil)
+	ctx := service.NewContext(gcontext.Background(), host)
 	return NewModuleBase(
 		moduleType,
 		name,

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -23,6 +23,8 @@ package modules
 import (
 	"testing"
 
+	gcontext "context"
+
 	"go.uber.org/fx/service"
 
 	"github.com/stretchr/testify/assert"
@@ -48,11 +50,6 @@ func TestNewModuleBase_Name(t *testing.T) {
 	assert.Equal(t, "foo", mb.Name())
 }
 
-func TestNewModuleBase_Host(t *testing.T) {
-	mb := nmb("test", "foo", nil)
-	assert.NotNil(t, mb.Host())
-}
-
 func TestNewModuleBase_Tracer(t *testing.T) {
 	mb := nmb("test", "foo", nil)
 	assert.NotNil(t, mb.Tracer())
@@ -60,11 +57,11 @@ func TestNewModuleBase_Tracer(t *testing.T) {
 
 func nmb(moduleType, name string, roles []string) *ModuleBase {
 	host := service.NullHost()
-
+	ctx := service.NewContext(gcontext.Background(), host, nil)
 	return NewModuleBase(
 		moduleType,
 		name,
-		host,
+		ctx,
 		roles,
 	)
 }

--- a/modules/options_test.go
+++ b/modules/options_test.go
@@ -50,6 +50,6 @@ func TestWithRoles_OK(t *testing.T) {
 
 func mci() *service.ModuleCreateInfo {
 	return &service.ModuleCreateInfo{
-		Ctx: service.NewContext(gcontext.Background(), service.NullHost(), nil),
+		Ctx: service.NewContext(gcontext.Background(), service.NullHost()),
 	}
 }

--- a/modules/options_test.go
+++ b/modules/options_test.go
@@ -21,6 +21,7 @@
 package modules
 
 import (
+	gcontext "context"
 	"testing"
 
 	"go.uber.org/fx/service"
@@ -49,6 +50,6 @@ func TestWithRoles_OK(t *testing.T) {
 
 func mci() *service.ModuleCreateInfo {
 	return &service.ModuleCreateInfo{
-		Host: service.NullHost(),
+		Ctx: service.NewContext(gcontext.Background(), service.NullHost(), nil),
 	}
 }

--- a/modules/rpc/json.go
+++ b/modules/rpc/json.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CreateJSONRegistrantsFunc returns a slice of registrants from a service host
-type CreateJSONRegistrantsFunc func(service service.Host) ([]transport.Registrant, error)
+type CreateJSONRegistrantsFunc func(ctx service.Context) ([]transport.Registrant, error)
 
 // JSONModule instantiates a core module from a registrant func
 func JSONModule(hookup CreateJSONRegistrantsFunc, options ...modules.Option) service.ModuleCreateFunc {
@@ -47,7 +47,7 @@ func newYarpcJSONModule(
 	createService CreateJSONRegistrantsFunc,
 	options ...modules.Option,
 ) (*YarpcModule, error) {
-	procs, err := createService(mi.Host)
+	procs, err := createService(mi.Ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -29,7 +29,7 @@ import (
 )
 
 // CreateThriftServiceFunc creates a Thrift service from a service host
-type CreateThriftServiceFunc func(svc service.Host) ([]transport.Registrant, error)
+type CreateThriftServiceFunc func(ctx service.Context) ([]transport.Registrant, error)
 
 // ThriftModule creates a Thrift Module from a service func
 func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) service.ModuleCreateFunc {
@@ -48,7 +48,7 @@ func newYarpcThriftModule(
 	createService CreateThriftServiceFunc,
 	options ...modules.Option,
 ) (*YarpcModule, error) {
-	registrants, err := createService(mi.Host)
+	registrants, err := createService(mi.Ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create YARPC thrift handler")
 	}

--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -21,6 +21,7 @@
 package rpc
 
 import (
+	gcontext "context"
 	"errors"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestThrfitModule_Error(t *testing.T) {
 
 func testInitRunModule(t *testing.T, mod service.Module, mci service.ModuleCreateInfo) {
 	readyCh := make(chan struct{}, 1)
-	assert.NoError(t, mod.Initialize(mci.Host))
+	assert.NoError(t, mod.Initialize(mci.Ctx))
 	assert.NoError(t, mod.Stop())
 	errs := mod.Start(readyCh)
 	defer func() {
@@ -70,7 +71,7 @@ func testInitRunModule(t *testing.T, mod service.Module, mci service.ModuleCreat
 
 func mch() service.ModuleCreateInfo {
 	return service.ModuleCreateInfo{
-		Host: service.NullHost(),
+		Ctx: service.NewContext(gcontext.Background(), service.NullHost(), nil),
 	}
 }
 
@@ -78,12 +79,12 @@ func errorOption(_ *service.ModuleCreateInfo) error {
 	return errors.New("bad option")
 }
 
-func okCreate(_ service.Host) ([]transport.Registrant, error) {
+func okCreate(_ service.Context) ([]transport.Registrant, error) {
 	return []transport.Registrant{{
 		Service: "foo",
 	}}, nil
 }
 
-func badCreateService(_ service.Host) ([]transport.Registrant, error) {
+func badCreateService(_ service.Context) ([]transport.Registrant, error) {
 	return nil, errors.New("can't create service")
 }

--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -71,7 +71,7 @@ func testInitRunModule(t *testing.T, mod service.Module, mci service.ModuleCreat
 
 func mch() service.ModuleCreateInfo {
 	return service.ModuleCreateInfo{
-		Ctx: service.NewContext(gcontext.Background(), service.NullHost(), nil),
+		Ctx: service.NewContext(gcontext.Background(), service.NullHost()),
 	}
 }
 

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -70,7 +70,7 @@ func newYarpcModule(
 	options ...modules.Option,
 ) (*YarpcModule, error) {
 	cfg := &yarpcConfig{
-		AdvertiseName: mi.Host.Name(),
+		AdvertiseName: mi.Ctx.Name(),
 		Bind:          ":0",
 	}
 
@@ -80,7 +80,7 @@ func newYarpcModule(
 	}
 
 	module := &YarpcModule{
-		ModuleBase: *modules.NewModuleBase(RPCModuleType, name, mi.Host, []string{}),
+		ModuleBase: *modules.NewModuleBase(RPCModuleType, name, mi.Ctx, []string{}),
 		register:   reg,
 		config:     *cfg,
 	}
@@ -93,7 +93,7 @@ func newYarpcModule(
 		}
 	}
 
-	err := module.Host().Config().GetValue(fmt.Sprintf("modules.%s", module.Name())).PopulateStruct(cfg)
+	err := module.Ctx().Config().GetValue(fmt.Sprintf("modules.%s", module.Name())).PopulateStruct(cfg)
 	// found values, update module
 	module.config = *cfg
 
@@ -103,7 +103,7 @@ func newYarpcModule(
 }
 
 // Initialize sets up a YAPR-backed module
-func (m *YarpcModule) Initialize(service service.Host) error {
+func (m *YarpcModule) Initialize(ctx service.Context) error {
 	return nil
 }
 
@@ -122,7 +122,7 @@ func (m *YarpcModule) Start(readyCh chan<- struct{}) <-chan error {
 	interceptor := yarpc.Interceptors(m.interceptors...)
 
 	// TODO(ai/madhu) pass option for opentracing to NewDispatcher
-	m.rpc, err = _dispatcherFn(m.Host(), yarpc.Config{
+	m.rpc, err = _dispatcherFn(m.Ctx(), yarpc.Config{
 		Name: m.config.AdvertiseName,
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(channel, tch.ListenAddr(m.config.Bind)),

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -95,7 +95,7 @@ type Config struct {
 }
 
 // CreateHTTPRegistrantsFunc returns a slice of registrants from a service host
-type CreateHTTPRegistrantsFunc func(service service.Host) []RouteHandler
+type CreateHTTPRegistrantsFunc func(ctx service.Context) []RouteHandler
 
 // New returns a new HTTP module
 func New(hookup CreateHTTPRegistrantsFunc, options ...modules.Option) service.ModuleCreateFunc {
@@ -124,11 +124,11 @@ func newModule(
 	}
 
 	module := &Module{
-		ModuleBase: *modules.NewModuleBase(ModuleType, mi.Name, mi.Host, []string{}),
-		handlers:   createService(mi.Host),
+		ModuleBase: *modules.NewModuleBase(ModuleType, mi.Name, mi.Ctx, []string{}),
+		handlers:   createService(mi.Ctx),
 	}
 
-	err := module.Host().Config().GetValue(getConfigKey(mi.Name)).PopulateStruct(cfg)
+	err := module.Ctx().Config().GetValue(getConfigKey(mi.Name)).PopulateStruct(cfg)
 	if err != nil {
 		ulog.Logger().Error("Error loading http module configuration", "error", err)
 	}
@@ -147,7 +147,7 @@ func newModule(
 }
 
 // Initialize sets up an HTTP-backed module
-func (m *Module) Initialize(host service.Host) error {
+func (m *Module) Initialize(ctx service.Context) error {
 	return nil
 }
 

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -137,7 +137,7 @@ func withModule(
 	fn func(*Module),
 ) {
 	mi := service.ModuleCreateInfo{
-		Ctx: service.NewContext(gcontext.Background(), service.NullHost(), nil),
+		Ctx: service.NewContext(gcontext.Background(), service.NullHost()),
 	}
 	mod, err := newModule(mi, hookup, options...)
 	if expectError {

--- a/service/context.go
+++ b/service/context.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package service
 
 import gcontext "context"
@@ -23,6 +43,7 @@ func NewContext(ctx gcontext.Context, host Host, resources interface{}) Context 
 	}
 }
 
+// Resources returns resources associated with the current context
 func (c *context) Resources() interface{} {
 	return c.resources
 }

--- a/service/context.go
+++ b/service/context.go
@@ -1,0 +1,28 @@
+package service
+
+import gcontext "context"
+
+// Context embeds Host and go context for use
+type Context interface {
+	gcontext.Context
+	Host
+}
+type context struct {
+	gcontext.Context
+	Host
+
+	resources interface{}
+}
+
+// NewContext always returns service.Context for use in the service
+func NewContext(ctx gcontext.Context, host Host, resources interface{}) Context {
+	return &context{
+		Context:   ctx,
+		Host:      host,
+		resources: resources,
+	}
+}
+
+func (c *context) Resources() interface{} {
+	return c.resources
+}

--- a/service/context.go
+++ b/service/context.go
@@ -31,19 +31,32 @@ type context struct {
 	gcontext.Context
 	Host
 
-	resources interface{}
+	resources map[string]interface{}
 }
 
 // NewContext always returns service.Context for use in the service
-func NewContext(ctx gcontext.Context, host Host, resources interface{}) Context {
+func NewContext(ctx gcontext.Context, host Host) Context {
 	return &context{
 		Context:   ctx,
 		Host:      host,
-		resources: resources,
+		resources: make(map[string]interface{}),
 	}
 }
 
 // Resources returns resources associated with the current context
-func (c *context) Resources() interface{} {
-	return c.resources
+func (c *context) Resource(key string) interface{} {
+	if res, ok := c.tryResource(key); ok {
+		return res
+	}
+	return nil
+}
+
+func (c *context) tryResource(key string) (interface{}, bool) {
+	res, ok := c.resources[key]
+	return res, ok
+}
+
+// SetResource sets resource on the specified key
+func (c *context) SetResource(key string, value interface{}) {
+	c.resources[key] = value
 }

--- a/service/context_test.go
+++ b/service/context_test.go
@@ -20,49 +20,37 @@
 
 package service
 
-import gcontext "context"
+import (
+	"testing"
 
-// Context embedds Host and go context for use
-type Context interface {
-	gcontext.Context
-	Host
+	"github.com/stretchr/testify/assert"
 
-	Resource(key string) interface{}
-	SetResource(key string, value interface{})
+	gcontext "context"
+)
+
+type _testStruct struct {
+	data string
 }
 
-type context struct {
-	gcontext.Context
-	Host
-
-	resources map[string]interface{}
-}
-
-var _ Context = &context{}
-
-// NewContext always returns service.Context for use in the service
-func NewContext(ctx gcontext.Context, host Host) Context {
-	return &context{
-		Context:   ctx,
-		Host:      host,
-		resources: make(map[string]interface{}),
+func TestContext_Simple(t *testing.T) {
+	ctx := NewContext(gcontext.Background(), NullHost())
+	testStruct := _testStruct{
+		data: "hello",
 	}
+	ctx.SetResource("resource", testStruct)
+
+	assert.NotNil(t, ctx.Resource("resource"))
+	assert.Equal(t, "hello", ctx.Resource("resource").(_testStruct).data)
 }
 
-// Resources returns resources associated with the current context
-func (c *context) Resource(key string) interface{} {
-	if res, ok := c.TryResource(key); ok {
-		return res
-	}
-	return nil
+func TestContext_NilResource(t *testing.T) {
+	ctx := NewContext(gcontext.Background(), NullHost())
+
+	assert.Nil(t, ctx.Resource("resource"))
 }
 
-func (c *context) TryResource(key string) (interface{}, bool) {
-	res, ok := c.resources[key]
-	return res, ok
-}
-
-// SetResource sets resource on the specified key
-func (c *context) SetResource(key string, value interface{}) {
-	c.resources[key] = value
+func TestContext_HostAccess(t *testing.T) {
+	ctx := NewContext(gcontext.Background(), NullHost())
+	assert.NotNil(t, ctx.Config())
+	assert.Equal(t, "dummy", ctx.Name())
 }

--- a/service/host.go
+++ b/service/host.go
@@ -21,6 +21,7 @@
 package service
 
 import (
+	gcontext "context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -62,7 +63,7 @@ func (s *host) addModule(module Module) error {
 		return fmt.Errorf("can't add module: service already started")
 	}
 	s.modules = append(s.modules, module)
-	return module.Initialize(s)
+	return module.Initialize(NewContext(gcontext.Background(), s, nil))
 }
 
 func (s *host) supportsRole(roles ...string) bool {
@@ -171,8 +172,8 @@ func (s *host) shutdown(err error, reason string, exitCode *int) (bool, error) {
 func (s *host) AddModules(modules ...ModuleCreateFunc) error {
 	for _, mcf := range modules {
 		mi := ModuleCreateInfo{
-			Host:  s,
 			Items: make(map[string]interface{}),
+			Ctx:   NewContext(gcontext.Background(), s, nil),
 		}
 
 		mods, err := mcf(mi)

--- a/service/host.go
+++ b/service/host.go
@@ -63,7 +63,7 @@ func (s *host) addModule(module Module) error {
 		return fmt.Errorf("can't add module: service already started")
 	}
 	s.modules = append(s.modules, module)
-	return module.Initialize(NewContext(gcontext.Background(), s, nil))
+	return module.Initialize(NewContext(gcontext.Background(), s))
 }
 
 func (s *host) supportsRole(roles ...string) bool {
@@ -173,7 +173,7 @@ func (s *host) AddModules(modules ...ModuleCreateFunc) error {
 	for _, mcf := range modules {
 		mi := ModuleCreateInfo{
 			Items: make(map[string]interface{}),
-			Ctx:   NewContext(gcontext.Background(), s, nil),
+			Ctx:   NewContext(gcontext.Background(), s),
 		}
 
 		mods, err := mcf(mi)

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -222,7 +222,7 @@ func TestAddModule_Locked(t *testing.T) {
 func TestAddModule_NotLocked(t *testing.T) {
 	mod := NewStubModule()
 	sh := &host{}
-	ctx := NewContext(gcontext.Background(), sh, nil)
+	ctx := NewContext(gcontext.Background(), sh)
 	assert.NoError(t, sh.addModule(mod))
 	assert.Equal(t, ctx, mod.Ctx)
 }

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -21,6 +21,7 @@
 package service
 
 import (
+	gcontext "context"
 	"errors"
 	"testing"
 	"time"
@@ -221,8 +222,9 @@ func TestAddModule_Locked(t *testing.T) {
 func TestAddModule_NotLocked(t *testing.T) {
 	mod := NewStubModule()
 	sh := &host{}
+	ctx := NewContext(gcontext.Background(), sh, nil)
 	assert.NoError(t, sh.addModule(mod))
-	assert.Equal(t, sh, mod.Host)
+	assert.Equal(t, ctx, mod.Ctx)
 }
 
 func TestStartModule_NoErrors(t *testing.T) {

--- a/service/module.go
+++ b/service/module.go
@@ -25,7 +25,7 @@ type ModuleType string
 
 // A Module is the basic building block of an UberFx service
 type Module interface {
-	Initialize(host Host) error
+	Initialize(ctx Context) error
 	Type() string
 	Name() string
 	Start(ready chan<- struct{}) <-chan error
@@ -41,7 +41,7 @@ type ModuleCreateInfo struct {
 	Name  string
 	Roles []string
 	Items map[string]interface{}
-	Host  Host
+	Ctx   Context
 }
 
 // A ModuleCreateFunc handles instantiating modules from creation configuration

--- a/service/stub_module.go
+++ b/service/stub_module.go
@@ -22,7 +22,7 @@ package service
 
 // A StubModule implements the Module interface for testing
 type StubModule struct {
-	Host             Host
+	Ctx              Context
 	InitError        error
 	TypeVal, NameVal string
 	StartError       error
@@ -38,8 +38,8 @@ func NewStubModule() *StubModule {
 }
 
 // Initialize fakes an init call on the module
-func (s *StubModule) Initialize(host Host) error {
-	s.Host = host
+func (s *StubModule) Initialize(ctx Context) error {
+	s.Ctx = ctx
 	return s.InitError
 }
 


### PR DESCRIPTION
GFM-126 prototype

Created service.Context and embedded context along with Host.

Shared resources can be passed around with service.Context.SetResource(key, value) and service.Context.Resource(key) methods.