### PR TITLE
Rename RawLogger method to Typed logger

### DIFF
--- a/ulog/builder_test.go
+++ b/ulog/builder_test.go
@@ -45,7 +45,7 @@ func TestConfiguredLogger(t *testing.T) {
 			Verbose:       false,
 		}
 		log := builder.WithConfiguration(cfg).Build()
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		assert.True(t, zapLogger.Check(zap.DebugLevel, "").OK())
 	})
 }
@@ -65,7 +65,7 @@ func TestConfiguredLoggerWithTextFormatter(t *testing.T) {
 			},
 		}
 		log := Builder().WithConfiguration(cfg).Build()
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		assert.True(t, zapLogger.Check(zap.DebugLevel, "").OK())
 	})
 }
@@ -77,7 +77,7 @@ func TestConfiguredLoggerWithTextFormatter_NonDev(t *testing.T) {
 			Level:         "debug",
 			TextFormatter: &txt,
 		}).Build()
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		assert.True(t, zapLogger.Check(zap.DebugLevel, "").OK())
 	})
 }
@@ -96,7 +96,7 @@ func TestConfiguredLoggerWithStdout(t *testing.T) {
 			},
 		}
 		log := Builder().WithConfiguration(cfg).Build()
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		assert.True(t, zapLogger.Check(zap.DebugLevel, "").OK())
 	})
 }
@@ -133,7 +133,7 @@ func TestDefaultPackageLogger(t *testing.T) {
 	withLogger(t, func(builder *LogBuilder, tmpDir string, logFile string) {
 		defer testutils.EnvOverride(t, config.EnvironmentKey(), "development")()
 		log := New()
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		assert.True(t, zapLogger.Check(zap.DebugLevel, "").OK())
 	})
 }
@@ -159,7 +159,7 @@ func testSentry(t *testing.T, dsn string, isValid bool) {
 		}
 		logBuilder := builder.WithConfiguration(cfg)
 		log := logBuilder.Build()
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		assert.True(t, zapLogger.Check(zap.DebugLevel, "").OK())
 		if isValid {
 			assert.NotNil(t, logBuilder.sentryHook)

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -50,8 +50,8 @@ type Log interface {
 	// Check returns a zap.CheckedMessage if logging a message at the specified level is enabled.
 	Check(level zap.Level, message string) *zap.CheckedMessage
 
-	// RawLogger returns underlying logger implementation (zap.Logger) to get around the ulog.Log interface
-	RawLogger() zap.Logger
+	// Typed returns underlying logger implementation (zap.Logger) to get around the ulog.Log interface
+	Typed() zap.Logger
 
 	// Log at the provided zap.Level with message, and a sequence of parameters as key value pairs
 	Log(level zap.Level, message string, keyVals ...interface{})
@@ -94,8 +94,8 @@ func Logger() Log {
 	}
 }
 
-// RawLogger returns underneath zap implementation for use
-func (l *baseLogger) RawLogger() zap.Logger {
+// Typed returns underneath zap implementation for use
+func (l *baseLogger) Typed() zap.Logger {
 	return l.log
 }
 

--- a/ulog/log_benchmark_test.go
+++ b/ulog/log_benchmark_test.go
@@ -93,7 +93,7 @@ func BenchmarkUlogWithFieldsBaseLoggerStruct(b *testing.B) {
 
 func BenchmarkUlogWithFieldsZapLogger(b *testing.B) {
 	withDiscardedLogger(b, func(log Log) {
-		zapLogger := log.RawLogger()
+		zapLogger := log.Typed()
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -121,14 +121,14 @@ func TestFieldConversion(t *testing.T) {
 	assert.Equal(t, zap.Error(err), base.fieldsConversion("error", err)[0])
 }
 
-func TestRawLogger(t *testing.T) {
+func TestTyped(t *testing.T) {
 	log := New()
-	assert.NotNil(t, log.RawLogger())
+	assert.NotNil(t, log.Typed())
 }
 
 func TestLogger(t *testing.T) {
 	log := Logger()
-	assert.NotNil(t, log.RawLogger())
+	assert.NotNil(t, log.Typed())
 }
 
 func TestSentryHook(t *testing.T) {


### PR DESCRIPTION
`Typed()` conforms with returning typed instance of the logger instead of wrapper interface.