### PR TITLE
Fix format and context propagation in uhttp filters

### DIFF
--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -42,7 +42,7 @@ func TestExecutionChain(t *testing.T) {
 
 func TestExecutionChainFilters(t *testing.T) {
 	chain := newExecutionChain(
-		[]Filter{tracerFilter{}, FilterFunc(panicFilter)},
+		[]Filter{FilterFunc(tracingServerFilter), FilterFunc(panicFilter)},
 		getNoopHandler(),
 	)
 	response := testServeHTTP(chain)

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -128,7 +128,7 @@ func newModule(
 	module := &Module{
 		ModuleBase: *modules.NewModuleBase(ModuleType, mi.Name, mi.Host, []string{}),
 		handlers:   handlers,
-		filters:    []Filter{tracerFilter{}, FilterFunc(panicFilter)},
+		filters:    []Filter{FilterFunc(tracingServerFilter), FilterFunc(panicFilter)},
 	}
 
 	err := module.Host().Config().Get(getConfigKey(mi.Name)).PopulateStruct(cfg)

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -41,6 +41,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Custom default client since http's defaultClient does not set timeout
+var defaultClient = &http.Client{Timeout: 5 * time.Second}
+
 func TestNew_OK(t *testing.T) {
 	WithService(New(registerNothing), nil, []service.Option{configOption()}, func(s service.Owner) {
 		assert.NotNil(t, s, "Should create a module")
@@ -205,7 +208,7 @@ func makeRequest(m *Module, method, url string, body io.Reader, fn func(r *http.
 		panic(err)
 	}
 
-	response, err := http.DefaultClient.Do(request)
+	response, err := defaultClient.Do(request)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 // Custom default client since http's defaultClient does not set timeout
-var defaultClient = &http.Client{Timeout: 5 * time.Second}
+var _defaultClient = &http.Client{Timeout: 5 * time.Second}
 
 func TestNew_OK(t *testing.T) {
 	WithService(New(registerNothing), nil, []service.Option{configOption()}, func(s service.Owner) {
@@ -208,7 +208,7 @@ func makeRequest(m *Module, method, url string, body io.Reader, fn func(r *http.
 		panic(err)
 	}
 
-	response, err := defaultClient.Do(request)
+	response, err := _defaultClient.Do(request)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Set http request context, create default client with timeout, fix logging format