### PR TITLE
Prepare unstuttering of configuration change callback

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -75,7 +75,7 @@ func (p envConfigProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, p)
 }
 
-func (p envConfigProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (p envConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Environments don't receive callback events
 	return nil
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -22,8 +22,12 @@ package config
 
 import "fmt"
 
+// ChangeCallback is a temporary step to un-stutter config.ConfigurationChangeCallback
+// TODO(glib): remove this after direct usage of ConfigurationChangeCallback has been removed
+type ChangeCallback ConfigurationChangeCallback
+
 // ConfigurationChangeCallback is called for updates of configuration data
-type ConfigurationChangeCallback func(key string, provider string, configdata interface{})
+type ConfigurationChangeCallback func(key string, provider string, configData interface{})
 
 // Root marks the root node in a Provider
 const Root = ""
@@ -39,7 +43,7 @@ type Provider interface {
 
 	// A RegisterChangeCallback provides callback registration for config providers.
 	// These callbacks are noop if a dynamic provider is not configured for the service.
-	RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error
+	RegisterChangeCallback(key string, callback ChangeCallback) error
 	UnregisterChangeCallback(token string) error
 }
 

--- a/config/provider_group.go
+++ b/config/provider_group.go
@@ -65,7 +65,7 @@ func (p providerGroup) Name() string {
 	return p.name
 }
 
-func (p providerGroup) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (p providerGroup) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	for _, provider := range p.providers {
 		if err := provider.RegisterChangeCallback(key, callback); err != nil {
 			return err

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -84,7 +84,7 @@ func (s *mockDynamicProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, s)
 }
 
-func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	return fmt.Errorf("registration error")
 }
 

--- a/config/static_provider.go
+++ b/config/static_provider.go
@@ -71,7 +71,7 @@ func (s *staticProvider) Scope(prefix string) Provider {
 	return newScopedStaticProvider(s, prefix)
 }
 
-func (s *staticProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (s *staticProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Static provider don't receive callback events
 	return nil
 }

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -141,7 +141,7 @@ func (y yamlConfigProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, y)
 }
 
-func (y yamlConfigProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (y yamlConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Yaml configuration don't receive callback events
 	return nil
 }


### PR DESCRIPTION
One private hooks are fixed, we can drop the old name
and change the alias definition to be the source of truth