### PR TITLE
Slim down the main readme and point to appropriate ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The core service is responsible for loading basic configuration and starting and
 stopping a set of these modules.  Each module gets a reference to the service to
 access standard values such as the Service name or basic configuration.
 
-[Read more about service model](service/README.md)
+[Read more about the service model](service/README.md)
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -25,82 +25,7 @@ The core service is responsible for loading basic configuration and starting and
 stopping a set of these modules.  Each module gets a reference to the service to
 access standard values such as the Service name or basic configuration.
 
-## Service Core
-
-This model results in a simple, consistent way to start a service.  For example,
-in the case of a simple TChannel Service, `main.go` might look like this:
-
-```go
-package main
-
-import (
-  "go.uber.org/fx/core/config"
-  "go.uber.org/fx/modules/rpc"
-  "go.uber.org/fx/service"
-)
-
-func main() {
-  // Create the service object
-  svc, err := service.WithModules(
-    // The list of module creators for this service, in this case
-    // creates a Thrift RPC module called "keyvalue"
-    rpc.ThriftModule(
-      rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
-      modules.WithName("keyvalue"),
-    ),
-  ).Build()
-
-  if err != nil {
-    log.Fatal("Could not initialize service: ", err)
-  }
-
-  // Start the service, with "true" meaning:
-  // * Wait for service exit
-  // * Report a non-zero exit code if shutdown is caused by an error
-  svc.Start(true)
-}
-```
-
-### Roles
-
-It's common for a service to handle many different workloads. For example, a
-service may expose RPC endpoints and also ingest Kafka messages.
-
-In UberFX, there is a simpler model where we create a single binary,
-but turn its modules on and off based on roles which are specified via the
-command line.
-
-For example, imagine we wanted a "worker" and a "service" role that handled
-Kafka and TChannel, respectively:
-
-```go
-func main() {
-  svc, err := service.WithModules(
-    kafka.Module("kakfa_topic1", []string{"worker"}),
-    rpc.ThriftModule(
-      rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
-      modules.WithName("keyvalue"),
-      modules.WithRoles("service"),
-    ),
-  ).Build()
-
-  if err != nil {
-    log.Fatal("Could not initialize service: ", err)
-  }
-
-  svc.Start(true)
-}
-```
-
-Which then allows us to set the roles either via a command line variable:
-
-`export CONFIG__roles__0=worker`
-
-Or via the service parameters, we would activate in the following ways:
-
-* `./myservice` or `./myservice --roles "service,worker"`: Runs all modules
-* `./myservice --roles "worker"`: Runs only the **Kakfa** module
-* Etc...
+[Read more about service model](service/README.md)
 
 ## Modules
 
@@ -153,70 +78,7 @@ interface to configuration from pluggable configuration sources. This interface
 defines methods for accessing values directly or into strongly
 typed structs.
 
-The configuration system wraps a set of _providers_ that each know how to get
-values from an underlying source:
-
-* Static YAML configuration
-* Environment variables
-
-So by stacking these providers, we can have a priority system for defining
-configuration that can be overridden by higher priority providers. For example,
-the static YAML configuration would be the lowest priority and those values
-should be overridden by values specified as environment variables.
-
-As an example, imagine a YAML config that looks like:
-
-```yaml
-foo:
-  bar:
-    boo: 1
-    baz: hello
-
-stuff:
-  server:
-    port: 8081
-    greeting: Hello There!
-```
-
-UberFx Config allows direct key access, such as `foo.bar.baz`:
-
-```go
-cfg := svc.Config()
-if value := cfg.Get("foo.bar.baz"); value.HasValue() {
-  fmt.Printf("Say %s", value.AsString()) // "Say hello"
-}
-```
-
-Or via a strongly typed structure, even as a nest value, such as:
-
-```go
-type myStuff struct {
-  Port     int    `yaml:"port" default:"8080"`
-  Greeting string `yaml:"greeting"`
-}
-
-// ....
-
-target := &myStuff{}
-cfg := svc.Config()
-if err := cfg.Get("stuff.server").PopulateStruct(target); err != nil {
-  // fail, we didn't find it.
-}
-
-fmt.Printf("Port is: %v", target.Port)
-```
-
-Prints **Port is 8081**
-
-This model respects priority of providers to allow overriding of individual
-values.  In this example, we override the server port via an environment
-variable:
-
-```sh
-export CONFIG__stuff__server__port=3000
-```
-
-Then running the above example will result in **Port is 3000**
+[Read more about configuration](core/config/README.md)
 
 ## Compatibility
 

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -31,6 +31,69 @@
 //
 // • Override any field if the default doesn't make sense for their use case
 //
