### PR TITLE
Make keyvalue Makefile runnable on a fresh clone

### DIFF
--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -1,8 +1,11 @@
-.PHONY: dependencies
-dependencies:
+.PHONY: libdeps
+libdeps:
 	@$(call label,Installing Glide and locked dependencies...)
 	$(ECHO_V)glide --version 2>/dev/null || go get -u -f github.com/Masterminds/glide
 	$(ECHO_V)glide install
+
+.PHONY: dependencies
+dependencies: libdeps
 	@$(call label,Installing test dependencies...)
 	$(ECHO_V)go install ./vendor/github.com/axw/gocov/gocov
 	$(ECHO_V)go install ./vendor/github.com/mattn/goveralls

--- a/examples/keyvalue/Makefile
+++ b/examples/keyvalue/Makefile
@@ -1,5 +1,7 @@
 .PHONY: deps
 deps:
+	@echo "Installing UberFx dependencies..."
+	$(ECHO_V)$(MAKE) -C ../.. libdeps
 	@echo "Installing thriftrw..."
 	$(ECHO_V)go install ../../vendor/go.uber.org/thriftrw
 	@echo "Installing thriftrw-plugin-yarpc..."


### PR DESCRIPTION
Prior to this, trying to `make` in here in a fresh checkout would fail
because vendor doesn't exist / dependencies haven't been fetched.