### PR TITLE
Fix the shutdown deadlock after blocking start

### DIFF
--- a/service/host.go
+++ b/service/host.go
@@ -238,7 +238,6 @@ func (s *host) Start(waitForShutdown bool) (<-chan Exit, <-chan struct{}, error)
 					ExitCode: 4,
 				}
 
-				s.shutdownMu.Unlock()
 				if _, err := s.shutdown(e, "", nil); err != nil {
 					s.Logger().Error("Unable to shut down modules", "initialError", e, "shutdownError", err)
 				}
@@ -249,12 +248,12 @@ func (s *host) Start(waitForShutdown bool) (<-chan Exit, <-chan struct{}, error)
 
 	s.registerSignalHandlers()
 
+	s.shutdownMu.Unlock()
+	s.transitionState(Running)
+
 	if waitForShutdown {
 		s.WaitForShutdown(nil)
 	}
-
-	s.transitionState(Running)
-	s.shutdownMu.Unlock()
 
 	return s.closeChan, readyCh, err
 }

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -225,6 +225,15 @@ func TestAddModule_NotLocked(t *testing.T) {
 	assert.Equal(t, sh, mod.Host)
 }
 
+func TestStartStopRegressionDeadlock(t *testing.T) {
+	sh := makeHost()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		sh.Stop("stop nao!", 1)
+	}()
+	sh.Start(true)
+}
+
 func TestStartModule_NoErrors(t *testing.T) {
 	s := makeHost()
 	mod := NewStubModule()


### PR DESCRIPTION
I noticed that Ctrl-C was no longer in the sample app (really annoying to kill -9 every time).

Dug into it a bit, found a deadlock:

```
1 @ 0x2ea5a 0x2eb4e 0x3e9fd 0x3e690 0x13d560 0xe5f8c 0xe76db 0x26ce 0x5e6c1
#	0x3e68f		sync.runtime_Semacquire+0x2f			/usr/local/Cellar/go/1.7.1/libexec/src/runtime/sema.go:47
#	0x13d55f	sync.(*Mutex).Lock+0xcf				/usr/local/Cellar/go/1.7.1/libexec/src/sync/mutex.go:85
#	0xe5f8b		go.uber.org/fx/service.(*host).shutdown+0x6b	/Users/glib/gocode/src/go.uber.org/fx/service/host.go:113
#	0xe76da		go.uber.org/fx/service.(*host).Stop+0x5a	/Users/glib/gocode/src/go.uber.org/fx/service/host.go:283
#	0x26cd		main.main.func2+0xdd				/Users/glib/gocode/src/go.uber.org/fx/examples/simple/main.go:59
```

Turns out when we had a blocking service, the unlock was never done for the shutdown mutex (my mistake during previous refactor).

Ctrl-C now works.