### PR TITLE
Rename config.GetValue to config.Get

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ UberFx Config allows direct key access, such as `foo.bar.baz`:
 
 ```go
 cfg := svc.Config()
-if value := cfg.GetValue("foo.bar.baz"); value.HasValue() {
+if value := cfg.Get("foo.bar.baz"); value.HasValue() {
   fmt.Printf("Say %s", value.AsString()) // "Say hello"
 }
 ```
@@ -199,7 +199,7 @@ type myStuff struct {
 
 target := &myStuff{}
 cfg := svc.Config()
-if err := cfg.GetValue("stuff.server").PopulateStruct(target); err != nil {
+if err := cfg.Get("stuff.server").PopulateStruct(target); err != nil {
   // fail, we didn't find it.
 }
 

--- a/core/config/README.md
+++ b/core/config/README.md
@@ -36,7 +36,7 @@ variables) where your ZooKeeper nodes live.
 ## Value
 
 `Value` is the return type of every configuration providers'
-`GetValue(key string)` method. Under the hood, we use the empty interface
+`Get(key string)` method. Under the hood, we use the empty interface
 (`interface{}`) since we don't necessarily know the structure of your
 configuration ahead of time.
 
@@ -54,7 +54,7 @@ one:
 You could access the value using "dotted notation":
 
 ```go
-foo := provider.GetValue("one.two").AsString()
+foo := provider.Get("one.two").AsString()
 fmt.Println(foo)
 // Output: hello
 ```
@@ -92,7 +92,7 @@ type myConfig struct {
 }
 
 m := myConfig{}
-provider.GetValue("hello").Populate(&m)
+provider.Get("hello").Populate(&m)
 fmt.Println(m.World)
 // Output: yes
 ```

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -118,12 +118,12 @@ func TestDirectAccess(t *testing.T) {
 		NewEnvProvider(defaultEnvPrefix, mapEnvironmentProvider{values: env}),
 	)
 
-	v := provider.GetValue("n1.id1").WithDefault("xxx")
+	v := provider.Get("n1.id1").WithDefault("xxx")
 
 	assert.True(t, v.HasValue())
 	assert.Equal(t, 111, v.Value())
 
-	v2 := provider.GetValue("n1.id2").WithDefault("xxx")
+	v2 := provider.Get("n1.id2").WithDefault("xxx")
 
 	assert.True(t, v2.HasValue())
 	assert.Equal(t, "-1", v2.Value())
@@ -138,8 +138,8 @@ func TestScopedAccess(t *testing.T) {
 
 	provider = provider.Scope("n1")
 
-	v1 := provider.GetValue("id1")
-	v2 := provider.GetValue("idx").WithDefault("nope")
+	v1 := provider.Get("id1")
+	v2 := provider.Get("idx").WithDefault("nope")
 
 	assert.True(t, v1.HasValue())
 	assert.Equal(t, 111, v1.AsInt())
@@ -157,7 +157,7 @@ func TestOverrideSimple(t *testing.T) {
 	)
 
 	rpc := &rpcStruct{}
-	v := provider.GetValue("modules.rpc")
+	v := provider.Get("modules.rpc")
 	assert.True(t, v.HasValue())
 	v.PopulateStruct(rpc)
 	assert.Equal(t, ":8888", rpc.Bind)
@@ -169,14 +169,14 @@ func TestSimpleConfigValues(t *testing.T) {
 		"test",
 		NewYAMLProviderFromBytes(yamlConfig3),
 	)
-	assert.Equal(t, 123, provider.GetValue("int").AsInt())
-	assert.Equal(t, "test string", provider.GetValue("string").AsString())
-	_, ok := provider.GetValue("nonexisting").TryAsString()
+	assert.Equal(t, 123, provider.Get("int").AsInt())
+	assert.Equal(t, "test string", provider.Get("string").AsString())
+	_, ok := provider.Get("nonexisting").TryAsString()
 	assert.False(t, ok)
-	assert.Equal(t, true, provider.GetValue("bool").AsBool())
-	assert.Equal(t, 1.123, provider.GetValue("float").AsFloat())
+	assert.Equal(t, true, provider.Get("bool").AsBool())
+	assert.Equal(t, 1.123, provider.Get("float").AsFloat())
 	nested := &nested{}
-	v := provider.GetValue("nonexisting")
+	v := provider.Get("nonexisting")
 	assert.NoError(t, v.PopulateStruct(nested))
 }
 
@@ -205,7 +205,7 @@ func TestNestedStructs(t *testing.T) {
 
 	str := &root{}
 
-	v := provider.GetValue("")
+	v := provider.Get("")
 
 	assert.True(t, v.HasValue())
 	v.PopulateStruct(str)
@@ -228,7 +228,7 @@ func TestArrayOfStructs(t *testing.T) {
 
 	target := &arrayOfStructs{}
 
-	v := provider.GetValue("")
+	v := provider.Get("")
 
 	assert.True(t, v.HasValue())
 	assert.NoError(t, v.PopulateStruct(target))
@@ -243,7 +243,7 @@ func TestDefault(t *testing.T) {
 		NewEnvProvider(defaultEnvPrefix, mapEnvironmentProvider{values: env}),
 	)
 	target := &nested{}
-	v := provider.GetValue("")
+	v := provider.Get("")
 	assert.True(t, v.HasValue())
 	assert.NoError(t, v.PopulateStruct(target))
 	assert.Equal(t, "default_name", target.Name)
@@ -254,7 +254,7 @@ func TestDefaultValue(t *testing.T) {
 		"test",
 		NewEnvProvider(defaultEnvPrefix, mapEnvironmentProvider{values: env}),
 	)
-	v := provider.GetValue("stuff")
+	v := provider.Get("stuff")
 	assert.False(t, v.HasValue())
 
 	v = v.WithDefault("ok")
@@ -263,7 +263,7 @@ func TestDefaultValue(t *testing.T) {
 	assert.True(t, v.IsDefault())
 	assert.Equal(t, "ok", v.Value())
 
-	v2 := provider.GetValue("other_stuff")
+	v2 := provider.Get("other_stuff")
 	assert.False(t, v2.HasValue())
 }
 
@@ -274,9 +274,9 @@ boolean:
 `)
 	provider := NewYAMLProviderFromBytes(valueType)
 	assert.Panics(t, func() { NewYAMLProviderFromBytes([]byte("bytes: \n\x010")) }, "Can't parse empty boolean")
