### PR TITLE
Benchmarks for context conversion

### DIFF
--- a/internal/fxcontext/context_benchmark_test.go
+++ b/internal/fxcontext/context_benchmark_test.go
@@ -1,0 +1,78 @@
+package fxcontext
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/service"
+	"go.uber.org/fx/ulog"
+)
+
+func withContext(t *testing.B, f func(fxctx fx.Context)) {
+	f(New(context.Background(), service.NullHost()))
+}
+
+func BenchmarkContext_StructWrapper(b *testing.B) {
+	withContext(b, func(fxctx fx.Context) {
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				fxCtx := typeConversion(fxctx)
+				fxCtx.Logger()
+			}
+		})
+	})
+}
+
+func BenchmarkContext_StructWrapperWithValue(b *testing.B) {
+	withContext(b, func(fxctx fx.Context) {
+		ctx := context.WithValue(fxctx, _contextLogger, ulog.Logger())
+
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				fxCtx := typeConversion(ctx)
+				fxCtx.Logger()
+			}
+		})
+	})
+}
+
+func BenchmarkContext_WithTypeAssertion(b *testing.B) {
+	withContext(b, func(fxctx fx.Context) {
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				fxCtx := typeUpgrade(fxctx)
+				fxCtx.Logger()
+			}
+		})
+	})
+}
+
+func BenchmarkContext_WithTypeAssertionWithValue(b *testing.B) {
+	withContext(b, func(fxctx fx.Context) {
+		ctx := context.WithValue(fxctx, _contextLogger, ulog.Logger())
+
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				fxCtx := typeUpgrade(ctx)
+				fxCtx.Logger()
+			}
+		})
+	})
+}
+
+func typeConversion(ctx context.Context) fx.Context {
+	return &Context{ctx}
+}
+
+func typeUpgrade(ctx context.Context) fx.Context {
+	fxctx, ok := ctx.(fx.Context)
+	if ok {
+		return fxctx
+	}
+	return &Context{ctx}
+}

--- a/internal/fxcontext/context_benchmark_test.go
+++ b/internal/fxcontext/context_benchmark_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fxcontext
 
 import (


### PR DESCRIPTION
Type conversion benchmarks for wrapping context.Context with fx.Context struct vs using Upgrade/Convert function with type assertion.

Looks like with type assertion when no WithValue is called, saves us 1 alloc and ~7 ns/op.  When WithValue is called, type assertion is 8 ns/op expensive. 

```
bash-3.2$ go test -bench=. -benchmem
BenchmarkContext_StructWrapper-8                	30000000	        55.3 ns/op	      32 B/op	       3 allocs/op
BenchmarkContext_StructWrapperWithValue-8       	30000000	        43.5 ns/op	      32 B/op	       3 allocs/op
BenchmarkContext_WithTypeAssertion-8            	30000000	        47.8 ns/op	      16 B/op	       2 allocs/op
BenchmarkContext_WithTypeAssertionWithValue-8   	20000000	        52.8 ns/op	      32 B/op	       3 allocs/op
```