### PR TITLE
Fix make

### DIFF
--- a/.build/check_license.sh
+++ b/.build/check_license.sh
@@ -8,7 +8,7 @@ run_uber_licence() {
   local bin="$LICENCE_BIN"
   # Ok, somebody hasn't run `npm install -g uber-licence`, that's cool
   if ! which "$bin" >/dev/null ; then
-    npm install "$bin"
+    npm install "$bin" >/dev/null
     bin="./node_modules/uber-licence/bin/licence"
   fi
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ include $(SUPPORT_FILES)/verbosity.mk
 
 .PHONY: all
 all: lint test
+.DEFAULT_GOAL := all
 
 COV_REPORT := overalls.coverprofile
 


### PR DESCRIPTION
`npm install` prints some output to the lint log, which then makes `make lint` fail. `.DEFAULT_GOAL` is also set to `all`.