### PR TITLE
thriftrw: Update fx plugin

### DIFF
--- a/examples/keyvalue/gen.go
+++ b/examples/keyvalue/gen.go
@@ -20,5 +20,4 @@
 
 package keyvalue
 
-//go:generate thriftrw --plugin=yarpc kv.thrift
 //go:generate thriftrw --plugin=fx kv.thrift

--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -37,9 +37,9 @@ type YarpcHandler struct {
 	items map[string]string
 }
 
-func NewYarpcThriftHandler(svc service.Host) ([]transport.Registrant, error) {
+func NewYarpcThriftHandler(service.Host) ([]transport.Registrant, error) {
 	handler := &YarpcHandler{items: map[string]string{}}
-	return kvs.New(svc, handler), nil
+	return kvs.New(handler), nil
 }
 
 func (h *YarpcHandler) GetValue(ctx fx.Context, req yarpc.ReqMeta, key *string) (string, yarpc.ResMeta, error) {

--- a/modules/rpc/handler.go
+++ b/modules/rpc/handler.go
@@ -47,7 +47,7 @@ func (f UnaryHandlerFunc) Handle(ctx fx.Context, reqMeta yarpc.ReqMeta, body wir
 
 // WrapUnary wraps the unary handler and returns a thrift.UnaryHandlerFunc for yarpc calls
 // TODO(anup): GFM-255 Remove host parameter once updated yarpc plugin is imported in the repo
-func WrapUnary(host service.Host, h UnaryHandlerFunc) thrift.UnaryHandlerFunc {
+func WrapUnary(h UnaryHandlerFunc) thrift.UnaryHandlerFunc {
 	return func(ctx context.Context, reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Response, error) {
 		fxctx := &fxcontext.Context{
 			Context: ctx,
@@ -71,7 +71,7 @@ func (f OnewayHandlerFunc) HandleOneway(ctx fx.Context, reqMeta yarpc.ReqMeta, b
 
 // WrapOneway wraps the oneway handler and returns a thrift.OnewayHandlerFunc for yarpc calls
 // TODO(anup): GFM-255 Remove host parameter once updated yarpc plugin is imported in the repo
-func WrapOneway(host service.Host, h OnewayHandlerFunc) thrift.OnewayHandlerFunc {
+func WrapOneway(h OnewayHandlerFunc) thrift.OnewayHandlerFunc {
 	return func(ctx context.Context, reqMeta yarpc.ReqMeta, body wire.Value) error {
 		fxctx := &fxcontext.Context{
 			Context: ctx,

--- a/modules/rpc/handler_test.go
+++ b/modules/rpc/handler_test.go
@@ -67,7 +67,7 @@ func OnewayFakeHandlerFuncWithError(ctx fx.Context, meta yarpc.ReqMeta, val wire
 }
 
 func TestWrapUnary(t *testing.T) {
-	handlerFunc := WrapUnary(service.NullHost(), UnaryFakeHandlerFunc)
+	handlerFunc := WrapUnary(UnaryFakeHandlerFunc)
 	assert.NotNil(t, handlerFunc)
 	resp, err := handlerFunc.Handle(context.Background(), nil, wire.Value{})
 	assert.NoError(t, err)
@@ -75,14 +75,14 @@ func TestWrapUnary(t *testing.T) {
 }
 
 func TestWrapOneway(t *testing.T) {
-	handlerFunc := WrapOneway(service.NullHost(), OnewayFakeHandlerFunc)
+	handlerFunc := WrapOneway(OnewayFakeHandlerFunc)
 	assert.NotNil(t, handlerFunc)
 	err := handlerFunc.HandleOneway(context.Background(), nil, wire.Value{})
 	assert.NoError(t, err)
 }
 
 func TestWrapOneway_error(t *testing.T) {
-	handlerFunc := WrapOneway(service.NullHost(), OnewayFakeHandlerFuncWithError)
+	handlerFunc := WrapOneway(OnewayFakeHandlerFuncWithError)
 	assert.NotNil(t, handlerFunc)
 	err := handlerFunc.HandleOneway(context.Background(), nil, wire.Value{})
 	assert.Error(t, err)


### PR DESCRIPTION
This updates the ThriftRW plugin used by UberFx to match the most recent
YARPC dev version of the plugin but using UberFx values as defaults for the
command line flags.

This plugin can be completely removed when the next version of YARPC Go is
released.

With this new version, `WrapUnary` and `WrapOneway` no longer accept
`service.Host` as an argument.