-	assert.Panics(t, func() { provider.GetValue("id").AsInt() }, "Can't parse as int")
-	assert.Panics(t, func() { provider.GetValue("boolean").AsBool() }, "Can't parse empty boolean")
-	assert.Panics(t, func() { provider.GetValue("id").AsFloat() }, "Can't parse as float")
+	assert.Panics(t, func() { provider.Get("id").AsInt() }, "Can't parse as int")
+	assert.Panics(t, func() { provider.Get("boolean").AsBool() }, "Can't parse empty boolean")
+	assert.Panics(t, func() { provider.Get("id").AsFloat() }, "Can't parse as float")
 }
 
 func TestRegisteredProvidersInitialization(t *testing.T) {
@@ -290,8 +290,8 @@ func TestRegisteredProvidersInitialization(t *testing.T) {
 	})
 	cfg := Load()
 	assert.Equal(t, "global", cfg.Name())
-	assert.Equal(t, "world", cfg.GetValue("hello").AsString())
-	assert.Equal(t, "provider", cfg.GetValue("dynamic").AsString())
+	assert.Equal(t, "world", cfg.Get("hello").AsString())
+	assert.Equal(t, "provider", cfg.Get("dynamic").AsString())
 	UnregisterProviders()
 	assert.Nil(t, _staticProviderFuncs)
 	assert.Nil(t, _dynamicProviderFuncs)

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -62,7 +62,7 @@
 // Value
 //
 // Value is the return type of every configuration providers'
-// GetValue(key string) method. Under the hood, we use the empty interface
+// Get(key string) method. Under the hood, we use the empty interface
 // (
 // interface{}) since we don't necessarily know the structure of your
 // configuration ahead of time.
@@ -79,7 +79,7 @@
 //
 // You could access the value using "dotted notation":
 //
-//   foo := provider.GetValue("one.two").AsString()
+//   foo := provider.Get("one.two").AsString()
 //   fmt.Println(foo)
 //   // Output: hello
 //
@@ -116,7 +116,7 @@
 //   }
 //
 //   m := myConfig{}
-//   provider.GetValue("hello").Populate(&m)
+//   provider.Get("hello").Populate(&m)
 //   fmt.Println(m.World)
 //   // Output: yes
 //

