### PR TITLE
Sentry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ BENCH_FILE ?= .bench/new.txt
 .PHONY: bench
 bench:
 	@$(call label,Running benchmarks)
-	$(ECHO_V)rm $(BENCH_FILE)
+	$(ECHO_V)rm -f $(BENCH_FILE)
 	$(ECHO_V)$(foreach pkg,$(BENCH_PKGS),go test -bench=. -run="^$$" $(BENCH_FLAGS) $(pkg) | \
 		tee -a $(BENCH_FILE);)
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,20 @@
-hash: a2a69cfc3530997a341379de8ad2b2fdedba0fe92434f9704a62096cdea5e2bf
-updated: 2016-12-07T11:33:53.160525342-08:00
+hash: 651629312a68a9d4145297cfeeb1af6c6fcc4f50e5580fd3beac47b0ac694d79
+updated: 2016-12-08T16:15:13.073285441-08:00
 imports:
 - name: github.com/apache/thrift
   version: 7ab125a253e5aebbf2a0ed9a0a1602a4b879eca7
   subpackages:
   - lib/go/thrift
+- name: github.com/certifi/gocertifi
+  version: a61bf5eafa3aee233ec8043e9da052447e5463dd
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+- name: github.com/getsentry/raven-go
+  version: 3f7439d3e74d88e21d196ba20eb61a5a958bc118
 - name: github.com/go-validator/validator
   version: 0a9835d809fb647a62611d30cb792e0b5dd65b11
 - name: github.com/gorilla/context
@@ -39,6 +43,8 @@ imports:
   version: 2750b4ae690cbeb294016efe18ceaeb80c4ce17c
 - name: github.com/uber-go/zap
   version: 35cd7966cc81adc0449c91b3f6b1939812be73aa
+  subpackages:
+  - zwrap
 - name: github.com/uber/jaeger-client-go
   version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
   subpackages:
@@ -89,7 +95,7 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: golang.org/x/net
-  version: 9773060888fba93b172cedcd70127db1ab739bd1
+  version: e31bd588d1077ee66a958c0ad3a235f2084b4195
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,6 +18,8 @@ import:
   version: v2
 - package: github.com/pkg/errors
   version: ^0.8.0
+- package: github.com/getsentry/raven-go
+  version: master
 - package: github.com/uber/jaeger-client-go
   version: ^1.6.0
 - package: github.com/stretchr/testify

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -155,8 +155,9 @@ logging:
 	svc, err := New(cfgOpt)
 	require.NoError(t, err)
 	assert.NotNil(t, svc.Logger())
-
-	// TODO (madhu): Figure out how to test sentry here
+	// Note: Sentry is not accessible so we cannot directly test it here. Just invoking the code
+	// path to make sure there is no panic
+	svc.Logger().Info("Testing sentry call")
 }
 
 func TestBadOption_Panics(t *testing.T) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -154,11 +154,9 @@ logging:
 
 	svc, err := New(cfgOpt)
 	require.NoError(t, err)
+	assert.NotNil(t, svc.Logger())
 
-	sh := svc.Logger().Sentry()
-
-	assert.NotNil(t, sh)
-	defer sh.Capturer.Close()
+	// TODO (madhu): Figure out how to test sentry here
 }
 
 func TestBadOption_Panics(t *testing.T) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -142,6 +142,25 @@ metrics:
 	assert.Nil(t, svc.RuntimeMetricsCollector())
 }
 