+// Nesting
+//
+// The configuration system wraps a set of *providers* that each know how to get
+// values from an underlying source:
+//
+//
+// • Static YAML configuration
+//
+// • Environment variables
+//
+// So by stacking these providers, we can have a priority system for defining
+// configuration that can be overridden by higher priority providers. For example,
+// the static YAML configuration would be the lowest priority and those values
+// should be overridden by values specified as environment variables.
+//
+//
+// As an example, imagine a YAML config that looks like:
+//
+//   foo:
+//     bar:
+//       boo: 1
+//       baz: hello
+//
+//   stuff:
+//     server:
+//       port: 8081
+//       greeting: Hello There!
+//
+// UberFx Config allows direct key access, such as foo.bar.baz:
+//
+//   cfg := svc.Config()
+//   if value := cfg.Get("foo.bar.baz"); value.HasValue() {
+//     fmt.Printf("Say %s", value.AsString()) // "Say hello"
+//   }
+//
+// Or via a strongly typed structure, even as a nest value, such as:
+//
+//   type myStuff struct {
+//     Port     int    `yaml:"port" default:"8080"`
+//     Greeting string `yaml:"greeting"`
+//   }
+//
+//   // ....
+//
+//   target := &myStuff{}
+//   cfg := svc.Config()
+//   if err := cfg.Get("stuff.server").PopulateStruct(target); err != nil {
+//     // fail, we didn't find it.
+//   }
+//
+//   fmt.Printf("Port is: %v", target.Port)
+//
+// Prints **Port is 8081**
+//
+// This model respects priority of providers to allow overriding of individual
+// values.  In this example, we override the server port via an environment
+// variable:
+//
+//
+//   export CONFIG__stuff__server__port=3000
+//
+// Then running the above example will result in **Port is 3000**
+//
 // Provider
 //
 // Provider is the interface for anything that can provide values.

--- a/doc.go
+++ b/doc.go
@@ -43,84 +43,7 @@
 // access standard values such as the Service name or basic configuration.
 //
 //
-// Service Core
-//
-// This model results in a simple, consistent way to start a service.  For example,
-// in the case of a simple TChannel Service,
-// main.go might look like this:
-//
-//   package main
-//
-//   import (
-//     "go.uber.org/fx/core/config"
-//     "go.uber.org/fx/modules/rpc"
-//     "go.uber.org/fx/service"
-//   )
-//
-//   func main() {
-//     // Create the service object
-//     svc, err := service.WithModules(
-//       // The list of module creators for this service, in this case
-//       // creates a Thrift RPC module called "keyvalue"
-//       rpc.ThriftModule(
-//         rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
-//         modules.WithName("keyvalue"),
-//       ),
-//     ).Build()
-//
-//     if err != nil {
-//       log.Fatal("Could not initialize service: ", err)
-//     }
-//
-//     // Start the service, with "true" meaning:
-//     // * Wait for service exit
-//     // * Report a non-zero exit code if shutdown is caused by an error
-//     svc.Start(true)
-//   }
-//
-// Roles
-//
-// It's common for a service to handle many different workloads. For example, a
-// service may expose RPC endpoints and also ingest Kafka messages.
-//
-//
-// In UberFX, there is a simpler model where we create a single binary,
-// but turn its modules on and off based on roles which are specified via the
-// command line.
-//
-//
-// For example, imagine we wanted a "worker" and a "service" role that handled
-// Kafka and TChannel, respectively:
-//
-//
-//   func main() {
-//     svc, err := service.WithModules(
-//       kafka.Module("kakfa_topic1", []string{"worker"}),
-//       rpc.ThriftModule(
-//         rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
-//         modules.WithName("keyvalue"),
-//         modules.WithRoles("service"),
-//       ),
-//     ).Build()
-//
-//     if err != nil {
-//       log.Fatal("Could not initialize service: ", err)
-//     }
-//
-//     svc.Start(true)
-//   }
-//
-// Which then allows us to set the roles either via a command line variable:
-//
-// export CONFIG__roles__0=worker
-//
-// Or via the service parameters, we would activate in the following ways:
-//
-// • ./myservice or ./myservice --roles "service,worker": Runs all modules
-//
-// • ./myservice --roles "worker": Runs only the **Kakfa** module
-//
-// • Etc...
+// Read more about service model (service/README.md)
 //
 // Modules
 //