--- a/core/config/env.go
+++ b/core/config/env.go
@@ -35,7 +35,7 @@ const defaultEnvPrefix = "CONFIG"
 
 // An EnvironmentValueProvider provides configuration from your environment
 type EnvironmentValueProvider interface {
-	GetValue(key string) (string, bool)
+	Get(key string) (string, bool)
 }
 
 var _ Provider = &envConfigProvider{}
@@ -62,11 +62,11 @@ func (p envConfigProvider) Name() string {
 	return "env"
 }
 
-func (p envConfigProvider) GetValue(key string) Value {
+func (p envConfigProvider) Get(key string) Value {
 	env := toEnvString(p.prefix, key)
 
 	var cv Value
-	value, found := p.provider.GetValue(env)
+	value, found := p.provider.Get(env)
 	cv = NewValue(p, key, value, found, String, nil)
 	return cv
 }
@@ -87,7 +87,7 @@ func (p envConfigProvider) UnregisterChangeCallback(token string) error {
 
 type osEnvironmentProvider struct{}
 
-func (p osEnvironmentProvider) GetValue(key string) (string, bool) {
+func (p osEnvironmentProvider) Get(key string) (string, bool) {
 	return os.LookupEnv(key)
 }
 
@@ -95,7 +95,7 @@ type mapEnvironmentProvider struct {
 	values map[string]string
 }
 
-func (p mapEnvironmentProvider) GetValue(key string) (string, bool) {
+func (p mapEnvironmentProvider) Get(key string) (string, bool) {
 	val, ok := p.values[key]
 	return val, ok
 }

--- a/core/config/provider.go
+++ b/core/config/provider.go
@@ -30,8 +30,8 @@ type ConfigurationChangeCallback func(key string, provider string, configdata in
 type Provider interface {
 	// the Name of the provider (YAML, Env, etc)
 	Name() string
-	// GetValue pulls a config value
-	GetValue(key string) Value
+	// Get pulls a config value
+	Get(key string) Value
 	Scope(prefix string) Provider
 
 	// A RegisterChangeCallback provides callback registration for config providers.
@@ -56,12 +56,12 @@ func NewScopedProvider(prefix string, provider Provider) Provider {
 	return &ScopedProvider{provider, prefix}
 }
 
-// GetValue returns configuration value
-func (sp ScopedProvider) GetValue(key string) Value {
+// Get returns configuration value
+func (sp ScopedProvider) Get(key string) Value {
 	if sp.prefix != "" {
 		key = fmt.Sprintf("%s.%s", sp.prefix, key)
 	}
-	return sp.Provider.GetValue(key)
+	return sp.Provider.Get(key)
 }
 
 // Scope returns new scoped provider, given a prefix

--- a/core/config/provider_group.go
+++ b/core/config/provider_group.go
@@ -44,12 +44,12 @@ func (p providerGroup) WithProvider(provider Provider) Provider {
 	}
 }
 
-func (p providerGroup) GetValue(key string) Value {
-	cv := NewValue(p, key, nil, false, GetValueType(nil), nil)
+func (p providerGroup) Get(key string) Value {
+	cv := NewValue(p, key, nil, false, GetType(nil), nil)
 
 	// loop through the providers and return the value defined by the highest priority provider
 	for _, provider := range p.providers {
-		if val := provider.GetValue(key); val.HasValue() && !val.IsDefault() {
+		if val := provider.Get(key); val.HasValue() && !val.IsDefault() {
 			cv = val
 			break
 		}

--- a/core/config/provider_group_test.go
+++ b/core/config/provider_group_test.go
@@ -30,7 +30,7 @@ import (
 func TestProviderGroup(t *testing.T) {
 	pg := NewProviderGroup("test-group", NewYAMLProviderFromBytes([]byte(`id: test`)))
 	assert.Equal(t, "test-group", pg.Name())
-	assert.Equal(t, "test", pg.GetValue("id").AsString())
+	assert.Equal(t, "test", pg.Get("id").AsString())
 	// TODO this should not require a cast GFM-74
 	assert.Empty(t, pg.(providerGroup).RegisterChangeCallback("", nil))
 	assert.Nil(t, pg.(providerGroup).UnregisterChangeCallback(""))
@@ -39,7 +39,7 @@ func TestProviderGroup(t *testing.T) {
 func TestProviderGroupScope(t *testing.T) {
 	data := map[string]interface{}{"hello.world": 42}
 	pg := NewProviderGroup("test-group", NewStaticProvider(data))
-	assert.Equal(t, 42, pg.Scope("hello").GetValue("world").AsInt())
+	assert.Equal(t, 42, pg.Scope("hello").Get("world").AsInt())
 }
 
 func TestCallbacks_WithDynamicProvider(t *testing.T) {
@@ -75,9 +75,9 @@ func (*mockDynamicProvider) Name() string {
 	return "mock"
 }
 
-func (s *mockDynamicProvider) GetValue(key string) Value {
+func (s *mockDynamicProvider) Get(key string) Value {
 	val, found := s.data[key]
-	return NewValue(s, key, val, found, GetValueType(val), nil)
+	return NewValue(s, key, val, found, GetType(val), nil)
 }
 
 func (s *mockDynamicProvider) Scope(prefix string) Provider {

--- a/core/config/static_provider.go
+++ b/core/config/static_provider.go
@@ -54,17 +54,17 @@ func (*staticProvider) Name() string {
 	return "static"
 }
 
-func (s *staticProvider) GetValue(key string) Value {
+func (s *staticProvider) Get(key string) Value {
 	s.RLock()
 	defer s.RUnlock()
 
 	if key == "" {
 		// NOTE: This returns access to the underlying map, which does not guarantee
 		// thread-safety. This is only used in the test suite.
-		return NewValue(s, key, s.data, true, GetValueType(s.data), nil)
+		return NewValue(s, key, s.data, true, GetType(s.data), nil)
 	}
 	val, found := s.data[key]
-	return NewValue(s, key, val, found, GetValueType(val), nil)
+	return NewValue(s, key, val, found, GetType(val), nil)
 }
 
 func (s *staticProvider) Scope(prefix string) Provider {
@@ -88,11 +88,11 @@ func newScopedStaticProvider(s *staticProvider, prefix string) Provider {
 	}
 }
 
-func (s *scopedStaticProvider) GetValue(key string) Value {
+func (s *scopedStaticProvider) Get(key string) Value {
 	if s.prefix != "" {
 		key = fmt.Sprintf("%s.%s", s.prefix, key)
 	}
-	return s.Provider.GetValue(key)
+	return s.Provider.Get(key)
 }
 
 var _ Provider = &staticProvider{}

--- a/core/config/static_provider_test.go
+++ b/core/config/static_provider_test.go
@@ -34,7 +34,7 @@ func TestStaticProvider_Name(t *testing.T) {
 func TestNewStaticProvider_NilData(t *testing.T) {
 	p := NewStaticProvider(nil)
 
-	val := p.GetValue("something")
+	val := p.Get("something")
 	assert.False(t, val.HasValue())
 }
 
@@ -44,7 +44,7 @@ func TestStaticProvider_WithData(t *testing.T) {
 	}
 	p := NewStaticProvider(data)
 
-	val := p.GetValue("hello")
+	val := p.Get("hello")
 	assert.True(t, val.HasValue())
 	assert.False(t, val.IsDefault())
 	assert.Equal(t, "world", val.AsString())
@@ -56,11 +56,11 @@ func TestStaticProvider_WithScope(t *testing.T) {
 	}
 	p := NewStaticProvider(data)
 
-	val := p.GetValue("hello")
+	val := p.Get("hello")
 	assert.False(t, val.HasValue())
 
 	sub := p.Scope("hello")
-	val = sub.GetValue("world")
+	val = sub.Get("world")
 	assert.True(t, val.HasValue())
 	assert.Equal(t, 42, val.AsInt())
 }

--- a/core/config/value.go
+++ b/core/config/value.go
@@ -354,7 +354,7 @@ func (cv Value) PopulateStruct(target interface{}) error {
 		return nil
 	}
 
-	_, err := cv.GetStruct(cv.key, target)
+	_, err := cv.valueStruct(cv.key, target)
 
 	return err
 }
@@ -366,7 +366,7 @@ func (cv Value) getGlobalProvider() Provider {
 	return cv.root
 }
 
-func (cv Value) GetStruct(key string, target interface{}) (interface{}, error) {
+func (cv Value) valueStruct(key string, target interface{}) (interface{}, error) {
 	// walk through the struct and start asking the providers for values at each key.
 	//
 	// - for individual values, we terminate

--- a/core/config/value.go
+++ b/core/config/value.go
@@ -52,8 +52,8 @@ const (
 
 var _typeTimeDuration = reflect.TypeOf(time.Duration(0))
 
-// GetValueType returns GO type of the provided object
-func GetValueType(value interface{}) ValueType {
+// GetType returns GO type of the provided object
+func GetType(value interface{}) ValueType {
 	if value == nil {
 		return Invalid
 	}
@@ -354,7 +354,7 @@ func (cv Value) PopulateStruct(target interface{}) error {
 		return nil
 	}
 
-	_, err := cv.getValueStruct(cv.key, target)
+	_, err := cv.GetStruct(cv.key, target)
 
 	return err
 }
@@ -366,7 +366,7 @@ func (cv Value) getGlobalProvider() Provider {
 	return cv.root
 }
 
-func (cv Value) getValueStruct(key string, target interface{}) (interface{}, error) {
+func (cv Value) GetStruct(key string, target interface{}) (interface{}, error) {
 	// walk through the struct and start asking the providers for values at each key.
 	//
 	// - for individual values, we terminate
@@ -374,12 +374,12 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 	// - for object values, we recurse.
 	//
 
-	targetValue := reflect.Indirect(reflect.ValueOf(target))
-	targetType := targetValue.Type()
-	// if b := getBucket(targetValue); b == bucketInvalid {
+	tarGet := reflect.Indirect(reflect.ValueOf(target))
+	targetType := tarGet.Type()
+	// if b := getBucket(tarGet); b == bucketInvalid {
 	// 	return nil, false, errors.Error("Invalid target object kind")
 	// } else if b == bucketPrimitive {
-	// 	return cc.GetValue(key, def)
+	// 	return cc.Get(key, def)
 	// }
 
 	global := cv.getGlobalProvider()
@@ -398,7 +398,7 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 		if key != "" {
 			childKey = key + "." + childKey
 		}
-		fieldValue := targetValue.Field(i)
+		fieldValue := tarGet.Field(i)
 
 		switch getBucket(fieldType) {
 		case bucketInvalid:
@@ -407,7 +407,7 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 			var val interface{}
 
 			if fieldType.Kind() == reflect.Ptr {
-				if v1 := global.GetValue(childKey); v1.HasValue() {
+				if v1 := global.Get(childKey); v1.HasValue() {
 					val = v1.Value()
 					if val != nil {
 						// We cannot assign reflect.ValueOf(Val) to it as is to fieldValue.
@@ -424,7 +424,7 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 			}
 
 			if fieldType == _typeTimeDuration {
-				if v := global.GetValue(childKey); v.HasValue() {
+				if v := global.Get(childKey); v.HasValue() {
 					duration, err := time.ParseDuration(v.AsString())
 					if err != nil {
 						return nil, errors.Wrap(err, "unable to parse time.Duration")
@@ -435,7 +435,7 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 			}
 
 			// For primitive values, just get the value and set it into the field
-			if v2 := global.GetValue(childKey); v2.HasValue() {
+			if v2 := global.Get(childKey); v2.HasValue() {
 				val = v2.Value()
 			} else if fieldInfo.DefaultValue != "" {
 				val = fieldInfo.DefaultValue
@@ -453,7 +453,7 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 		case bucketObject:
 			ntt := derefType(fieldType)
 			newTarget := reflect.New(ntt)
-			if v2 := global.GetValue(childKey); v2.HasValue() {
+			if v2 := global.Get(childKey); v2.HasValue() {
 
 				if err := v2.PopulateStruct(newTarget.Interface()); err != nil {
 					return nil, errors.Wrap(err, "unable to populate struct of object target")
@@ -479,12 +479,12 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 				var itemValue interface{}
 				switch bucket {
 				case bucketPrimitive:
-					if v2 := global.GetValue(arrayKey); v2.HasValue() {
+					if v2 := global.Get(arrayKey); v2.HasValue() {
 						itemValue = v2.Value()
 					}
 				case bucketObject:
 					newTarget := reflect.New(elementType)
-					if v2 := global.GetValue(arrayKey); v2.HasValue() {
+					if v2 := global.Get(arrayKey); v2.HasValue() {
 						if err := v2.PopulateStruct(newTarget.Interface()); err != nil {
 							return nil, errors.Wrap(err, "unable to populate struct of object")
 						}
@@ -508,7 +508,7 @@ func (cv Value) getValueStruct(key string, target interface{}) (interface{}, err
 				fieldValue.Set(destSlice)
 			}
 		case bucketMap:
-			val := global.GetValue(childKey).Value()
+			val := global.Get(childKey).Value()
 			if val != nil {
 				destMap := reflect.ValueOf(reflect.MakeMap(fieldType).Interface())
 

--- a/core/config/yaml.go
+++ b/core/config/yaml.go
@@ -117,8 +117,8 @@ func (y yamlConfigProvider) Name() string {
 	return "yaml"
 }
 
-// GetValue returns a configuration value by name
-func (y yamlConfigProvider) GetValue(key string) Value {
+// Get returns a configuration value by name
+func (y yamlConfigProvider) Get(key string) Value {
 	// check the cache for the value
 	if node, ok := y.vCache[key]; ok {
 		return node
@@ -130,7 +130,7 @@ func (y yamlConfigProvider) GetValue(key string) Value {
 	}
 
 	// cache the found value
-	value := NewValue(y, key, node.value, true, GetValueType(node.value), nil)
+	value := NewValue(y, key, node.value, true, GetType(node.value), nil)
 	y.vCache[key] = value
 
 	return value

--- a/core/config/yaml_benchmark_test.go
+++ b/core/config/yaml_benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkYAMLSimpleGetLevel1(b *testing.B) {
 	provider := NewYAMLProviderFromBytes([]byte(`foo: 1`))
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		provider.GetValue("foo")
+		provider.Get("foo")
 	}
 }
 
@@ -50,7 +50,7 @@ foo:
 `))
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		provider.GetValue("foo.bar.baz")
+		provider.Get("foo.bar.baz")
 	}
 }
 
@@ -66,7 +66,7 @@ foo:
 `))
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		provider.GetValue("foo.bar.baz.alpha.bravo.charlie.foxtrot")
+		provider.Get("foo.bar.baz.alpha.bravo.charlie.foxtrot")
 	}
 }
 
@@ -81,7 +81,7 @@ func BenchmarkYAMLPopulateStruct(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.GetValue("api.credentials").PopulateStruct(c)
+		p.Get("api.credentials").PopulateStruct(c)
 	}
 }
 
@@ -102,7 +102,7 @@ func BenchmarkYAMLPopulateStructNested(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.GetValue("api").PopulateStruct(s)
+		p.Get("api").PopulateStruct(s)
 	}
 }
 
@@ -125,7 +125,7 @@ func BenchmarkYAMLPopulateStructNestedMultipleFiles(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.GetValue("api").PopulateStruct(s)
+		p.Get("api").PopulateStruct(s)
 	}
 }
 

--- a/core/config/yaml_test.go
+++ b/core/config/yaml_test.go
@@ -43,7 +43,7 @@ modules:
 func TestYamlSimple(t *testing.T) {
 	provider := NewYAMLProviderFromBytes(yamlConfig1)
 
-	c := provider.GetValue("modules.rpc.bind")
+	c := provider.Get("modules.rpc.bind")
 	assert.True(t, c.HasValue())
 	assert.NotNil(t, c.Value())
 
@@ -61,7 +61,7 @@ func TestYamlStructRoot(t *testing.T) {
 
 	cs := &configStruct{}
 
-	assert.NoError(t, provider.GetValue("").PopulateStruct(cs))
+	assert.NoError(t, provider.Get("").PopulateStruct(cs))
 
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "uberfx@uber.com", cs.Owner)
@@ -76,7 +76,7 @@ func TestYamlStructChild(t *testing.T) {
 
 	cs := &rpcStruct{}
 
-	assert.NoError(t, provider.GetValue("modules.rpc").PopulateStruct(cs))
+	assert.NoError(t, provider.Get("modules.rpc").PopulateStruct(cs))
 
 	assert.Equal(t, ":28941", cs.Bind)
 }
@@ -84,10 +84,10 @@ func TestYamlStructChild(t *testing.T) {
 func TestExtends(t *testing.T) {
 	provider := NewYAMLProviderFromFiles(false, NewRelativeResolver("./testdata"), "base.yaml", "dev.yaml")
 
-	baseValue := provider.GetValue("value").AsString()
+	baseValue := provider.Get("value").AsString()
 	assert.Equal(t, "base_only", baseValue)
 
-	devValue := provider.GetValue("value_override").AsString()
+	devValue := provider.Get("value_override").AsString()
 	assert.Equal(t, "dev_setting", devValue)
 }
 
@@ -95,7 +95,7 @@ func TestNewYamlProviderFromReader(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(yamlConfig1))
 	provider := NewYamlProviderFromReader(ioutil.NopCloser(buff))
 	cs := &configStruct{}
-	assert.NoError(t, provider.GetValue("").PopulateStruct(cs))
+	assert.NoError(t, provider.Get("").PopulateStruct(cs))
 	assert.Equal(t, "yaml", provider.Scope("").Name())
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "uberfx@uber.com", cs.Owner)
@@ -131,7 +131,7 @@ func withYamlBytes(t *testing.T, yamlBytes []byte, f func(Provider)) {
 func TestMatchEmptyStruct(t *testing.T) {
 	withYamlBytes(t, []byte(``), func(provider Provider) {
 		es := emptystruct{}
-		provider.GetValue("emptystruct").PopulateStruct(&es)
+		provider.Get("emptystruct").PopulateStruct(&es)
 		empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
 		assert.True(t, reflect.DeepEqual(empty, es))
 	})
@@ -140,7 +140,7 @@ func TestMatchEmptyStruct(t *testing.T) {
 func TestMatchPopulatedEmptyStruct(t *testing.T) {
 	withYamlBytes(t, emptyyaml, func(provider Provider) {
 		es := emptystruct{}
-		provider.GetValue("emptystruct").PopulateStruct(&es)
+		provider.Get("emptystruct").PopulateStruct(&es)
 		empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
 		assert.True(t, reflect.DeepEqual(empty, es))
 	})
@@ -149,7 +149,7 @@ func TestMatchPopulatedEmptyStruct(t *testing.T) {
 func TestPopulateStructWithPointers(t *testing.T) {
 	withYamlBytes(t, pointerYaml, func(provider Provider) {
 		ps := pointerStruct{}
-		provider.GetValue("pointerStruct").PopulateStruct(&ps)
+		provider.Get("pointerStruct").PopulateStruct(&ps)
 		assert.True(t, *ps.MyTrueBool)
 		assert.False(t, *ps.MyFalseBool)
 		assert.Equal(t, "hello", *ps.MyString)
@@ -159,7 +159,7 @@ func TestPopulateStructWithPointers(t *testing.T) {
 func TestNonExistingPopulateStructWithPointers(t *testing.T) {
 	withYamlBytes(t, []byte(``), func(provider Provider) {
 		ps := pointerStruct{}
-		provider.GetValue("pointerStruct").PopulateStruct(&ps)
+		provider.Get("pointerStruct").PopulateStruct(&ps)
 		assert.Nil(t, ps.MyTrueBool)
 		assert.Nil(t, ps.MyFalseBool)
 		assert.Nil(t, ps.MyString)
@@ -169,7 +169,7 @@ func TestNonExistingPopulateStructWithPointers(t *testing.T) {
 func TestMapParsing(t *testing.T) {
 	withYamlBytes(t, complexMapYaml, func(provider Provider) {
 		ms := mapStruct{}
-		provider.GetValue("mapStruct").PopulateStruct(&ms)
+		provider.Get("mapStruct").PopulateStruct(&ms)
 
 		assert.NotNil(t, ms.MyMap)
 		assert.NotZero(t, len(ms.MyMap))
@@ -194,7 +194,7 @@ func TestMapParsing(t *testing.T) {
 func TestMapParsingSimpleMap(t *testing.T) {
 	withYamlBytes(t, simpleMapYaml, func(provider Provider) {
 		ms := mapStruct{}
-		provider.GetValue("mapStruct").PopulateStruct(&ms)
+		provider.Get("mapStruct").PopulateStruct(&ms)
 		assert.Equal(t, 1, ms.MyMap["one"])
 		assert.Equal(t, 2, ms.MyMap["two"])
 		assert.Equal(t, 3, ms.MyMap["three"])
@@ -205,7 +205,7 @@ func TestMapParsingSimpleMap(t *testing.T) {
 func TestMapParsingMapWithNonStringKeys(t *testing.T) {
 	withYamlBytes(t, intKeyMapYaml, func(provider Provider) {
 		ik := intKeyMapStruct{}
-		err := provider.GetValue("intKeyMapStruct").PopulateStruct(&ik)
+		err := provider.Get("intKeyMapStruct").PopulateStruct(&ik)
 		assert.NoError(t, err)
 		assert.Equal(t, "onetwothree", ik.IntKeyMap[123])
 	})
@@ -214,7 +214,7 @@ func TestMapParsingMapWithNonStringKeys(t *testing.T) {
 func TestDurationParsing(t *testing.T) {
 	withYamlBytes(t, durationYaml, func(provider Provider) {
 		ds := durationStruct{}
-		err := provider.GetValue("durationStruct").PopulateStruct(&ds)
+		err := provider.Get("durationStruct").PopulateStruct(&ds)
 		assert.NoError(t, err)
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, ds.Seconds)
@@ -226,7 +226,7 @@ func TestDurationParsing(t *testing.T) {
 func TestParsingUnparsableDuration(t *testing.T) {
 	withYamlBytes(t, unparsableDurationYaml, func(provider Provider) {
 		ds := durationStruct{}
-		err := provider.GetValue("durationStruct").PopulateStruct(&ds)
+		err := provider.Get("durationStruct").PopulateStruct(&ds)
 		assert.Error(t, err)
 	})
 }

--- a/doc.go
+++ b/doc.go
@@ -206,7 +206,7 @@
 // UberFx Config allows direct key access, such as foo.bar.baz:
 //
 //   cfg := svc.Config()
-//   if value := cfg.GetValue("foo.bar.baz"); value.HasValue() {
+//   if value := cfg.Get("foo.bar.baz"); value.HasValue() {
 //     fmt.Printf("Say %s", value.AsString()) // "Say hello"
 //   }
 //
@@ -221,7 +221,7 @@
 //
 //   target := &myStuff{}
 //   cfg := svc.Config()
-//   if err := cfg.GetValue("stuff.server").PopulateStruct(target); err != nil {
+//   if err := cfg.Get("stuff.server").PopulateStruct(target); err != nil {
 //     // fail, we didn't find it.
 //   }
 //

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -93,7 +93,7 @@ func newYarpcModule(
 		}
 	}
 
-	err := module.Host().Config().GetValue(fmt.Sprintf("modules.%s", module.Name())).PopulateStruct(cfg)
+	err := module.Host().Config().Get(fmt.Sprintf("modules.%s", module.Name())).PopulateStruct(cfg)
 	// found values, update module
 	module.config = *cfg
 

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -131,7 +131,7 @@ func newModule(
 		filters:    []Filter{tracerFilter{}, FilterFunc(panicFilter)},
 	}
 
-	err := module.Host().Config().GetValue(getConfigKey(mi.Name)).PopulateStruct(cfg)
+	err := module.Host().Config().Get(getConfigKey(mi.Name)).PopulateStruct(cfg)
 	if err != nil {
 		ulog.Logger().Error("Error loading http module configuration", "error", err)
 	}

--- a/service/host.go
+++ b/service/host.go
@@ -378,7 +378,7 @@ func loadInstanceConfig(cfg config.Provider, key string, instance interface{}) b
 		configValue := reflect.New(field.Type())
 
 		// Try to load the service config
-		err := cfg.GetValue(key).PopulateStruct(configValue.Interface())
+		err := cfg.Get(key).PopulateStruct(configValue.Interface())
 		if err != nil {
 			ulog.Logger().Error("Unable to load instance config", "error", err)
 			return false

--- a/service/service.go
+++ b/service/service.go
@@ -105,15 +105,15 @@ func New(options ...Option) (Owner, error) {
 	}
 
 	// load standard config
-	// TODO(glib): `.GetValue("")` is a confusing interface for getting the root config node
-	if err := svc.configProvider.GetValue("").PopulateStruct(&svc.standardConfig); err != nil {
+	// TODO(glib): `.Get("")` is a confusing interface for getting the root config node
+	if err := svc.configProvider.Get("").PopulateStruct(&svc.standardConfig); err != nil {
 		return nil, errors.Wrap(err, "unable to load standard configuration")
 	}
 
 	if svc.log == nil {
 		logBuilder := ulog.Builder()
 		// load and configure logging
-		err := svc.configProvider.GetValue("logging").PopulateStruct(&svc.logConfig)
+		err := svc.configProvider.Get("logging").PopulateStruct(&svc.logConfig)
 		if err != nil {
 			ulog.Logger().Info("Logging configuration is not provided, setting to default logger", "error", err)
 		}
@@ -140,7 +140,7 @@ func New(options ...Option) (Owner, error) {
 	}
 
 	if svc.Tracer() == nil {
-		if err := svc.configProvider.GetValue("tracing").PopulateStruct(&svc.tracerConfig); err != nil {
+		if err := svc.configProvider.Get("tracing").PopulateStruct(&svc.tracerConfig); err != nil {
 			return nil, errors.Wrap(err, "unable to load tracing configuration")
 		}
 		tracer, closer, err := tracing.InitGlobalTracer(


### PR DESCRIPTION
GFM-203

`cfg.GetValue().Value()`, stutters, and no `go` style method naming.
I wanted to get this in earlier as more code we write, we'll have to update in more places. 