### PR TITLE
Change metrics func to get a stats reporter and propagate to the tracer

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -72,7 +72,7 @@ func ensureNotFrozen() {
 	}
 }
 
-// RegisterRootScope initializes the stats reporter for all the service metrics
+// RegisterRootScope initializes the root scope for all the service metrics
 func RegisterRootScope(scopeFunc ScopeFunc) {
 	ensureNotFrozen()
 	_mu.Lock()
@@ -86,7 +86,7 @@ func RegisterRootScope(scopeFunc ScopeFunc) {
 	_scopeFunc = scopeFunc
 }
 
-// RootScope returns the provided stats reporter, or nil
+// RootScope returns the provided metrics scope and stats reporter, or nil if not provided
 func RootScope(i ScopeInit) (tally.Scope, tally.StatsReporter, io.Closer) {
 	_mu.Lock()
 	defer _mu.Unlock()

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -34,20 +34,22 @@ import (
 func TestRegisterReporter_OK(t *testing.T) {
 	defer cleanup()
 
-	scope, _ := getScope()
+	scope, reporter, _ := getScope()
 	assert.Nil(t, scope)
+	assert.Nil(t, reporter)
 
-	RegisterRootScope(goodScope)
-	scope, _ = getScope()
+	RegisterStatsReporter(goodScope)
+	scope, reporter, _ = getScope()
 	assert.NotNil(t, scope)
+	assert.NotNil(t, reporter)
 }
 
 func TestRegisterReporterPanics(t *testing.T) {
 	defer cleanup()
 
-	RegisterRootScope(goodScope)
+	RegisterStatsReporter(goodScope)
 	assert.Panics(t, func() {
-		RegisterRootScope(goodScope)
+		RegisterStatsReporter(goodScope)
 	})
 }
 
@@ -56,28 +58,28 @@ func TestRegisterReporterFrozen(t *testing.T) {
 
 	Freeze()
 	assert.Panics(t, func() {
-		RegisterRootScope(goodScope)
+		RegisterStatsReporter(goodScope)
 	})
 }
 
 func TestRegisterBadReporterPanics(t *testing.T) {
 	defer cleanup()
 
-	RegisterRootScope(badScope)
+	RegisterStatsReporter(badScope)
 	assert.Panics(t, func() {
 		getScope()
 	})
 }
 
-func goodScope(i ScopeInit) (tally.Scope, io.Closer, error) {
-	return tally.NoopScope, nil, nil
+func goodScope(i ScopeInit) (tally.StatsReporter, error) {
+	return tally.NullStatsReporter, nil
 }
 
-func badScope(i ScopeInit) (tally.Scope, io.Closer, error) {
-	return nil, nil, errors.New("fake error")
+func badScope(i ScopeInit) (tally.StatsReporter, error) {
+	return nil, errors.New("fake error")
 }
 
-func getScope() (tally.Scope, io.Closer) {
+func getScope() (tally.Scope, tally.StatsReporter, io.Closer) {
 	return RootScope(scopeInit())
 }
 
@@ -104,7 +106,7 @@ func scopeInit() ScopeInit {
 }
 
 func cleanup() {
-	_scopeFunc = nil
+	_repFunc = nil
 	_frozen = false
 }
 

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -34,14 +34,17 @@ import (
 func TestRegisterReporter_OK(t *testing.T) {
 	defer cleanup()
 
-	scope, reporter, _ := getScope()
+	scope, reporter, closer := getScope()
 	assert.Nil(t, scope)
 	assert.Nil(t, reporter)
+	assert.Nil(t, closer)
 
 	RegisterStatsReporter(goodScope)
-	scope, reporter, _ = getScope()
+	scope, reporter, closer = getScope()
+	defer closer.Close()
 	assert.NotNil(t, scope)
 	assert.NotNil(t, reporter)
+	assert.NotNil(t, closer)
 }
 
 func TestRegisterReporterPanics(t *testing.T) {

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -66,7 +66,7 @@ func TestRegisterReporterFrozen(t *testing.T) {
 	})
 }
 
-func TestRegisterbadScopePanics(t *testing.T) {
+func TestRegisterBadReporterPanics(t *testing.T) {
 	defer cleanup()
 
 	RegisterRootScope(badScope)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -39,7 +39,7 @@ func TestRegisterReporter_OK(t *testing.T) {
 	assert.Nil(t, reporter)
 	assert.Nil(t, closer)
 
-	RegisterStatsReporter(goodScope)
+	RegisterStatsReporter(goodReporter)
 	scope, reporter, closer = getScope()
 	defer closer.Close()
 	assert.NotNil(t, scope)
@@ -50,9 +50,9 @@ func TestRegisterReporter_OK(t *testing.T) {
 func TestRegisterReporterPanics(t *testing.T) {
 	defer cleanup()
 
-	RegisterStatsReporter(goodScope)
+	RegisterStatsReporter(goodReporter)
 	assert.Panics(t, func() {
-		RegisterStatsReporter(goodScope)
+		RegisterStatsReporter(goodReporter)
 	})
 }
 
@@ -61,24 +61,24 @@ func TestRegisterReporterFrozen(t *testing.T) {
 
 	Freeze()
 	assert.Panics(t, func() {
-		RegisterStatsReporter(goodScope)
+		RegisterStatsReporter(goodReporter)
 	})
 }
 
 func TestRegisterBadReporterPanics(t *testing.T) {
 	defer cleanup()
 
-	RegisterStatsReporter(badScope)
+	RegisterStatsReporter(badReporter)
 	assert.Panics(t, func() {
 		getScope()
 	})
 }
 
-func goodScope(i ScopeInit) (tally.StatsReporter, error) {
+func goodReporter(i ScopeInit) (tally.StatsReporter, error) {
 	return tally.NullStatsReporter, nil
 }
 
-func badScope(i ScopeInit) (tally.StatsReporter, error) {
+func badReporter(i ScopeInit) (tally.StatsReporter, error) {
 	return nil, errors.New("fake error")
 }
 

--- a/service/core.go
+++ b/service/core.go
@@ -66,13 +66,14 @@ type SetContainerer interface {
 }
 
 type metricsCore struct {
-	scope            tally.Scope
+	metrics          tally.Scope
+	statsReporter    tally.StatsReporter
 	metricsCloser    io.Closer
 	runtimeCollector *metrics.RuntimeCollector
 }
 
 func (mc *metricsCore) Metrics() tally.Scope {
-	return mc.scope
+	return mc.metrics
 }
 
 func (mc *metricsCore) MetricsCloser() io.Closer {

--- a/service/host_mock.go
+++ b/service/host_mock.go
@@ -41,7 +41,8 @@ func NullHost() Host {
 			log: ulog.NoopLogger,
 		},
 		metricsCore: metricsCore{
-			metrics: tally.NoopScope,
+			metrics:       tally.NoopScope,
+			statsReporter: tally.NullStatsReporter,
 		},
 		tracerCore: tracerCore{
 			tracer: opentracing.NoopTracer{},

--- a/service/host_mock.go
+++ b/service/host_mock.go
@@ -41,7 +41,7 @@ func NullHost() Host {
 			log: ulog.NoopLogger,
 		},
 		metricsCore: metricsCore{
-			scope: tally.NoopScope,
+			metrics: tally.NoopScope,
 		},
 		tracerCore: tracerCore{
 			tracer: opentracing.NoopTracer{},

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -195,7 +195,7 @@ func TestHostShutdown_RunningService(t *testing.T) {
 func TestHostShutdown_CloseSuccessful(t *testing.T) {
 	sh := makeRunningHost()
 	sh.serviceCore.metricsCore = metricsCore{
-		scope:            tally.NoopScope,
+		metrics:          tally.NoopScope,
 		metricsCloser:    testutils.NoopCloser{},
 		runtimeCollector: metrics.NewRuntimeCollector(tally.NoopScope, time.Millisecond),
 	}
@@ -208,7 +208,7 @@ func TestHostShutdown_CloseSuccessful(t *testing.T) {
 func TestHostShutdown_MetricsCloserError(t *testing.T) {
 	sh := makeRunningHost()
 	sh.serviceCore.metricsCore = metricsCore{
-		scope:         tally.NoopScope,
+		metrics:       tally.NoopScope,
 		metricsCloser: testutils.ErrorCloser{},
 	}
 	checkShutdown(t, sh, true)

--- a/service/options.go
+++ b/service/options.go
@@ -55,7 +55,7 @@ func WithLogger(log ulog.Log) Option {
 func WithMetricsRootScope(scope tally.Scope) Option {
 	return func(svc Host) error {
 		svc2 := svc.(*host)
-		svc2.scope = scope
+		svc2.metrics = scope
 		return nil
 	}
 }

--- a/service/options.go
+++ b/service/options.go
@@ -51,11 +51,12 @@ func WithLogger(log ulog.Log) Option {
 	}
 }
 
-// WithMetricsRootScope configures a service host with metrics
-func WithMetricsRootScope(scope tally.Scope) Option {
+// WithMetrics configures a service host with metrics and stats reporter
+func WithMetrics(scope tally.Scope, reporter tally.StatsReporter) Option {
 	return func(svc Host) error {
 		svc2 := svc.(*host)
 		svc2.metrics = scope
+		svc2.statsReporter = reporter
 		return nil
 	}
 }

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func TestAddModules_OK(t *testing.T) {
@@ -46,6 +47,12 @@ func TestWithLogger_OK(t *testing.T) {
 	logger := ulog.New()
 	assert.NotPanics(t, func() {
 		New(WithLogger(logger))
+	})
+}
+
+func TestWithMetrics_OK(t *testing.T) {
+	assert.NotPanics(t, func() {
+		New(WithMetrics(tally.NoopScope, tally.NullStatsReporter))
 	})
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -147,10 +147,10 @@ func New(options ...Option) (Owner, error) {
 	// Initialize metrics. If no metrics reporters were Registered, do noop
 	// TODO(glib): add a logging reporter and use it by default, rather than noop
 	if svc.Metrics() == nil {
-		svc.scope, svc.metricsCloser = metrics.RootScope(svc)
+		svc.metrics, svc.statsReporter, svc.metricsCloser = metrics.RootScope(svc)
 
-		if svc.scope == nil {
-			svc.scope = tally.NoopScope
+		if svc.metrics == nil {
+			svc.metrics = tally.NoopScope
 		}
 
 		metrics.Freeze()
@@ -163,7 +163,7 @@ func New(options ...Option) (Owner, error) {
 			return nil, errors.Wrap(err, "unable to load runtime metrics configuration")
 		}
 		svc.runtimeCollector = metrics.StartCollectingRuntimeMetrics(
-			svc.scope.SubScope("runtime"), time.Second, runtimeMetricsConfig,
+			svc.metrics.SubScope("runtime"), time.Second, runtimeMetricsConfig,
 		)
 	}
 
@@ -175,7 +175,7 @@ func New(options ...Option) (Owner, error) {
 			&svc.tracerConfig,
 			svc.standardConfig.ServiceName,
 			svc.log,
-			svc.scope.SubScope("tracing"),
+			svc.statsReporter,
 		)
 		if err != nil {
 			return svc, errors.Wrap(err, "unable to initialize global tracer")

--- a/service/service.go
+++ b/service/service.go
@@ -152,6 +152,9 @@ func New(options ...Option) (Owner, error) {
 		if svc.metrics == nil {
 			svc.metrics = tally.NoopScope
 		}
+		if svc.statsReporter == nil {
+			svc.statsReporter = tally.NullStatsReporter
+		}
 
 		metrics.Freeze()
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -87,7 +87,7 @@ func TestServiceCreation(t *testing.T) {
 	defer closer.Close()
 	svc, err := New(
 		withConfig(validServiceConfig),
-		WithMetricsRootScope(scope),
+		WithMetrics(scope, nil),
 	)
 	require.NoError(t, err)
 	assert.NotNil(t, svc, "Service should be created")

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -36,14 +36,14 @@ func InitGlobalTracer(
 	cfg *config.Configuration,
 	serviceName string,
 	logger ulog.Log,
-	scope tally.Scope,
+	statsReporter tally.StatsReporter,
 ) (opentracing.Tracer, io.Closer, error) {
 	var reporter *jaegerReporter
 	if cfg == nil || !cfg.Disabled {
 		cfg = loadAppConfig(cfg, logger)
 		// TODO: Change to use the right stats reporter
 		reporter = &jaegerReporter{
-			reporter: tally.NullStatsReporter,
+			reporter: statsReporter,
 		}
 	}
 	tracer, closer, err := cfg.New(serviceName, reporter)

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -49,6 +49,7 @@ func TestInitGlobalTracer_Simple(t *testing.T) {
 	tracer, closer, err := InitGlobalTracer(
 		_emptyJaegerConfig, _serviceName, getLogger(), _statsReporter,
 	)
+	defer closer.Close()
 	assert.NotNil(t, tracer)
 	assert.NotNil(t, closer)
 	assert.NoError(t, err)
@@ -58,6 +59,7 @@ func TestInitGlobalTracer_Disabled(t *testing.T) {
 	tracer, closer, err := InitGlobalTracer(
 		_disabledJaegerConfig, _serviceName, getLogger(), _statsReporter,
 	)
+	defer closer.Close()
 	assert.NotNil(t, tracer)
 	assert.NotNil(t, closer)
 	assert.NoError(t, err)

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 	"github.com/uber-go/zap"
-	"github.com/uber/jaeger-client-go"
+	jaeger "github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/config"
 )
 
 var (
 	_serviceName            = "serviceName"
-	_scope                  = tally.NoopScope
+	_statsReporter          = tally.NullStatsReporter
 	_emptyJaegerConfig      = &config.Configuration{}
 	_disabledJaegerConfig   = &config.Configuration{Disabled: true}
 	_jaegerConfigWithLogger = &config.Configuration{Logger: jaeger.NullLogger}
@@ -46,21 +46,25 @@ func getLogger() ulog.Log {
 }
 
 func TestInitGlobalTracer_Simple(t *testing.T) {
-	tracer, closer, err := InitGlobalTracer(_emptyJaegerConfig, _serviceName, getLogger(), _scope)
+	tracer, closer, err := InitGlobalTracer(
+		_emptyJaegerConfig, _serviceName, getLogger(), _statsReporter,
+	)
 	assert.NotNil(t, tracer)
 	assert.NotNil(t, closer)
 	assert.NoError(t, err)
 }
 
 func TestInitGlobalTracer_Disabled(t *testing.T) {
-	tracer, closer, err := InitGlobalTracer(_disabledJaegerConfig, _serviceName, getLogger(), _scope)
+	tracer, closer, err := InitGlobalTracer(
+		_disabledJaegerConfig, _serviceName, getLogger(), _statsReporter,
+	)
 	assert.NotNil(t, tracer)
 	assert.NotNil(t, closer)
 	assert.NoError(t, err)
 }
 
 func TestInitGlobalTracer_NoServiceName(t *testing.T) {
-	tracer, closer, err := InitGlobalTracer(_emptyJaegerConfig, "", getLogger(), _scope)
+	tracer, closer, err := InitGlobalTracer(_emptyJaegerConfig, "", getLogger(), _statsReporter)
 	assert.Error(t, err)
 	assert.Nil(t, tracer)
 	assert.Nil(t, closer)


### PR DESCRIPTION
Tally API upgrade removed access to the stats reporter from the scope. Tracer needs access to the stats reporter. This is to propagate and store stats reporter in service.Host so it can be used by the tracer.