@@ -177,66 +100,7 @@
 // typed structs.
 //
 //
-// The configuration system wraps a set of *providers* that each know how to get
-// values from an underlying source:
-//
-//
-// • Static YAML configuration
-//
-// • Environment variables
-//
-// So by stacking these providers, we can have a priority system for defining
-// configuration that can be overridden by higher priority providers. For example,
-// the static YAML configuration would be the lowest priority and those values
-// should be overridden by values specified as environment variables.
-//
-//
-// As an example, imagine a YAML config that looks like:
-//
-//   foo:
-//     bar:
-//       boo: 1
-//       baz: hello
-//
-//   stuff:
-//     server:
-//       port: 8081
-//       greeting: Hello There!
-//
-// UberFx Config allows direct key access, such as foo.bar.baz:
-//
-//   cfg := svc.Config()
-//   if value := cfg.Get("foo.bar.baz"); value.HasValue() {
-//     fmt.Printf("Say %s", value.AsString()) // "Say hello"
-//   }
-//
-// Or via a strongly typed structure, even as a nest value, such as:
-//
-//   type myStuff struct {
-//     Port     int    `yaml:"port" default:"8080"`
-//     Greeting string `yaml:"greeting"`
-//   }
-//
-//   // ....
-//
-//   target := &myStuff{}
-//   cfg := svc.Config()
-//   if err := cfg.Get("stuff.server").PopulateStruct(target); err != nil {
-//     // fail, we didn't find it.
-//   }
-//
-//   fmt.Printf("Port is: %v", target.Port)
-//
-// Prints **Port is 8081**
-//
-// This model respects priority of providers to allow overriding of individual
-// values.  In this example, we override the server port via an environment
-// variable:
-//
-//
-//   export CONFIG__stuff__server__port=3000
-//
-// Then running the above example will result in **Port is 3000**
+// Read more about configuration (core/config/README.md)
 //
 // Compatibility
 //

--- a/doc.go
+++ b/doc.go
@@ -43,7 +43,7 @@
 // access standard values such as the Service name or basic configuration.
 //
 //
-// Read more about service model (service/README.md)
+// Read more about the service model (service/README.md)
 //
 // Modules
 //

--- a/service/README.md
+++ b/service/README.md
@@ -1,8 +1,85 @@
-# Service Lifecycle
+# Service
 
 Service, being a bit of an overloaded term, requires some
 specific care to explain the various components in the `service`
 package in UberFx.
