### PR TITLE
Auth interface with Logger and SetAttribute methods

### DIFF
--- a/auth/auth_failure_client.go
+++ b/auth/auth_failure_client.go
@@ -44,6 +44,6 @@ func (*failureClient) Authorize(ctx context.Context) error {
 	return errors.New(ErrAuthorization)
 }
 
-func (*failureClient) SetAttribute(ctx context.Context, key string, value string) context.Context {
+func (*failureClient) SetAttribute(ctx context.Context, key, value string) context.Context {
 	return ctx
 }

--- a/auth/auth_failure_client.go
+++ b/auth/auth_failure_client.go
@@ -43,3 +43,7 @@ func (*failureClient) Authenticate(ctx context.Context) (context.Context, error)
 func (*failureClient) Authorize(ctx context.Context) error {
 	return errors.New(ErrAuthorization)
 }
+
+func (*failureClient) SetAttribute(ctx context.Context, key string, value string) context.Context {
+	return ctx
+}

--- a/auth/auth_stub.go
+++ b/auth/auth_stub.go
@@ -42,3 +42,7 @@ func (*noop) Authenticate(ctx context.Context) (context.Context, error) {
 func (*noop) Authorize(ctx context.Context) error {
 	return nil
 }
+
+func (*noop) SetAttribute(ctx context.Context, key string, value string) context.Context {
+	return ctx
+}

--- a/auth/auth_stub.go
+++ b/auth/auth_stub.go
@@ -43,6 +43,6 @@ func (*noop) Authorize(ctx context.Context) error {
 	return nil
 }
 
-func (*noop) SetAttribute(ctx context.Context, key string, value string) context.Context {
+func (*noop) SetAttribute(ctx context.Context, key, value string) context.Context {
 	return ctx
 }

--- a/auth/localauth.go
+++ b/auth/localauth.go
@@ -55,6 +55,6 @@ func (d *defaultClient) Authorize(ctx context.Context) error {
 	return d.authClient.Authorize(ctx)
 }
 
-func (d *defaultClient) SetAttribute(ctx context.Context, key string, value string) context.Context {
+func (d *defaultClient) SetAttribute(ctx context.Context, key, value string) context.Context {
 	return d.authClient.SetAttribute(ctx, key, value)
 }

--- a/auth/localauth.go
+++ b/auth/localauth.go
@@ -54,3 +54,7 @@ func (d *defaultClient) Authenticate(ctx context.Context) (context.Context, erro
 func (d *defaultClient) Authorize(ctx context.Context) error {
 	return d.authClient.Authorize(ctx)
 }
+
+func (d *defaultClient) SetAttribute(ctx context.Context, key string, value string) context.Context {
+	return d.authClient.SetAttribute(ctx, key, value)
+}

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -92,4 +92,7 @@ type Client interface {
 
 	// Authorize is called by the server to authorize the request
 	Authorize(ctx context.Context) error
+
+	// SetAttribute sets attribute on the provided context for authorization
+	SetAttribute(ctx context.Context, key string, value string) context.Context
 }

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -94,5 +94,5 @@ type Client interface {
 	Authorize(ctx context.Context) error
 
 	// SetAttribute sets attribute on the provided context for authorization
-	SetAttribute(ctx context.Context, key string, value string) context.Context
+	SetAttribute(ctx context.Context, key, value string) context.Context
 }

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"go.uber.org/fx/config"
+	"go.uber.org/fx/ulog"
 )
 
 var (
@@ -43,6 +44,7 @@ var (
 // CreateAuthInfo interface provides necessary data
 type CreateAuthInfo interface {
 	Config() config.Provider
+	Logger() ulog.Log
 }
 
 // RegisterFunc is used during service init time to register the Auth client

--- a/auth/uauth_test.go
+++ b/auth/uauth_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"go.uber.org/fx/config"
+	"go.uber.org/fx/ulog"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,4 +79,8 @@ type fakeAuthInfo struct{}
 
 func (fakeAuthInfo) Config() config.Provider {
 	return nil
+}
+
+func (fakeAuthInfo) Logger() ulog.Log {
+	return ulog.NoopLogger
 }

--- a/auth/uauth_test.go
+++ b/auth/uauth_test.go
@@ -46,6 +46,8 @@ func TestUauth_Stub(t *testing.T) {
 	ctx, err := authClient.Authenticate(context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, ctx)
+	ctx = authClient.SetAttribute(ctx, "key", "value")
+	assert.NotNil(t, ctx)
 }
 
 func TestUauth_Register(t *testing.T) {
@@ -57,6 +59,8 @@ func TestUauth_Register(t *testing.T) {
 		assert.Error(t, err)
 		ctx, err := authClient.Authenticate(context.Background())
 		require.Error(t, err)
+		assert.NotNil(t, ctx)
+		ctx = authClient.SetAttribute(ctx, "key", "value")
 		assert.NotNil(t, ctx)
 	})
 }


### PR DESCRIPTION
Updated CreateAuthInfo with Logger, for logging during Auth.Client creation.
SetAttribute method to set necessary baggage from service (service name, UUID, etc) during authentication.