### PR TITLE
Pin tally to pre-refactor

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cafcc2c159448839c2858b98c9b98f7f5e63d900023fc3f2da812248fa8c262a
-updated: 2016-11-22T11:34:34.666075064-08:00
+hash: 33315208f69dde5b12a1fd0ea73baefaa96328eee3b3e6c6bdbf8498901bd180
+updated: 2016-11-22T14:59:34.742671317-08:00
 imports:
 - name: github.com/apache/thrift
   version: 84d6af4cf903571319e0ebddd7beb12bc93fb752

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: go.uber.org/fx
 import:
 - package: github.com/uber-go/zap
+# TODO(glib): Tally pinned for the time being until we've updated to the new API
 - package: github.com/uber-go/tally
   version: 17aa18f4826bf57be74cbb9a94984cdb7aa63716
 - package: github.com/gorilla/mux

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,7 @@ package: go.uber.org/fx
 import:
 - package: github.com/uber-go/zap
 - package: github.com/uber-go/tally
+  version: 17aa18f4826bf57be74cbb9a94984cdb7aa63716
 - package: github.com/gorilla/mux
   version: ^1.1.0
 - package: github.com/gorilla/context


### PR DESCRIPTION
Tally went through some rather large interface changes, so I'm pinning that dependency for now.
Going to work on adopting the new api, but I don't want anyone's service to break in the mean time.