+
+## Core
+
+This model results in a simple, consistent way to start a service.  For example,
+in the case of a simple TChannel Service, `main.go` might look like this:
+
+```go
+package main
+
+import (
+  "go.uber.org/fx/core/config"
+  "go.uber.org/fx/modules/rpc"
+  "go.uber.org/fx/service"
+)
+
+func main() {
+  // Create the service object
+  svc, err := service.WithModules(
+    // The list of module creators for this service, in this case
+    // creates a Thrift RPC module called "keyvalue"
+    rpc.ThriftModule(
+      rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+      modules.WithName("keyvalue"),
+    ),
+  ).Build()
+
+  if err != nil {
+    log.Fatal("Could not initialize service: ", err)
+  }
+
+  // Start the service, with "true" meaning:
+  // * Wait for service exit
+  // * Report a non-zero exit code if shutdown is caused by an error
+  svc.Start(true)
+}
+```
+
+### Roles
+
+It's common for a service to handle many different workloads. For example, a
+service may expose RPC endpoints and also ingest Kafka messages.
+
+In UberFX, there is a simpler model where we create a single binary,
+but turn its modules on and off based on roles which are specified via the
+command line.
+
+For example, imagine we wanted a "worker" and a "service" role that handled
+Kafka and TChannel, respectively:
+
+```go
+func main() {
+  svc, err := service.WithModules(
+    kafka.Module("kakfa_topic1", []string{"worker"}),
+    rpc.ThriftModule(
+      rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+      modules.WithName("keyvalue"),
+      modules.WithRoles("service"),
+    ),
+  ).Build()
+
+  if err != nil {
+    log.Fatal("Could not initialize service: ", err)
+  }
+
+  svc.Start(true)
+}
+```
+
+Which then allows us to set the roles either via a command line variable:
+
+`export CONFIG__roles__0=worker`
+
+Or via the service parameters, we would activate in the following ways:
+
+* `./myservice` or `./myservice --roles "service,worker"`: Runs all modules
+* `./myservice --roles "worker"`: Runs only the **Kakfa** module
+* Etc...
 
 ## Instantiation
 

--- a/service/doc.go
+++ b/service/doc.go
@@ -18,12 +18,91 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package service is the Service Lifecycle.
+// Package service is the Service.
 //
 // Service, being a bit of an overloaded term, requires some
 // specific care to explain the various components in the
 // servicepackage in UberFx.
 //
+//
+// Core
+//
+// This model results in a simple, consistent way to start a service.  For example,
+// in the case of a simple TChannel Service,
+// main.go might look like this:
+//
+//   package main
+//
+//   import (
+//     "go.uber.org/fx/core/config"
+//     "go.uber.org/fx/modules/rpc"
+//     "go.uber.org/fx/service"
+//   )
+//
+//   func main() {
+//     // Create the service object
+//     svc, err := service.WithModules(
+//       // The list of module creators for this service, in this case
+//       // creates a Thrift RPC module called "keyvalue"
+//       rpc.ThriftModule(
+//         rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+//         modules.WithName("keyvalue"),
+//       ),
+//     ).Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     // Start the service, with "true" meaning:
+//     // * Wait for service exit
+//     // * Report a non-zero exit code if shutdown is caused by an error
+//     svc.Start(true)
+//   }
+//
+// Roles
+//
+// It's common for a service to handle many different workloads. For example, a
+// service may expose RPC endpoints and also ingest Kafka messages.
+//
+//
+// In UberFX, there is a simpler model where we create a single binary,
+// but turn its modules on and off based on roles which are specified via the
+// command line.
+//
+//
+// For example, imagine we wanted a "worker" and a "service" role that handled
+// Kafka and TChannel, respectively:
+//
+//
+//   func main() {
+//     svc, err := service.WithModules(
+//       kafka.Module("kakfa_topic1", []string{"worker"}),
+//       rpc.ThriftModule(
+//         rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+//         modules.WithName("keyvalue"),
+//         modules.WithRoles("service"),
+//       ),
+//     ).Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     svc.Start(true)
+//   }
+//
+// Which then allows us to set the roles either via a command line variable:
+//
+// export CONFIG__roles__0=worker
+//
+// Or via the service parameters, we would activate in the following ways:
+//
+// • ./myservice or ./myservice --roles "service,worker": Runs all modules
+//
+// • ./myservice --roles "worker": Runs only the **Kakfa** module
+//
+// • Etc...
 //
 // Instantiation
 //


### PR DESCRIPTION
Tried to keep only the most relevant high-level information in the main README. Everything special or too technical went to the README in the appropriate location.

I'd like us to try and keep this model going forward, so the main README doesn't scare people away by being too diluted and large