### PR TITLE
Stop running tests twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor \
 TEST_TIMEOUT := "-timeout=3s"
 
 .PHONY: test
-test: examples
-	$(ECHO_V)go test $(RACE) $(TEST_TIMEOUT) $(PKGS)
-	$(ECHO_V)$(MAKE) $(COV_REPORT)
+test: examples $(COV_REPORT)
 
 TEST_IGNORES = vendor .git
 COVER_IGNORES = $(TEST_IGNORES) examples testutils


### PR DESCRIPTION
COV_REPORT is already the target that runs the tests. Prior to this
`make test` was running the tests with `go test` and then again for
coverage.