### PR TITLE
Add a root node string

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -126,6 +126,14 @@ fmt.Println(foo)
 // Output: hello
 ```
 
+To get an access to the root element use `config.Root`:
+```go
+root := provider.Get(config.Root).AsString()
+fmt.Println(root)
+// Output: map[one:map[two:hello]]
+```
+
+
 * Populate a struct (`PopulateStruct(&myStruct)`)
 
 The `As*` method has two variants: `TryAs*` and `As*`. The former is a

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -215,7 +215,7 @@ func TestNestedStructs(t *testing.T) {
 
 	str := &root{}
 
-	v := provider.Get("")
+	v := provider.Get(Root)
 
 	assert.True(t, v.HasValue())
 	v.PopulateStruct(str)
@@ -238,7 +238,7 @@ func TestArrayOfStructs(t *testing.T) {
 
 	target := &arrayOfStructs{}
 
-	v := provider.Get("")
+	v := provider.Get(Root)
 
 	assert.True(t, v.HasValue())
 	assert.NoError(t, v.PopulateStruct(target))
@@ -253,7 +253,7 @@ func TestDefault(t *testing.T) {
 		NewEnvProvider(defaultEnvPrefix, mapEnvironmentProvider{values: env}),
 	)
 	target := &nested{}
-	v := provider.Get("")
+	v := provider.Get(Root)
 	assert.True(t, v.HasValue())
 	assert.NoError(t, v.PopulateStruct(target))
 	assert.Equal(t, "default_name", target.Name)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,6 +111,16 @@ func TestGlobalConfig(t *testing.T) {
 	assert.Equal(t, "test", cfg.Name())
 }
 
+func TestRootNodeConfig(t *testing.T) {
+	txt := []byte(`
+one:
+  two: hello
+`)
+
+	cfg := NewYAMLProviderFromBytes(txt).Get(Root).AsString()
+	assert.Equal(t, "map[one:map[two:hello]]", cfg)
+}
+
 func TestDirectAccess(t *testing.T) {
 	provider := NewProviderGroup(
 		"test",

--- a/config/doc.go
+++ b/config/doc.go
@@ -146,6 +146,12 @@
 //   fmt.Println(foo)
 //   // Output: hello
 //
+// To get an access to the root element use config.Root:
+//
+//   root := provider.Get(config.Root).AsString()
+//   fmt.Println(root)
+//   // Output: map[one:map[two:hello]]
+//
 // • Populate a struct (PopulateStruct(&myStruct))
 //
 // The As* method has two variants: TryAs* and As*. The former is a

--- a/config/provider.go
+++ b/config/provider.go
@@ -25,6 +25,9 @@ import "fmt"
 // ConfigurationChangeCallback is called for updates of configuration data
 type ConfigurationChangeCallback func(key string, provider string, configdata interface{})
 
+// Root marks the root node in a Provider
+const Root = ""
+
 // A Provider provides a unified interface to accessing
 // configuration systems.
 type Provider interface {

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -32,8 +32,8 @@ func TestProviderGroup(t *testing.T) {
 	assert.Equal(t, "test-group", pg.Name())
 	assert.Equal(t, "test", pg.Get("id").AsString())
 	// TODO this should not require a cast GFM-74
-	assert.Empty(t, pg.(providerGroup).RegisterChangeCallback("", nil))
-	assert.Nil(t, pg.(providerGroup).UnregisterChangeCallback(""))
+	assert.Empty(t, pg.(providerGroup).RegisterChangeCallback(Root, nil))
+	assert.Nil(t, pg.(providerGroup).UnregisterChangeCallback(Root))
 }
 
 func TestProviderGroupScope(t *testing.T) {

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -61,7 +61,7 @@ func TestYamlStructRoot(t *testing.T) {
 
 	cs := &configStruct{}
 
-	assert.NoError(t, provider.Get("").PopulateStruct(cs))
+	assert.NoError(t, provider.Get(Root).PopulateStruct(cs))
 
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "owner@service.com", cs.Owner)
@@ -95,8 +95,8 @@ func TestNewYamlProviderFromReader(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(yamlConfig1))
 	provider := NewYamlProviderFromReader(ioutil.NopCloser(buff))
 	cs := &configStruct{}
-	assert.NoError(t, provider.Get("").PopulateStruct(cs))
-	assert.Equal(t, "yaml", provider.Scope("").Name())
+	assert.NoError(t, provider.Get(Root).PopulateStruct(cs))
+	assert.Equal(t, "yaml", provider.Scope(Root).Name())
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "owner@service.com", cs.Owner)
 }
@@ -234,7 +234,7 @@ func TestParsingUnparsableDuration(t *testing.T) {
 func TestTypeOfTypes(t *testing.T) {
 	withYamlBytes(t, typeStructYaml, func(provider Provider) {
 		tts := typeStructStruct{}
-		err := provider.Get("").PopulateStruct(&tts)
+		err := provider.Get(Root).PopulateStruct(&tts)
 		assert.NoError(t, err)
 		assert.Equal(t, userDefinedTypeInt(123), *tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), *tts.TypeStruct.TestUInt)

--- a/service/service.go
+++ b/service/service.go
@@ -119,7 +119,6 @@ func New(options ...Option) (Owner, error) {
 	svc.setupAuthClient(svc.configProvider)
 
 	// load standard config
-	// TODO(glib): `.Get("")` is a confusing interface for getting the root config node
 	if err := svc.setupStandardConfig(svc.Config()); err != nil {
 		return nil, err
 	}

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -48,7 +48,7 @@ func (svc *serviceCore) setupLogging(cfg config.Provider) {
 }
 
 func (svc *serviceCore) setupStandardConfig(cfg config.Provider) error {
-	if err := cfg.Get("").PopulateStruct(&svc.standardConfig); err != nil {
+	if err := cfg.Get(config.Root).PopulateStruct(&svc.standardConfig); err != nil {
 		return errors.Wrap(err, "unable to load standard configuration")
 	}
 


### PR DESCRIPTION
Remove a confusing interface for getting the root node.