### PR TITLE
 Followup nit fixes on fx.Context

### DIFF
--- a/internal/fxcontext/context.go
+++ b/internal/fxcontext/context.go
@@ -46,7 +46,9 @@ type Context struct {
 // New always returns Context for use in the service
 func New(ctx gcontext.Context, host service.Host) fx.Context {
 	if host != nil {
-		ctx = gcontext.WithValue(ctx, _fxContextStore, store{host.Logger()})
+		ctx = gcontext.WithValue(ctx, _fxContextStore, store{
+			log: host.Logger(),
+		})
 	}
 	return &Context{
 		Context: ctx,

--- a/internal/fxcontext/context.go
+++ b/internal/fxcontext/context.go
@@ -30,7 +30,11 @@ import (
 
 type contextKey int
 
-const _contextLogger contextKey = iota
+type store struct {
+	log ulog.Log
+}
+
+const _fxContextStore contextKey = iota
 
 var _ fx.Context = &Context{}
 
@@ -42,23 +46,22 @@ type Context struct {
 // New always returns Context for use in the service
 func New(ctx gcontext.Context, host service.Host) fx.Context {
 	if host != nil {
-		return &Context{
-			gcontext.WithValue(ctx, _contextLogger, host.Logger()),
-		}
+		ctx = gcontext.WithValue(ctx, _fxContextStore, store{host.Logger()})
 	}
 	return &Context{
 		Context: ctx,
 	}
 }
 
-// Logger returns context based logger
+// Logger returns context based logger. If logger is absent from the context,
+// the function updates the context with a new context based logger
 func (c *Context) Logger() ulog.Log {
-	return c.getLogger()
-}
-
-func (c *Context) getLogger() ulog.Log {
-	if c.Context.Value(_contextLogger) == nil {
-		c.Context = gcontext.WithValue(c.Context, _contextLogger, ulog.Logger())
+	fxctxStore := c.Context.Value(_fxContextStore)
+	if fxctxStore == nil {
+		fxctxStore = store{
+			log: ulog.Logger(),
+		}
+		c.Context = gcontext.WithValue(c.Context, _fxContextStore, fxctxStore)
 	}
-	return c.Context.Value(_contextLogger).(ulog.Log)
+	return fxctxStore.(store).log
 }

--- a/internal/fxcontext/context.go
+++ b/internal/fxcontext/context.go
@@ -58,6 +58,10 @@ func New(ctx gcontext.Context, host service.Host) fx.Context {
 // Logger returns context based logger. If logger is absent from the context,
 // the function updates the context with a new context based logger
 func (c *Context) Logger() ulog.Log {
+	return c.getStore().log
+}
+
+func (c *Context) getStore() store {
 	fxctxStore := c.Context.Value(_fxContextStore)
 	if fxctxStore == nil {
 		fxctxStore = store{
@@ -65,5 +69,5 @@ func (c *Context) Logger() ulog.Log {
 		}
 		c.Context = gcontext.WithValue(c.Context, _fxContextStore, fxctxStore)
 	}
-	return fxctxStore.(store).log
+	return fxctxStore.(store)
 }

--- a/internal/fxcontext/context_benchmark_test.go
+++ b/internal/fxcontext/context_benchmark_test.go
@@ -33,7 +33,7 @@ func withContext(t *testing.B, f func(fxctx fx.Context)) {
 	f(New(context.Background(), service.NullHost()))
 }
 
-func BenchmarkContext_StructWrapper(b *testing.B) {
+func BenchmarkContext_TypeConversion(b *testing.B) {
 	withContext(b, func(fxctx fx.Context) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
@@ -45,9 +45,9 @@ func BenchmarkContext_StructWrapper(b *testing.B) {
 	})
 }
 
-func BenchmarkContext_StructWrapperWithValue(b *testing.B) {
+func BenchmarkContext_TypeConversionWithValue(b *testing.B) {
 	withContext(b, func(fxctx fx.Context) {
-		ctx := context.WithValue(fxctx, _contextLogger, ulog.Logger())
+		ctx := context.WithValue(fxctx, _fxContextStore, store{ulog.Logger()})
 
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
@@ -64,7 +64,7 @@ func BenchmarkContext_WithTypeAssertion(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				fxCtx := typeUpgrade(fxctx)
+				fxCtx := typeAssertion(fxctx)
 				fxCtx.Logger()
 			}
 		})
@@ -73,12 +73,12 @@ func BenchmarkContext_WithTypeAssertion(b *testing.B) {
 
 func BenchmarkContext_WithTypeAssertionWithValue(b *testing.B) {
 	withContext(b, func(fxctx fx.Context) {
-		ctx := context.WithValue(fxctx, _contextLogger, ulog.Logger())
+		ctx := context.WithValue(fxctx, _fxContextStore, store{ulog.Logger()})
 
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				fxCtx := typeUpgrade(ctx)
+				fxCtx := typeAssertion(ctx)
 				fxCtx.Logger()
 			}
 		})
@@ -89,7 +89,7 @@ func typeConversion(ctx context.Context) fx.Context {
 	return &Context{ctx}
 }
 
-func typeUpgrade(ctx context.Context) fx.Context {
+func typeAssertion(ctx context.Context) fx.Context {
 	fxctx, ok := ctx.(fx.Context)
 	if ok {
 		return fxctx

--- a/internal/fxcontext/context_test.go
+++ b/internal/fxcontext/context_test.go
@@ -24,17 +24,17 @@ import (
 	gcontext "context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"go.uber.org/fx/service"
 	"go.uber.org/fx/ulog"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestContext_HostAccess(t *testing.T) {
 	ctx := New(gcontext.Background(), service.NullHost())
 	assert.NotNil(t, ctx)
 	assert.NotNil(t, ctx.Logger())
-	assert.NotNil(t, ctx.Value(_contextLogger))
+	assert.NotNil(t, ctx.Value(_fxContextStore))
 }
 
 func TestWithContext(t *testing.T) {

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -21,18 +21,17 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"golang.org/x/net/context"
-
 	"go.uber.org/fx"
-
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx/internal/fxcontext"
 	"go.uber.org/fx/service"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (


### PR DESCRIPTION
Addressed feedback on #131 

Updated benchmark after addressing feedback-
```
bash-3.2$ go test -bench=. -benchmem
BenchmarkContext_TypeConversion-8               	50000000	        36.9 ns/op	      24 B/op	       2 allocs/op
BenchmarkContext_TypeConversionWithValue-8      	50000000	        34.5 ns/op	      24 B/op	       2 allocs/op
BenchmarkContext_WithTypeAssertion-8            	50000000	        30.8 ns/op	       8 B/op	       1 allocs/op
BenchmarkContext_WithTypeAssertionWithValue-8   	50000000	        39.0 ns/op	      24 B/op	       2 allocs/op
PASS
```