+func TestServiceWithSentryHook(t *testing.T) {
+	data := []byte(`
+applicationID: name
+applicationOwner: owner
+logging:
+  sentry:
+    dsn: http://user:secret@your.sentry.dsn/project
+`)
+	cfgOpt := WithConfiguration(config.NewYAMLProviderFromBytes(data))
+
+	svc, err := New(cfgOpt)
+	require.NoError(t, err)
+
+	sh := svc.Logger().Sentry()
+
+	assert.NotNil(t, sh)
+	defer sh.Capturer.Close()
+}
+
 func TestBadOption_Panics(t *testing.T) {
 	opt := func(_ Host) error {
 		return errors.New("nope")

--- a/ulog/README.md
+++ b/ulog/README.md
@@ -107,3 +107,34 @@ BenchmarkUlogWithFieldsBaseLoggerStruct-8  2000000   912 ns/op  795 B/op   18 al
 BenchmarkUlogWithFieldsZapLogger-8         3000000   558 ns/op  513 B/op   1 allocs/op
 BenchmarkUlogLiteWithFields-8              3000000   466 ns/op  297 B/op   7 allocs/op
 ```
+
+## Sentry
+
+`ulog` has a seamless integration with Sentry. For out-of-the-box usage
+just include this in your configuration yaml:
+
+```yaml
+logging:
+  sentry:
+    dsn: http://user:secret@your.sentry.dsn/project
+```
+
+If you'd like to take more control over the Sentry integration, see
+`sentry.Hook`
+
+For example, to turn off Stacktrace generation:
+
+```go
+import (
+  "github.com/uber-go/zap"
+  "go.uber.org/fx/ulog/ulog"
+  "go.uber.org/fx/ulog/sentry"
+  "go.uber.org/fx/service"
+)
+
+func main() {
+  h := sentry.New(MY_DSN, MinLevel(zap.InfoLevel), DisableTraces())
+  l := ulog.Builder().WithSentryHook(h).Build()
+  svc, err := service..WithLogger(l).Build()
+}
+```

--- a/ulog/README.md
+++ b/ulog/README.md
@@ -135,6 +135,6 @@ import (
 func main() {
   h := sentry.New(MY_DSN, MinLevel(zap.InfoLevel), DisableTraces())
   l := ulog.Builder().WithSentryHook(h).Build()
-  svc, err := service..WithLogger(l).Build()
+  svc, err := service.WithLogger(l).Build()
 }
 ```

--- a/ulog/README.md
+++ b/ulog/README.md
@@ -101,11 +101,13 @@ Current performance benchmark data with `ulog interface`,
 `ulog baseLogger struct`, and `zap.Logger`
 
 ```
-BenchmarkUlogWithoutFields-8               5000000   226 ns/op  48 B/op    1 allocs/op
-BenchmarkUlogWithFieldsLogIFace-8          2000000   1026 ns/op 1052 B/op  19 allocs/op
-BenchmarkUlogWithFieldsBaseLoggerStruct-8  2000000   912 ns/op  795 B/op   18 allocs/op
-BenchmarkUlogWithFieldsZapLogger-8         3000000   558 ns/op  513 B/op   1 allocs/op
-BenchmarkUlogLiteWithFields-8              3000000   466 ns/op  297 B/op   7 allocs/op
+BenchmarkUlogWithoutFields-8                    10000000               223 ns/op               0 B/op          0 allocs/op
+BenchmarkUlogWithFieldsLogIFace-8                1000000              1237 ns/op            1005 B/op         18 allocs/op
+BenchmarkUlogWithFieldsBaseLoggerStruct-8        1000000              1096 ns/op             748 B/op         17 allocs/op
+BenchmarkUlogWithFieldsZapLogger-8               2000000               664 ns/op             514 B/op          1 allocs/op
+BenchmarkUlogLiteWithFields-8                    3000000               489 ns/op             249 B/op          6 allocs/op
+BenchmarkUlogSentry-8                            3000000               407 ns/op             128 B/op          4 allocs/op
+BenchmarkUlogSentryWith-8                        1000000              1535 ns/op            1460 B/op         12 allocs/op
 ```
 
 ## Sentry

--- a/ulog/builder.go
+++ b/ulog/builder.go
@@ -26,6 +26,7 @@ import (
 	"path"
 
 	"go.uber.org/fx/config"
+	"go.uber.org/fx/ulog/sentry"
 
 	"github.com/uber-go/zap"
 )
@@ -50,8 +51,9 @@ type FileConfiguration struct {
 
 // LogBuilder is the struct containing logger
 type LogBuilder struct {
-	log       zap.Logger
-	logConfig Configuration
+	log        zap.Logger
+	logConfig  Configuration
+	sentryHook *sentry.Hook
 }
 
 // Builder creates an empty builder for building ulog.Log object
@@ -76,6 +78,12 @@ func (lb *LogBuilder) SetLogger(zap zap.Logger) *LogBuilder {
 	return lb
 }
 
+// WithSentryHook lalalal
+func (lb *LogBuilder) WithSentryHook(hook *sentry.Hook) *LogBuilder {
+	lb.sentryHook = hook
+	return lb
+}
+
 // Build the ulog logger for use
 func (lb *LogBuilder) Build() Log {
 	var log zap.Logger
@@ -95,6 +103,7 @@ func (lb *LogBuilder) Build() Log {
 
 	return &baseLogger{
 		log: log,
+		sh:  lb.sentryHook,
 	}
 }
 

--- a/ulog/builder.go
+++ b/ulog/builder.go
@@ -86,7 +86,7 @@ func (lb *LogBuilder) SetLogger(zap zap.Logger) *LogBuilder {
 	return lb
 }
 
-// WithSentryHook allows to manually configure the sentry hook
+// WithSentryHook allows users to manually configure the sentry hook
 func (lb *LogBuilder) WithSentryHook(hook *sentry.Hook) *LogBuilder {
 	lb.sentryHook = hook
 	return lb
@@ -116,6 +116,8 @@ func (lb *LogBuilder) Build() Log {
 			hook, err := sentry.New(lb.logConfig.Sentry.DSN)
 			if err == nil {
 				lb.sentryHook = hook
+			} else {
+				log.Warn("Sentry creation failed with error", zap.Error(err))
 			}
 		}
 	}

--- a/ulog/builder.go
+++ b/ulog/builder.go
@@ -86,7 +86,7 @@ func (lb *LogBuilder) SetLogger(zap zap.Logger) *LogBuilder {
 	return lb
 }
 
-// WithSentryHook lalalal
+// WithSentryHook allows to manually configure the sentry hook
 func (lb *LogBuilder) WithSentryHook(hook *sentry.Hook) *LogBuilder {
 	lb.sentryHook = hook
 	return lb

--- a/ulog/doc.go
+++ b/ulog/doc.go
@@ -123,5 +123,33 @@
 //   BenchmarkUlogWithFieldsZapLogger-8         3000000   558 ns/op  513 B/op   1 allocs/op
 //   BenchmarkUlogLiteWithFields-8              3000000   466 ns/op  297 B/op   7 allocs/op
 //
+// Sentry
+//
+// ulog has a seamless integration with Sentry. For out-of-the-box usage
+// just include this in your configuration yaml:
+//
+//
+//   logging:
+//     sentry:
+//       dsn: http://user:secret@your.sentry.dsn/project
+//
+// If you'd like to take more control over the Sentry integration, see
+// sentry.Hook
+//
+// For example, to turn off Stacktrace generation:
+//
+//   import (
+//     "github.com/uber-go/zap"
+//     "go.uber.org/fx/ulog/ulog"
+//     "go.uber.org/fx/ulog/sentry"
+//     "go.uber.org/fx/service"
+//   )
+//
+//   func main() {
+//     h := sentry.New(MY_DSN, MinLevel(zap.InfoLevel), DisableTraces())
+//     l := ulog.Builder().WithSentryHook(h).Build()
+//     svc, err := service..WithLogger(l).Build()
+//   }
+//
 //
 package ulog

--- a/ulog/doc.go
+++ b/ulog/doc.go
@@ -117,11 +117,13 @@
 // Current performance benchmark data with ulog interface,
 // ulog baseLogger struct, and zap.Logger
 //
-//   BenchmarkUlogWithoutFields-8               5000000   226 ns/op  48 B/op    1 allocs/op
-//   BenchmarkUlogWithFieldsLogIFace-8          2000000   1026 ns/op 1052 B/op  19 allocs/op
-//   BenchmarkUlogWithFieldsBaseLoggerStruct-8  2000000   912 ns/op  795 B/op   18 allocs/op
-//   BenchmarkUlogWithFieldsZapLogger-8         3000000   558 ns/op  513 B/op   1 allocs/op
-//   BenchmarkUlogLiteWithFields-8              3000000   466 ns/op  297 B/op   7 allocs/op
+//   BenchmarkUlogWithoutFields-8                    10000000               223 ns/op               0 B/op          0 allocs/op
+//   BenchmarkUlogWithFieldsLogIFace-8                1000000              1237 ns/op            1005 B/op         18 allocs/op
+//   BenchmarkUlogWithFieldsBaseLoggerStruct-8        1000000              1096 ns/op             748 B/op         17 allocs/op
+//   BenchmarkUlogWithFieldsZapLogger-8               2000000               664 ns/op             514 B/op          1 allocs/op
+//   BenchmarkUlogLiteWithFields-8                    3000000               489 ns/op             249 B/op          6 allocs/op
+//   BenchmarkUlogSentry-8                            3000000               407 ns/op             128 B/op          4 allocs/op
+//   BenchmarkUlogSentryWith-8                        1000000              1535 ns/op            1460 B/op         12 allocs/op
 //
 // Sentry
 //
@@ -148,7 +150,7 @@
 //   func main() {
 //     h := sentry.New(MY_DSN, MinLevel(zap.InfoLevel), DisableTraces())
 //     l := ulog.Builder().WithSentryHook(h).Build()
-//     svc, err := service..WithLogger(l).Build()
+//     svc, err := service.WithLogger(l).Build()
 //   }
 //
 //

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -29,12 +29,8 @@ import (
 	"github.com/uber-go/zap"
 )
 
-<<<<<<< HEAD
 type baseLogger struct {
-=======
-type baselogger struct {
 	sh  *sentry.Hook
->>>>>>> Implement a sentry logging hook
 	log zap.Logger
 }
 
@@ -56,6 +52,9 @@ type Log interface {
 
 	// RawLogger returns underlying logger implementation (zap.Logger) to get around the ulog.Log interface
 	RawLogger() zap.Logger
+
+	// Sentry returns the underlying sentry hook
+	Sentry() *sentry.Hook
 
 	// Log at the provided zap.Level with message, and a sequence of parameters as key value pairs
 	Log(level zap.Level, message string, keyVals ...interface{})
@@ -103,13 +102,18 @@ func (l *baseLogger) RawLogger() zap.Logger {
 	return l.log
 }
 
+// Sentry returns underlying sentry hook
+func (l *baseLogger) Sentry() *sentry.Hook {
+	return l.sh
+}
+
 func (l *baseLogger) With(keyVals ...interface{}) Log {
 	if l.sh != nil {
-		l.sh.AppendFields(keyvals)
+		l.sh.AppendFields(keyVals)
 	}
 
-	return &baselogger{
-		log: l.log.With(l.fieldsConversion(keyvals...)...),
+	return &baseLogger{
+		log: l.log.With(l.fieldsConversion(keyVals...)...),
 		sh:  l.sh,
 	}
 }
@@ -148,7 +152,7 @@ func (l *baseLogger) DPanic(message string, keyVals ...interface{}) {
 
 func (l *baseLogger) Log(lvl zap.Level, message string, keyVals ...interface{}) {
 	if l.sh != nil {
-		l.sh.CheckAndFire(lvl, message, keyvals...)
+		l.sh.CheckAndFire(lvl, message, keyVals...)
 	}
 
 	if cm := l.Check(lvl, message); cm.OK() {

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -99,11 +99,6 @@ func (l *baseLogger) RawLogger() zap.Logger {
 	return l.log
 }
 
-// sentry returns underlying sentry hook
-func (l *baseLogger) sentry() *sentry.Hook {
-	return l.sh
-}
-
 func (l *baseLogger) With(keyVals ...interface{}) Log {
 	var sh *sentry.Hook
 	if l.sh != nil {

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -145,12 +145,11 @@ func (l *baseLogger) DPanic(message string, keyVals ...interface{}) {
 }
 
 func (l *baseLogger) Log(lvl zap.Level, message string, keyVals ...interface{}) {
-	if l.sh != nil {
-		l.sh.CheckAndFire(lvl, message, keyVals...)
-	}
-
 	if cm := l.Check(lvl, message); cm.OK() {
 		cm.Write(l.fieldsConversion(keyVals...)...)
+	}
+	if l.sh != nil {
+		l.sh.CheckAndFire(lvl, message, keyVals...)
 	}
 }
 

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -108,13 +108,15 @@ func (l *baseLogger) Sentry() *sentry.Hook {
 }
 
 func (l *baseLogger) With(keyVals ...interface{}) Log {
+	var sh *sentry.Hook
 	if l.sh != nil {
-		l.sh.AppendFields(keyVals)
+		sh = l.sh.Copy()
+		sh.AppendFields(keyVals...)
 	}
 
 	return &baseLogger{
 		log: l.log.With(l.fieldsConversion(keyVals...)...),
-		sh:  l.sh,
+		sh:  sh,
 	}
 }
 

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -53,9 +53,6 @@ type Log interface {
 	// RawLogger returns underlying logger implementation (zap.Logger) to get around the ulog.Log interface
 	RawLogger() zap.Logger
 
-	// Sentry returns the underlying sentry hook
-	Sentry() *sentry.Hook
-
 	// Log at the provided zap.Level with message, and a sequence of parameters as key value pairs
 	Log(level zap.Level, message string, keyVals ...interface{})
 
@@ -102,8 +99,8 @@ func (l *baseLogger) RawLogger() zap.Logger {
 	return l.log
 }
 
-// Sentry returns underlying sentry hook
-func (l *baseLogger) Sentry() *sentry.Hook {
+// sentry returns underlying sentry hook
+func (l *baseLogger) sentry() *sentry.Hook {
 	return l.sh
 }
 

--- a/ulog/log_benchmark_test.go
+++ b/ulog/log_benchmark_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/fx/ulog/sentry"
+
 	"github.com/uber-go/zap"
 )
 
@@ -117,5 +119,16 @@ func BenchmarkUlogLiteWithFields(b *testing.B) {
 				log.Info("Ulog message", "integer", 123, "string", "string")
 			}
 		})
+	})
+}
+
+func BenchmarkUlogWithSentry(b *testing.B) {
+	h, _ := sentry.New("")
+	l := Builder().SetLogger(discardedLogger()).WithSentryHook(h).Build()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			l.With("foo", "bar").Error("Ulog message", "string", "string")
+		}
 	})
 }

--- a/ulog/log_benchmark_test.go
+++ b/ulog/log_benchmark_test.go
@@ -122,7 +122,18 @@ func BenchmarkUlogLiteWithFields(b *testing.B) {
 	})
 }
 
-func BenchmarkUlogWithSentry(b *testing.B) {
+func BenchmarkUlogSentry(b *testing.B) {
+	h, _ := sentry.New("")
+	l := Builder().SetLogger(discardedLogger()).WithSentryHook(h).Build()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			l.Error("Ulog message", "string", "string")
+		}
+	})
+}
+
+func BenchmarkUlogSentryWith(b *testing.B) {
 	h, _ := sentry.New("")
 	l := Builder().SetLogger(discardedLogger()).WithSentryHook(h).Build()
 	b.ResetTimer()

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/zap"
+	"go.uber.org/fx/ulog/sentry"
 )
 
 func TestSimpleLogger(t *testing.T) {
@@ -128,4 +129,22 @@ func TestRawLogger(t *testing.T) {
 func TestLogger(t *testing.T) {
 	log := Logger()
 	assert.NotNil(t, log.RawLogger())
+}
+
+func TestSentryHook(t *testing.T) {
+	c := &sentry.MemCapturer{}
+	h, err := sentry.New("")
+	assert.NoError(t, err, "Need to be able to create a sentry hook")
+	h.Capturer = c
+
+	l := Builder().WithSentryHook(h).Build()
+
+	l.Error("you work, yea?", "key", 123)
+	l.Info("this should not be sent, right?", "key", "val")
+
+	fmt.Println(c.Packets)
+
+	assert.Equal(t, 1, len(c.Packets))
+	p := c.Packets[0]
+	assert.Equal(t, "you work, yea?", p.Message)
 }

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -149,8 +149,8 @@ func TestSentryHook(t *testing.T) {
 
 func TestSentryHookDoesNotMutatePrevious(t *testing.T) {
 	h, err := sentry.New("")
-	assert.NoError(t, err)
 	defer h.Close()
+	assert.NoError(t, err)
 
 	l := Builder().WithSentryHook(h).Build().(*baseLogger)
 	assert.Equal(t, make(map[string]interface{}), l.sh.Fields())

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -152,12 +152,12 @@ func TestSentryHookDoesNotMutatePrevious(t *testing.T) {
 	assert.NoError(t, err)
 	defer h.Close()
 
-	l := Builder().WithSentryHook(h).Build()
-	assert.Equal(t, make(map[string]interface{}), l.Sentry().Fields())
+	l := Builder().WithSentryHook(h).Build().(*baseLogger)
+	assert.Equal(t, make(map[string]interface{}), l.sh.Fields())
 
-	l2 := l.With("key", "value")
-	assert.Equal(t, map[string]interface{}{}, l.Sentry().Fields())
-	assert.NotNil(t, l2.Sentry())
-	assert.NotNil(t, l2.Sentry().Fields())
-	assert.Equal(t, map[string]interface{}{"key": "value"}, l2.Sentry().Fields())
+	l2 := l.With("key", "value").(*baseLogger)
+	assert.Equal(t, map[string]interface{}{}, l.sh.Fields())
+	assert.NotNil(t, l2.sh)
+	assert.NotNil(t, l2.sh.Fields())
+	assert.Equal(t, map[string]interface{}{"key": "value"}, l2.sh.Fields())
 }

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -142,8 +142,6 @@ func TestSentryHook(t *testing.T) {
 	l.Error("you work, yea?", "key", 123)
 	l.Info("this should not be sent, right?", "key", "val")
 
-	fmt.Println(c.Packets)
-
 	assert.Equal(t, 1, len(c.Packets))
 	p := c.Packets[0]
 	assert.Equal(t, "you work, yea?", p.Message)

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -146,3 +146,18 @@ func TestSentryHook(t *testing.T) {
 	p := c.Packets[0]
 	assert.Equal(t, "you work, yea?", p.Message)
 }
+
+func TestSentryHookDoesNotMutatePrevious(t *testing.T) {
+	h, err := sentry.New("")
+	assert.NoError(t, err)
+	defer h.Close()
+
+	l := Builder().WithSentryHook(h).Build()
+	assert.Equal(t, make(map[string]interface{}), l.Sentry().Fields())
+
+	l2 := l.With("key", "value")
+	assert.Equal(t, map[string]interface{}{}, l.Sentry().Fields())
+	assert.NotNil(t, l2.Sentry())
+	assert.NotNil(t, l2.Sentry().Fields())
+	assert.Equal(t, map[string]interface{}{"key": "value"}, l2.Sentry().Fields())
+}

--- a/ulog/sentry/capturer.go
+++ b/ulog/sentry/capturer.go
@@ -24,7 +24,7 @@ import raven "github.com/getsentry/raven-go"
 
 // Capturer knows what to do with a Sentry packet.
 type Capturer interface {
-	Capture(p *raven.Packet) error
+	Capture(p *raven.Packet)
 	Close()
 }
 
@@ -37,9 +37,8 @@ type MemCapturer struct {
 func (m *MemCapturer) Close() {}
 
 // Capture remembers the would-be-sent packet in the packets array
-func (m *MemCapturer) Capture(p *raven.Packet) error {
+func (m *MemCapturer) Capture(p *raven.Packet) {
 	m.Packets = append(m.Packets, p)
-	return nil
 }
 
 type nonBlockingCapturer struct {
@@ -51,7 +50,7 @@ func (nb *nonBlockingCapturer) Close() {
 }
 
 // Capture will fire off a packet without checking the error channel.
-func (nb *nonBlockingCapturer) Capture(p *raven.Packet) error {
+func (nb *nonBlockingCapturer) Capture(p *raven.Packet) {
+	// TODO (madhu/glib): Capture returns an error channel. Should we handle it?
 	nb.Client.Capture(p, nil)
-	return nil
 }

--- a/ulog/sentry/capturer.go
+++ b/ulog/sentry/capturer.go
@@ -18,26 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Copyright (c) 2016 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE
-
 package sentry
 
 import raven "github.com/getsentry/raven-go"

--- a/ulog/sentry/capturer.go
+++ b/ulog/sentry/capturer.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+
+package sentry
+
+import raven "github.com/getsentry/raven-go"
+
+// Capturer knows what to do with a Sentry packet.
+type Capturer interface {
+	Capture(p *raven.Packet) error
+	Close()
+}
+
+// MemCapturer foo
+type MemCapturer struct {
+	Packets []*raven.Packet
+}
+
+// Close is a nop
+func (m *MemCapturer) Close() {}
+
+// Capture remembers the would-be-sent packet in the packets array
+func (m *MemCapturer) Capture(p *raven.Packet) error {
+	m.Packets = append(m.Packets, p)
+	return nil
+}
+
+type nonBlockingCapturer struct {
+	*raven.Client
+}
+
+func (nb *nonBlockingCapturer) Close() {
+	nb.Client.Close()
+}
+
+// Capture will fire off a packet without checking the error channel.
+func (nb *nonBlockingCapturer) Capture(p *raven.Packet) error {
+	nb.Client.Capture(p, nil)
+	return nil
+}

--- a/ulog/sentry/sentry.go
+++ b/ulog/sentry/sentry.go
@@ -211,10 +211,5 @@ func (sh *Hook) CheckAndFire(lvl zap.Level, msg string, keyvals ...interface{}) 
 		}
 	}
 
-	err := sh.Capture(packet)
-	if err != nil {
-		// TODO(glib): Ok now what?
-		// Sentry just failed, should we log more about it and have it fail again?
-		// That can bring a whole service down...
-	}
+	sh.Capture(packet)
 }

--- a/ulog/sentry/sentry.go
+++ b/ulog/sentry/sentry.go
@@ -45,7 +45,8 @@ var _zapToRavenMap = map[zap.Level]raven.Severity{
 	zap.FatalLevel: raven.FATAL,
 }
 
-// Hook allala
+// Hook wraps the default raven-go client for some out-of-box awesomeness
+// and tight integration with ulog
 type Hook struct {
 	Capturer
 
@@ -152,7 +153,8 @@ func (l *Hook) AppendFields(keyvals ...interface{}) {
 	}
 }
 
-// CheckAndFire lalala
+// CheckAndFire check to see if logging level is above Sentry treshold
+// and if so, fires off a Sentry packet
 func (l *Hook) CheckAndFire(lvl zap.Level, msg string, keyvals ...interface{}) {
 	fmt.Println(lvl)
 	if lvl < l.minLevel {
@@ -187,5 +189,10 @@ func (l *Hook) CheckAndFire(lvl zap.Level, msg string, keyvals ...interface{}) {
 		}
 	}
 
-	l.Capture(packet)
+	err := l.Capture(packet)
+	if err != nil {
+		// TODO(glib): Ok now what?
+		// Sentry just failed, should we log more about it and have it fail again?
+		// That can bring a whole service down...
+	}
 }

--- a/ulog/sentry/sentry.go
+++ b/ulog/sentry/sentry.go
@@ -176,7 +176,7 @@ func (sh *Hook) Copy() *Hook {
 	}
 }
 
-// CheckAndFire check to see if logging level is above Sentry treshold
+// CheckAndFire check to see if logging level is above Sentry threshold
 // and if so, fires off a Sentry packet
 func (sh *Hook) CheckAndFire(lvl zap.Level, msg string, keyvals ...interface{}) {
 	if lvl < sh.minLevel {

--- a/ulog/sentry/sentry.go
+++ b/ulog/sentry/sentry.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sentry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/uber-go/zap"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/pkg/errors"
+)
+
+const (
+	_platform          = "go"
+	_traceContextLines = 3
+	_traceSkipFrames   = 2
+)
+
+var _zapToRavenMap = map[zap.Level]raven.Severity{
+	zap.DebugLevel: raven.INFO,
+	zap.InfoLevel:  raven.INFO,
+	zap.WarnLevel:  raven.WARNING,
+	zap.ErrorLevel: raven.ERROR,
+	zap.PanicLevel: raven.FATAL,
+	zap.FatalLevel: raven.FATAL,
+}
+
+// Hook allala
+type Hook struct {
+	Capturer
+
+	// This is pretty expensive as far as allocations go.
+	// No need to copy maps around, especially if they are not going to be used
+	// TODO(glib): make this better. We should be able to have an efficient
+	// marshaler of this data that won't have us copy maps around
+	fields map[string]interface{}
+
+	// Minimum level threshold for sending a Sentry event
+	minLevel zap.Level
+
+	// Controls if stack trace should be automatically generated, and how many frames to skip
+	traceEnabled      bool
+	traceSkipFrames   int
+	traceContextLines int
+	traceAppPrefixes  []string
+}
+
+// Option pattern for Hook creation.
+type Option func(l *Hook)
+
+// New Sentry Hook.
+func New(dsn string, options ...Option) (*Hook, error) {
+	l := &Hook{
+		minLevel:          zap.ErrorLevel,
+		traceEnabled:      true,
+		traceSkipFrames:   _traceSkipFrames,
+		traceContextLines: _traceContextLines,
+		fields:            make(map[string]interface{}),
+	}
+
+	for _, option := range options {
+		option(l)
+	}
+
+	client, err := raven.New(dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create sentry client")
+	}
+
+	l.Capturer = &nonBlockingCapturer{Client: client}
+
+	return l, nil
+}
+
+// MinLevel provides a minimum level threshold.
+// All log messages above the set level are sent to Sentry.
+func MinLevel(level zap.Level) Option {
+	return func(l *Hook) {
+		l.minLevel = level
+	}
+}
+
+// DisableTraces allows to turn off Stacktrace for sentry packets.
+func DisableTraces() Option {
+	return func(l *Hook) {
+		l.traceEnabled = false
+	}
+}
+
+// TraceContextLines sets how many lines of code (in on direction) are sent
+// with the Sentry packet.
+func TraceContextLines(lines int) Option {
+	return func(l *Hook) {
+		l.traceContextLines = lines
+	}
+}
+
+// TraceAppPrefixes sets a list of go import prefixes that are considered "in app".
+func TraceAppPrefixes(prefixes []string) Option {
+	return func(l *Hook) {
+		l.traceAppPrefixes = prefixes
+	}
+}
+
+// TraceSkipFrames sets how many stacktrace frames to skip when sending a
+// sentry packet. This is very useful when helper functions are involved.
+func TraceSkipFrames(skip int) Option {
+	return func(l *Hook) {
+		l.traceSkipFrames = skip
+	}
+}
+
+// Fields stores additional information for each Sentry event.
+func Fields(fields map[string]interface{}) Option {
+	return func(l *Hook) {
+		// TODO(glib): yuck!
+		f := make(map[string]interface{})
+		for k, v := range fields {
+			f[k] = v
+		}
+		l.fields = f
+	}
+}
+
+// AppendFields expands the currently stored context of the hook
+func (l *Hook) AppendFields(keyvals ...interface{}) {
+	for idx := 0; idx < len(keyvals); idx += 2 {
+		if key, ok := keyvals[idx].(string); ok {
+			val := keyvals[idx+1]
+			l.fields[key] = val
+		}
+	}
+}
+
+// CheckAndFire lalala
+func (l *Hook) CheckAndFire(lvl zap.Level, msg string, keyvals ...interface{}) {
+	fmt.Println(lvl)
+	if lvl < l.minLevel {
+		return
+	}
+
+	// append all the fields from the current log message to the stored ones
+	f := make(map[string]interface{}, len(l.fields)+len(keyvals)/2)
+	for k, v := range l.fields {
+		f[k] = v
+	}
+
+	for idx := 0; idx < len(keyvals); idx += 2 {
+		if key, ok := keyvals[idx].(string); ok {
+			val := keyvals[idx+1]
+			f[key] = val
+		}
+	}
+
+	packet := &raven.Packet{
+		Message:   msg,
+		Timestamp: raven.Timestamp(time.Now()),
+		Level:     _zapToRavenMap[lvl],
+		Platform:  _platform,
+		Extra:     f,
+	}
+
+	if l.traceEnabled {
+		trace := raven.NewStacktrace(l.traceSkipFrames, l.traceContextLines, l.traceAppPrefixes)
+		if trace != nil {
+			packet.Interfaces = append(packet.Interfaces, trace)
+		}
+	}
+
+	l.Capture(packet)
+}

--- a/ulog/sentry/sentry_test.go
+++ b/ulog/sentry/sentry_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sentry
+
+import (
+	"compress/zlib"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/zap"
+)
+
+type fakeClient raven.Client
+
+func TestBadDSN(t *testing.T) {
+	_, err := New("123http://whoops")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create sentry client")
+}
+
+func TestEmptyDSN(t *testing.T) {
+	l, err := New("")
+	assert.NoError(t, err)
+	assert.NotNil(t, l)
+}
+
+func TestWithLevels(t *testing.T) {
+	l, err := New("", MinLevel(zap.InfoLevel))
+	assert.NoError(t, err)
+	assert.NotNil(t, l)
+	assert.Equal(t, l.minLevel, zap.InfoLevel)
+}
+
+func TestExtra(t *testing.T) {
+	f := map[string]interface{}{
+		"requestID":         "123h2eor2039423",
+		"someInt":           123,
+		"arrayOfManyThings": []int{1, 2, 3},
+	}
+	s, err := New("", Fields(f))
+	s.CheckAndFire(zap.ErrorLevel, "error log", "foo", "bar")
+	assert.NoError(t, err)
+	assert.Equal(t, s.fields, f)
+}
+
+func TestWith(t *testing.T) {
+	sh, err := New("", Fields(map[string]interface{}{
+		"someInt": 123,
+	}))
+	assert.NoError(t, err)
+	expected := map[string]interface{}{"someInt": 123, "someFloat": float64(10)}
+	sh.AppendFields("someFloat", float64(10))
+	assert.Equal(t, expected, sh.fields)
+}
+
+func TestWithTraceDisabled(t *testing.T) {
+	_, ps := capturePackets(func(sh *Hook) {
+		sh.CheckAndFire(zap.ErrorLevel, "some error message", "foo", "bar")
+		sh.CheckAndFire(zap.ErrorLevel, "another error message")
+	}, DisableTraces())
+
+	for _, p := range ps {
+		assert.Empty(t, p.Interfaces)
+	}
+}
+
+func TestTraceCfg(t *testing.T) {
+	l, err := New(
+		"",
+		TraceSkipFrames(1),
+		TraceContextLines(7),
+		TraceAppPrefixes([]string{"github.com/uber-go/unicorns"}),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, l.traceSkipFrames, 1)
+	assert.Equal(t, l.traceContextLines, 7)
+	assert.Equal(t, l.traceAppPrefixes, []string{"github.com/uber-go/unicorns"})
+}
+
+func TestLevels(t *testing.T) {
+	_, ps := capturePackets(func(sh *Hook) {
+		sh.CheckAndFire(zap.DebugLevel, "debug level log")
+		sh.CheckAndFire(zap.InfoLevel, "info level log")
+		sh.CheckAndFire(zap.WarnLevel, "warn level log")
+		sh.CheckAndFire(zap.ErrorLevel, "error level log")
+	}, MinLevel(zap.WarnLevel))
+
+	assert.Equal(t, len(ps), 2, "only Warn and Error packets should be collected")
+}
+
+func TestErrorCapture(t *testing.T) {
+	_, p := capturePacket(func(sh *Hook) {
+		sh.CheckAndFire(zap.ErrorLevel, "some error message", "foo", "bar")
+	})
+
+	assert.Equal(t, p.Message, "some error message")
+	assert.Equal(t, p.Extra, map[string]interface{}{"foo": "bar"})
+
+	trace := p.Interfaces[0].(*raven.Stacktrace)
+	assert.NotNil(t, trace.Frames)
+}
+
+func TestPacketSending(t *testing.T) {
+	withTestSentry(func(dsn string, ch <-chan *raven.Packet) {
+		sh, err := New(dsn)
+		defer sh.Close()
+
+		if err != nil {
+			panic("Failed to create sentry client")
+		}
+		sh.CheckAndFire(zap.ErrorLevel, "my error message", "mykey1", "myvalue1")
+		sh.CheckAndFire(zap.ErrorLevel, "my error message", "mykey1", "myvalue1")
+		p := <-ch
+
+		assert.Equal(t, p.Message, "my error message")
+		assert.Equal(t, map[string]interface{}{"mykey1": "myvalue1"}, p.Extra)
+	})
+}
+
+func capturePacket(f func(sh *Hook), options ...Option) (*Hook, *raven.Packet) {
+	l, ps := capturePackets(f, options...)
+	if len(ps) != 1 {
+		panic("Expected to capture a packet, but didn't")
+	}
+	return l, ps[0]
+}
+
+func capturePackets(f func(sh *Hook), options ...Option) (*Hook, []*raven.Packet) {
+	sh, err := New("", options...)
+	if err != nil {
+		panic("Failed to create the logger")
+	}
+
+	c := &MemCapturer{}
+	sh.Capturer = c
+
+	f(sh)
+
+	return sh, c.Packets
+}
+
+func withTestSentry(f func(string, <-chan *raven.Packet)) {
+	ch := make(chan *raven.Packet)
+	h := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+
+		contentType := req.Header.Get("Content-Type")
+		var bodyReader io.Reader = req.Body
+		// underlying client will compress and encode payload above certain size
+		if contentType == "application/octet-stream" {
+			bodyReader = base64.NewDecoder(base64.StdEncoding, bodyReader)
+			bodyReader, _ = zlib.NewReader(bodyReader)
+		}
+
+		d := json.NewDecoder(bodyReader)
+		p := &raven.Packet{}
+		err := d.Decode(p)
+		if err != nil {
+			ch <- nil
+			panic(err.Error())
+		}
+		ch <- p
+	})
+	s := httptest.NewServer(h)
+	defer s.Close()
+
+	fragments := strings.SplitN(s.URL, "://", 2)
+	dsn := fmt.Sprintf(
+		"%s://public:secret@%s/sentry/project-id",
+		fragments[0],
+		fragments[1],
+	)
+
+	f(dsn, ch)
+}

--- a/ulog/sentry/sentry_test.go
+++ b/ulog/sentry/sentry_test.go
@@ -147,10 +147,8 @@ func TestPacketSending(t *testing.T) {
 	withTestSentry(func(dsn string, ch <-chan *raven.Packet) {
 		sh, err := New(dsn)
 		defer sh.Close()
+		assert.NoError(t, err)
 
-		if err != nil {
-			panic("Failed to create sentry client")
-		}
 		sh.CheckAndFire(zap.ErrorLevel, "my error message", "mykey1", "myvalue1")
 		sh.CheckAndFire(zap.ErrorLevel, "my error message", "mykey1", "myvalue1")
 		p := <-ch

--- a/ulog/sentry/sentry_test.go
+++ b/ulog/sentry/sentry_test.go
@@ -66,7 +66,7 @@ func TestExtra(t *testing.T) {
 	s, err := New("", Fields(f))
 	s.CheckAndFire(zap.ErrorLevel, "error log", "foo", "bar")
 	assert.NoError(t, err)
-	assert.Equal(t, s.fields, f)
+	assert.Equal(t, f, s.Fields())
 }
 
 func TestWith(t *testing.T) {
@@ -76,7 +76,24 @@ func TestWith(t *testing.T) {
 	assert.NoError(t, err)
 	expected := map[string]interface{}{"someInt": 123, "someFloat": float64(10)}
 	sh.AppendFields("someFloat", float64(10))
-	assert.Equal(t, expected, sh.fields)
+	assert.Equal(t, expected, sh.Fields())
+}
+
+func TestCopy(t *testing.T) {
+	sh, err := New("", Fields(map[string]interface{}{
+		"someInt": 123,
+	}))
+	assert.NoError(t, err)
+	shCopy := sh.Copy()
+	for k, v := range sh.Fields() {
+		assert.Equal(t, v, shCopy.Fields()[k])
+	}
+	assert.Equal(t, sh.Capturer, shCopy.Capturer)
+	assert.Equal(t, sh.minLevel, shCopy.minLevel)
+	assert.Equal(t, sh.traceEnabled, shCopy.traceEnabled)
+	assert.Equal(t, sh.traceSkipFrames, shCopy.traceSkipFrames)
+	assert.Equal(t, sh.traceContextLines, shCopy.traceContextLines)
+	assert.Equal(t, sh.traceAppPrefixes, shCopy.traceAppPrefixes)
 }
 
 func TestWithTraceDisabled(t *testing.T) {


### PR DESCRIPTION
Adds sentry integration for `ulog`. 

Can be configured out-of-the-box with defaults by just providing a `logging.sentry.dsn` in config, or for those wanting more control there is a way for that too.