### PR TITLE
make: Use local UberFx ThriftRW plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,21 +123,22 @@ clean:
 	$(ECHO_V)rm -rf examples/keyvalue/kv/ .bin
 
 .PHONY: examples
-examples: .bin/thriftrw .bin/thriftrw-plugin-yarpc
-	@$(call label,Installing thriftrw and YARPC plugins)
-	@echo
-	$(ECHO_V)which thriftrw-plugin-fx >/dev/null || go install ./modules/rpc/thriftrw-plugin-fx
+examples: .bin/thriftrw .bin/thriftrw-plugin-yarpc .bin/thriftrw-plugin-fx
 	@$(call label,Generating example RPC bindings)
 	@echo
 	$(ECHO_V)PATH=$(shell pwd)/.bin:$$PATH $(MAKE) -C examples/keyvalue kv/types.go ECHO_V=$(ECHO_V)
 
-.bin/thriftrw: vendor
+.bin/thriftrw: vendor ./vendor/go.uber.org/thriftrw/*.go
 	$(ECHO_V)mkdir -p .bin
 	$(ECHO_V)./.build/build_vendored.sh .bin go.uber.org/thriftrw
 
-.bin/thriftrw-plugin-yarpc: vendor
+.bin/thriftrw-plugin-yarpc: vendor ./vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/*.go
 	$(ECHO_V)mkdir -p .bin
 	$(ECHO_V)./.build/build_vendored.sh .bin go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
+
+.bin/thriftrw-plugin-fx: vendor ./modules/rpc/thriftrw-plugin-fx/*.go
+	$(ECHO_V)mkdir -p .bin
+	$(ECHO_V)go build -o .bin/thriftrw-plugin-fx ./modules/rpc/thriftrw-plugin-fx
 
 .PHONY: vendor
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,20 @@ examples: .bin/thriftrw .bin/thriftrw-plugin-yarpc .bin/thriftrw-plugin-fx
 	$(ECHO_V)PATH=$(shell pwd)/.bin:$$PATH $(MAKE) -C examples/keyvalue kv/types.go ECHO_V=$(ECHO_V)
 
 .bin/thriftrw: vendor ./vendor/go.uber.org/thriftrw/*.go
+	@$(call label,Building ThriftRW)
+	@echo
 	$(ECHO_V)mkdir -p .bin
 	$(ECHO_V)./.build/build_vendored.sh .bin go.uber.org/thriftrw
 
 .bin/thriftrw-plugin-yarpc: vendor ./vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/*.go
+	@$(call label,Building ThriftRW YARPC plugin)
+	@echo
 	$(ECHO_V)mkdir -p .bin
 	$(ECHO_V)./.build/build_vendored.sh .bin go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
 
 .bin/thriftrw-plugin-fx: vendor ./modules/rpc/thriftrw-plugin-fx/*.go
+	@$(call label,Building ThriftRW UberFx plugin)
+	@echo
 	$(ECHO_V)mkdir -p .bin
 	$(ECHO_V)go build -o .bin/thriftrw-plugin-fx ./modules/rpc/thriftrw-plugin-fx
 


### PR DESCRIPTION
This changes `make examples` to use a locally built version of the UberFx
ThriftRW plugin rather than installing it globally.