### PR TITLE
Log the trace id and span id in http filters

### DIFF
--- a/internal/fxcontext/context.go
+++ b/internal/fxcontext/context.go
@@ -58,15 +58,28 @@ func New(ctx gcontext.Context, host service.Host) fx.Context {
 // Logger returns context based logger. If logger is absent from the context,
 // the function updates the context with a new context based logger
 func (c *Context) Logger() ulog.Log {
-	return c.getStore().log
+	store := c.getStore()
+	if store.log == nil {
+		store.log = ulog.Logger()
+	}
+	return store.log
 }
 
+// WithLogger returns a new context with the input logger
+func (c *Context) WithLogger(logger ulog.Log) *Context {
+	store := c.getStore()
+	store.log = logger
+	ctx := gcontext.WithValue(c, _fxContextStore, store)
+	return &Context{
+		Context: ctx,
+	}
+}
+
+// getStore returns a non-nil store instance
 func (c *Context) getStore() store {
 	fxctxStore := c.Context.Value(_fxContextStore)
 	if fxctxStore == nil {
-		fxctxStore = store{
-			log: ulog.Logger(),
-		}
+		fxctxStore = store{}
 		c.Context = gcontext.WithValue(c.Context, _fxContextStore, fxctxStore)
 	}
 	return fxctxStore.(store)

--- a/internal/fxcontext/context_test.go
+++ b/internal/fxcontext/context_test.go
@@ -24,6 +24,8 @@ import (
 	gcontext "context"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"go.uber.org/fx/service"
 	"go.uber.org/fx/ulog"
 
@@ -48,6 +50,15 @@ func TestWithContext(t *testing.T) {
 	}
 	assert.Equal(t, nil, ctx.Value("key"))
 	assert.Equal(t, "val1", ctx.Value("key1"))
+}
+
+func TestWithLogger(t *testing.T) {
+	ctx := &Context{
+		Context: context.Background(),
+	}
+	assert.Equal(t, ulog.Logger(), ctx.Logger())
+	loggerCtx := ctx.WithLogger(ulog.NoopLogger)
+	assert.Equal(t, ulog.NoopLogger, loggerCtx.Logger())
 }
 
 func TestWithContext_NilHost(t *testing.T) {

--- a/internal/fxcontext/context_test.go
+++ b/internal/fxcontext/context_test.go
@@ -24,8 +24,6 @@ import (
 	gcontext "context"
 	"testing"
 
-	"golang.org/x/net/context"
-
 	"go.uber.org/fx/service"
 	"go.uber.org/fx/ulog"
 
@@ -54,7 +52,7 @@ func TestWithContext(t *testing.T) {
 
 func TestWithLogger(t *testing.T) {
 	ctx := &Context{
-		Context: context.Background(),
+		Context: gcontext.Background(),
 	}
 	assert.Equal(t, ulog.Logger(), ctx.Logger())
 	loggerCtx := ctx.WithLogger(ulog.NoopLogger)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -75,12 +75,13 @@ func tracingServerFilter(host service.Host) FilterFunc {
 
 		jSpanCtx, ok := span.Context().(jaeger.SpanContext)
 		if ok {
-			fxctx.Logger().Info(
-				"Tracing data", "trace id", jSpanCtx.TraceID(), "span id", jSpanCtx.SpanID(),
+			traceLogger := fxctx.Logger().With(
+				"trace id", jSpanCtx.TraceID(), "span id", jSpanCtx.SpanID(),
 			)
+			fxctx = fxctx.WithLogger(traceLogger)
 		}
 		fxctx = &fxcontext.Context{
-			Context: opentracing.ContextWithSpan(ctx, span),
+			Context: opentracing.ContextWithSpan(fxctx, span),
 		}
 		r = r.WithContext(fxctx)
 		next.ServeHTTP(fxctx, w, r)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -73,8 +73,7 @@ func tracingServerFilter(host service.Host) FilterFunc {
 		ext.HTTPUrl.Set(span, r.URL.String())
 		defer span.Finish()
 
-		jSpanCtx, ok := span.Context().(jaeger.SpanContext)
-		if ok {
+		if jSpanCtx, ok := span.Context().(jaeger.SpanContext); ok {
 			traceLogger := fxctx.Logger().With(
 				"trace id", jSpanCtx.TraceID(), "span id", jSpanCtx.SpanID(),
 			)

--- a/service/host_mock.go
+++ b/service/host_mock.go
@@ -30,6 +30,11 @@ import (
 
 // NullHost is to be used in tests
 func NullHost() Host {
+	return NullHostConfigured(ulog.NoopLogger, opentracing.NoopTracer{})
+}
+
+// NullHostConfigured is a noop host with set logger and tracer for tests
+func NullHostConfigured(logger ulog.Log, tracer opentracing.Tracer) Host {
 	return &serviceCore{
 		configProvider: config.NewStaticProvider(nil),
 		standardConfig: serviceConfig{
@@ -38,14 +43,14 @@ func NullHost() Host {
 			ServiceDescription: "does cool stuff",
 		},
 		loggingCore: loggingCore{
-			log: ulog.NoopLogger,
+			log: logger,
 		},
 		metricsCore: metricsCore{
 			metrics:       tally.NoopScope,
 			statsReporter: tally.NullStatsReporter,
 		},
 		tracerCore: tracerCore{
-			tracer: opentracing.NoopTracer{},
+			tracer: tracer,
 		},
 	}
 }


### PR DESCRIPTION
Set trace id and span id as logger fields in the http filter chain.