### PR TITLE
Renamed items to resources

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -30,16 +30,11 @@ import (
 type Context interface {
 	gcontext.Context
 	service.Host
-
-	Resource(key string) interface{}
-	SetResource(key string, value interface{})
 }
 
 type context struct {
 	gcontext.Context
 	service.Host
-
-	resources map[string]interface{}
 }
 
 var _ Context = &context{}
@@ -47,26 +42,7 @@ var _ Context = &context{}
 // NewContext always returns core.Context for use in the service
 func NewContext(ctx gcontext.Context, host service.Host) Context {
 	return &context{
-		Context:   ctx,
-		Host:      host,
-		resources: make(map[string]interface{}),
+		Context: ctx,
+		Host:    host,
 	}
-}
-
-// Resources returns resources associated with the current context
-func (c *context) Resource(key string) interface{} {
-	if res, ok := c.TryResource(key); ok {
-		return res
-	}
-	return nil
-}
-
-func (c *context) TryResource(key string) (interface{}, bool) {
-	res, ok := c.resources[key]
-	return res, ok
-}
-
-// SetResource sets resource on the specified key
-func (c *context) SetResource(key string, value interface{}) {
-	c.resources[key] = value
 }

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -30,29 +30,9 @@ import (
 	gcontext "context"
 )
 
-type _testStruct struct {
-	data string
-}
-
-func TestContext_Simple(t *testing.T) {
-	ctx := NewContext(gcontext.Background(), service.NullHost())
-	testStruct := _testStruct{
-		data: "hello",
-	}
-	ctx.SetResource("resource", testStruct)
-
-	assert.NotNil(t, ctx.Resource("resource"))
-	assert.Equal(t, "hello", ctx.Resource("resource").(_testStruct).data)
-}
-
-func TestContext_NilResource(t *testing.T) {
-	ctx := NewContext(gcontext.Background(), service.NullHost())
-
-	assert.Nil(t, ctx.Resource("resource"))
-}
-
 func TestContext_HostAccess(t *testing.T) {
 	ctx := NewContext(gcontext.Background(), service.NullHost())
+	assert.NotNil(t, ctx)
 	assert.NotNil(t, ctx.Config())
 	assert.Equal(t, "dummy", ctx.Name())
 }

--- a/service/core.go
+++ b/service/core.go
@@ -41,7 +41,7 @@ type Host interface {
 	Metrics() tally.Scope
 	Observer() Observer
 	Config() config.Provider
-	Items() map[string]interface{}
+	Resources() map[string]interface{}
 	Logger() ulog.Log
 	Tracer() opentracing.Tracer
 }
@@ -71,7 +71,7 @@ type serviceCore struct {
 	scopeMux       sync.Mutex
 	scope          tally.RootScope
 	observer       Observer
-	items          map[string]interface{}
+	resources      map[string]interface{}
 	logConfig      ulog.Configuration
 	log            ulog.Log
 	tracerConfig   jaegerconfig.Configuration
@@ -104,8 +104,8 @@ func (s *serviceCore) Roles() []string {
 }
 
 // What items?
-func (s *serviceCore) Items() map[string]interface{} {
-	return s.items
+func (s *serviceCore) Resources() map[string]interface{} {
+	return s.resources
 }
 
 func (s *serviceCore) Metrics() tally.Scope {

--- a/service/core_test.go
+++ b/service/core_test.go
@@ -74,10 +74,10 @@ func TestCoreConfig(t *testing.T) {
 	assert.Equal(t, "static", cfg.Name())
 }
 
-func TestCoreItems(t *testing.T) {
+func TestCoreResources(t *testing.T) {
 	sh := &serviceCore{
-		items: map[string]interface{}{"test": true},
+		resources: map[string]interface{}{"test": true},
 	}
 
-	assert.True(t, sh.Items()["test"].(bool))
+	assert.True(t, sh.Resources()["test"].(bool))
 }

--- a/service/service.go
+++ b/service/service.go
@@ -80,7 +80,7 @@ func New(options ...Option) (Owner, error) {
 		// TODO: get these out of config struct instead
 		modules: []Module{},
 		serviceCore: serviceCore{
-			items: map[string]interface{}{},
+			resources: map[string]interface{}{},
 		},
 	}
 


### PR DESCRIPTION
GFM-126

set resource once on global service object - 
`service.Resources()["resource"] = xyz`

Access resource via core.context
`res := ctx.Resources()["resource"]`
