### PR TITLE
Merge objects

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -181,13 +181,13 @@ Note that any fields you wish to deserialize into must be exported, just like
 Current performance benchmark data:
 
 ```
-BenchmarkYAMLCreateSingleFile-8                       50000     31317 ns/op   10832 B/op     121 allocs/op
-BenchmarkYAMLCreateMultiFile-8                        30000     51650 ns/op   19840 B/op     207 allocs/op
-BenchmarkYAMLSimpleGetLevel1-8                     50000000      26.7 ns/op       0 B/op       0 allocs/op
-BenchmarkYAMLSimpleGetLevel3-8                     50000000      26.4 ns/op       0 B/op       0 allocs/op
-BenchmarkYAMLSimpleGetLevel7-8                     50000000      26.0 ns/op       0 B/op       0 allocs/op
-BenchmarkYAMLPopulateStruct-8                       2000000       860 ns/op     192 B/op      10 allocs/op
-BenchmarkYAMLPopulateStructNested-8                  500000      2615 ns/op     632 B/op      34 allocs/op
-BenchmarkYAMLPopulateStructNestedMultipleFiles-8     500000      3585 ns/op     816 B/op      45 allocs/op
-BenchmarkYAMLPopulateNestedTextUnmarshaler-8         100000     17016 ns/op    3217 B/op     209 allocs/op
+BenchmarkYAMLCreateSingleFile-8                       50000     31269 ns/op   11136 B/op     121 allocs/op
+BenchmarkYAMLCreateMultiFile-8                        30000     52378 ns/op   20064 B/op     205 allocs/op
+BenchmarkYAMLSimpleGetLevel1-8                     50000000      27.1 ns/op       0 B/op       0 allocs/op
+BenchmarkYAMLSimpleGetLevel3-8                     50000000      26.8 ns/op       0 B/op       0 allocs/op
+BenchmarkYAMLSimpleGetLevel7-8                     50000000      26.3 ns/op       0 B/op       0 allocs/op
+BenchmarkYAMLPopulateStruct-8                       2000000       861 ns/op     192 B/op      10 allocs/op
+BenchmarkYAMLPopulateStructNested-8                  500000      2616 ns/op     616 B/op      34 allocs/op
+BenchmarkYAMLPopulateStructNestedMultipleFiles-8     500000      3330 ns/op     744 B/op      42 allocs/op
+BenchmarkYAMLPopulateNestedTextUnmarshaler-8         100000     16775 ns/op    3201 B/op     209 allocs/op
 ```

--- a/config/doc.go
+++ b/config/doc.go
@@ -196,15 +196,15 @@
 //
 // Current performance benchmark data:
 //
-//   BenchmarkYAMLCreateSingleFile-8                       50000     31317 ns/op   10832 B/op     121 allocs/op
-//   BenchmarkYAMLCreateMultiFile-8                        30000     51650 ns/op   19840 B/op     207 allocs/op
-//   BenchmarkYAMLSimpleGetLevel1-8                     50000000      26.7 ns/op       0 B/op       0 allocs/op
-//   BenchmarkYAMLSimpleGetLevel3-8                     50000000      26.4 ns/op       0 B/op       0 allocs/op
-//   BenchmarkYAMLSimpleGetLevel7-8                     50000000      26.0 ns/op       0 B/op       0 allocs/op
-//   BenchmarkYAMLPopulateStruct-8                       2000000       860 ns/op     192 B/op      10 allocs/op
-//   BenchmarkYAMLPopulateStructNested-8                  500000      2615 ns/op     632 B/op      34 allocs/op
-//   BenchmarkYAMLPopulateStructNestedMultipleFiles-8     500000      3585 ns/op     816 B/op      45 allocs/op
-//   BenchmarkYAMLPopulateNestedTextUnmarshaler-8         100000     17016 ns/op    3217 B/op     209 allocs/op
+//   BenchmarkYAMLCreateSingleFile-8                       50000     31269 ns/op   11136 B/op     121 allocs/op
+//   BenchmarkYAMLCreateMultiFile-8                        30000     52378 ns/op   20064 B/op     205 allocs/op
+//   BenchmarkYAMLSimpleGetLevel1-8                     50000000      27.1 ns/op       0 B/op       0 allocs/op
+//   BenchmarkYAMLSimpleGetLevel3-8                     50000000      26.8 ns/op       0 B/op       0 allocs/op
+//   BenchmarkYAMLSimpleGetLevel7-8                     50000000      26.3 ns/op       0 B/op       0 allocs/op
+//   BenchmarkYAMLPopulateStruct-8                       2000000       861 ns/op     192 B/op      10 allocs/op
+//   BenchmarkYAMLPopulateStructNested-8                  500000      2616 ns/op     616 B/op      34 allocs/op
+//   BenchmarkYAMLPopulateStructNestedMultipleFiles-8     500000      3330 ns/op     744 B/op      42 allocs/op
+//   BenchmarkYAMLPopulateNestedTextUnmarshaler-8         100000     16775 ns/op    3201 B/op     209 allocs/op
 //
 //
 package config

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -54,7 +54,8 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 		root: &yamlNode{
 			nodeType: objectNode,
 			key:      Root,
-			value:    root},
+			value:    root,
+		},
 		vCache: make(map[string]Value),
 	}
 }
@@ -74,7 +75,7 @@ func mergeMaps(dst interface{}, src interface{}) interface{} {
 	case map[interface{}]interface{}:
 		dstMap, ok := dst.(map[interface{}]interface{})
 		if !ok {
-			panic(fmt.Sprintf("Expected map[interface{}]interface{}, actual: %+v", dstMap))
+			panic(fmt.Sprintf("Expected map[interface{}]interface{}, actual: %T", dstMap))
 		}
 
 		for k, v := range s {
@@ -123,8 +124,8 @@ func NewYamlProviderFromReader(readers ...io.ReadCloser) Provider {
 // As above, all the objects are going to be merged and arrays/values overridden in the order of the yamls.
 func NewYAMLProviderFromBytes(yamls ...[]byte) Provider {
 	closers := make([]io.ReadCloser, len(yamls))
-	for i := range yamls {
-		closers[i] = ioutil.NopCloser(bytes.NewReader(yamls[i]))
+	for i, yml := range yamls {
+		closers[i] = ioutil.NopCloser(bytes.NewReader(yml))
 	}
 
 	return newYAMLProviderCore(closers...)

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -104,7 +104,7 @@ func TestNewYamlProviderFromReader(t *testing.T) {
 func TestYamlNode(t *testing.T) {
 	buff := bytes.NewBuffer([]byte("a: b"))
 	node := &yamlNode{value: make(map[interface{}]interface{})}
-	err := unmarshalYamlValue(ioutil.NopCloser(buff), node.value)
+	err := unmarshalYamlValue(ioutil.NopCloser(buff), &node.value)
 	require.NoError(t, err)
 	assert.Equal(t, "map[a:b]", node.String())
 	assert.Equal(t, "map[interface {}]interface {}", node.Type().String())
@@ -114,7 +114,7 @@ func TestYamlNodeWithNil(t *testing.T) {
 	provider := NewYAMLProviderFromFiles(false, nil)
 	assert.NotNil(t, provider)
 	assert.Panics(t, func() {
-		_ = unmarshalYamlValue(nil, &yamlNode{})
+		_ = unmarshalYamlValue(nil, nil)
 	}, "Expected panic with nil inpout.")
 }
 
@@ -175,19 +175,17 @@ func TestMapParsing(t *testing.T) {
 		assert.NotNil(t, ms.MyMap)
 		assert.NotZero(t, len(ms.MyMap))
 
-		found := false
-		switch p := ms.MyMap["policy"].(type) {
-		case map[interface{}]interface{}:
-			for key, val := range p {
-				switch key := key.(type) {
-				case string:
-					assert.Equal(t, "makeway", key)
-					assert.Equal(t, "notanoption", val)
-					found = true
-				}
+		p, ok := ms.MyMap["policy"].(map[interface{}]interface{})
+		assert.True(t, ok)
+
+		for key, val := range p {
+			switch key := key.(type) {
+			case string:
+				assert.Equal(t, "makeway", key)
+				assert.Equal(t, "notanoption", val)
 			}
 		}
-		assert.True(t, found)
+
 		assert.Equal(t, "nesteddata", ms.NestedStruct.AdditionalData)
 	})
 }
@@ -261,6 +259,7 @@ func TestGrumpyTextUnMarshallerParsing(t *testing.T) {
 }
 
 func TestMergeUnmarshaller(t *testing.T) {
+	t.Parallel()
 	provider := NewYAMLProviderFromBytes(complexMapYaml, complexMapYamlV2)
 
 	ms := mapStruct{}
@@ -269,23 +268,30 @@ func TestMergeUnmarshaller(t *testing.T) {
 	assert.NotNil(t, ms.MyMap)
 	assert.NotZero(t, len(ms.MyMap))
 
-	found := false
-	switch p := ms.MyMap["policy"].(type) {
-	case map[interface{}]interface{}:
-		for key, val := range p {
-			switch key := key.(type) {
-			case string:
-				assert.Equal(t, "makeway", key)
-				assert.Equal(t, "notanoption", val)
-				found = true
-			}
-		}
-	}
-	assert.True(t, found)
-
-	p, ok := ms.MyMap["pools"].([]interface{})
+	p, ok := ms.MyMap["policy"].(map[interface{}]interface{})
 	assert.True(t, ok)
-	assert.Equal(t, []interface{}{"very", "funny"}, p)
+	for key, val := range p {
+		assert.Equal(t, "makeway", key)
+		assert.Equal(t, "notanoption", val)
+	}
+
+	s, ok := ms.MyMap["pools"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{"very", "funny"}, s)
 
 	assert.Equal(t, "", ms.NestedStruct.AdditionalData)
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+	for _, v := range mergeTest {
+		t.Run(v.description, func(t *testing.T) {
+			prov := NewYAMLProviderFromBytes(v.yaml...)
+			for path, exp := range v.expected {
+				res := reflect.New(reflect.ValueOf(exp).Type()).Interface()
+				assert.NoError(t, prov.Get(path).PopulateStruct(res))
+				assert.Equal(t, exp, reflect.ValueOf(res).Elem().Interface(), "For path: %s", path)
+			}
+		})
+	}
 }

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -179,11 +179,8 @@ func TestMapParsing(t *testing.T) {
 		assert.True(t, ok)
 
 		for key, val := range p {
-			switch key := key.(type) {
-			case string:
-				assert.Equal(t, "makeway", key)
-				assert.Equal(t, "notanoption", val)
-			}
+			assert.Equal(t, "makeway", key)
+			assert.Equal(t, "notanoption", val)
 		}
 
 		assert.Equal(t, "nesteddata", ms.NestedStruct.AdditionalData)
@@ -264,7 +261,6 @@ func TestMergeUnmarshaller(t *testing.T) {
 
 	ms := mapStruct{}
 	assert.NoError(t, provider.Get("mapStruct").PopulateStruct(&ms))
-
 	assert.NotNil(t, ms.MyMap)
 	assert.NotZero(t, len(ms.MyMap))
 
@@ -278,7 +274,6 @@ func TestMergeUnmarshaller(t *testing.T) {
 	s, ok := ms.MyMap["pools"].([]interface{})
 	assert.True(t, ok)
 	assert.Equal(t, []interface{}{"very", "funny"}, s)
-
 	assert.Equal(t, "", ms.NestedStruct.AdditionalData)
 }
 

--- a/config/yaml_test_data.go
+++ b/config/yaml_test_data.go
@@ -192,3 +192,139 @@ type duckTales struct {
 	Protagonist duckTaleCharacter
 	Pilot       duckTaleCharacter
 }
+
+type mergeTestData struct {
+	description string
+	yaml        [][]byte
+	expected    map[string]interface{}
+}
+
+type firstLevelMerge struct {
+	Slice     []string
+	Map       map[string]string
+	Base      string
+	Overwrite string
+}
+
+type secondLevelMerge struct {
+	Slice     []firstLevelMerge
+	Base      firstLevelMerge
+	Overwrite firstLevelMerge
+}
+
+var baseFirstLevel = firstLevelMerge{
+	Map:       map[string]string{"keep": "ok", "override": "updated"},
+	Slice:     []string{"Wonder Woman", "Batman"},
+	Base:      "MSDOS",
+	Overwrite: "Windows 10",
+}
+
+var overwriteFirstLevel = firstLevelMerge{
+	Map:       map[string]string{"keep": "ok", "override": "updated"},
+	Slice:     []string{"Wonder Woman", "Batman"},
+	Base:      "UNIX",
+	Overwrite: "FreeBSD",
+}
+
+var mergeTest = []mergeTestData{
+
+	{
+		"First level maps",
+		[][]byte{[]byte(`
+slice:
+- DuckTales
+- Darkwingduck
+map:
+  keep: ok
+  override: oldValue
+base: UNIX
+overwrite: Linux
+
+`),
+			[]byte(`
+slice:
+- Wonder Woman
+- Batman
+map:
+  override: updated
+overwrite: FreeBSD
+`)},
+		map[string]interface{}{
+			"": overwriteFirstLevel,
+		},
+	},
+	{
+		"Second level structs",
+		[][]byte{[]byte(`
+slice:
+- slice:
+  - DuckTales
+  - Darkwingduck
+  map:
+    keep: no
+base:
+  slice:
+  - Wonder Woman
+  - Batman
+  map:
+    keep: ok
+    override: updated
+  base: MSDOS
+  overwrite: Windows 8
+overwrite:
+  slice:
+  - Spider-Man
+  - Deadpool
+  map:
+    keep: ok
+    override: oldValue
+  overwrite: Linux
+`),
+			[]byte(`
+slice:
+- slice:
+  - Wonder Woman
+  - Batman
+  map:
+    keep: ok
+    override: updated
+  base: UNIX
+  overwrite: FreeBSD
+base:
+  map:
+    override: updated
+  overwrite: Windows 10
+overwrite:
+  slice:
+  - Wonder Woman
+  - Batman
+  map:
+    keep: ok
+    override: updated
+  base: UNIX
+  overwrite: FreeBSD
+`)},
+		map[string]interface{}{
+			"": secondLevelMerge{
+				Base:      baseFirstLevel,
+				Overwrite: overwriteFirstLevel,
+				Slice:     []firstLevelMerge{overwriteFirstLevel}},
+			"Base":      baseFirstLevel,
+			"Overwrite": overwriteFirstLevel,
+		},
+	},
+	{
+		"Empty yamls",
+		[][]byte{[]byte(``), []byte(``)},
+		map[string]interface{}{
+			"": struct{ Field string }{},
+		},
+	},
+	{
+		"No overwrite for empty yamls",
+		[][]byte{[]byte(`Keep: true`), []byte(``)},
+		map[string]interface{}{
+			"": struct{ Keep bool }{true},
+		},
+	},
+}

--- a/config/yaml_test_data.go
+++ b/config/yaml_test_data.go
@@ -118,6 +118,17 @@ mapStruct:
     additionalData: nesteddata
 `)
 
+var complexMapYamlV2 = []byte(`
+mapStruct:
+  oneTrueMap:
+    name: poem
+    pools:
+    - very
+    - funny
+  nestedStruct:
+    additionalData:
+`)
+
 type userDefinedTypeInt nestedTypeInt
 type nestedTypeInt int64
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 47612d13426779e7a74a7c873888a1d94a5fa1607275ce585e746b09d7a5f22d
-updated: 2016-12-15T14:37:04.023171932-08:00
+hash: be3c167ee35ffbe3e836762c10c1ac48fb45b62ee178ac2e74bfe5453f5637ab
+updated: 2017-01-10T19:43:22.331309685-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 0d9b713b173f35ce02552b2f4372899440a99b25
+  version: 4f710aa4f47e051d41c863aa7aa9239dab5b9636
   subpackages:
   - lib/go/thrift
 - name: github.com/certifi/gocertifi
@@ -33,7 +33,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - assert
   - require
@@ -42,7 +42,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 2750b4ae690cbeb294016efe18ceaeb80c4ce17c
 - name: github.com/uber-go/zap
-  version: 05dadc4e239529c50d6f730c17f0a3aaf35b64fd
+  version: a5783ee4b216a927da8f839c45cfbf9d694e1467
 - name: github.com/uber/jaeger-client-go
   version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
   subpackages:
@@ -55,7 +55,7 @@ imports:
   - transport/udp
   - utils
 - name: github.com/uber/tchannel-go
-  version: 4a23f3aae76694b21107f118ece763a61b98ea07
+  version: 2caa315516e1836b7b2eff70d2fcbd23538d1b22
   subpackages:
   - relay
   - tnet
@@ -100,12 +100,12 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: golang.org/x/net
-  version: 45e771701b814666a7eb299e6c7a57d0b1799e91
+  version: 60c41d1de8da134c05b7b40154a9a82bf5b7edb9
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/tools
-  version: 3fe2afc9e626f32e91aff6eddb78b14743446865
+  version: 1529f889eb4b594d1f047f2fb8d5b3cc85c8f006
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/yaml.v2
@@ -114,29 +114,29 @@ testImports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
 - name: github.com/axw/gocov
-  version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
+  version: c77561ca0c0cb1ed5d4ce4a912a75f5532566422
   subpackages:
   - gocov
 - name: github.com/go-playground/overalls
-  version: 6de3f6a9f4b3449d179d98d63b521716cda834fb
+  version: dab02cad1edafb5aa1d38729ba4bfd5618b836ce
 - name: github.com/golang/lint
-  version: 3390df4df2787994aea98de825b964ac7944b817
+  version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
   subpackages:
   - golint
 - name: github.com/jessevdk/go-flags
   version: 0648c820cd4e564706597268ae2d2c7d9e6900c6
 - name: github.com/kisielk/errcheck
-  version: 9c1292e1c962175f76516859f4a88aabd86dc495
+  version: db0ca22445717d1b2c51ac1034440e0a2a2de645
 - name: github.com/kisielk/gotool
-  version: 5e136deb9b893bbe6c8f23236ff4378b7a8a0dbb
+  version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
 - name: github.com/mattn/goveralls
-  version: edf7508a2bcb40ec1160e94518c983c2fc169f02
+  version: 61ac1a6b48f7f76ff3d14e00d3192e7dd0b9db91
 - name: github.com/mvdan/interfacer
   version: 588bd9940e912b1b2760d41bd836ef28ff97164d
   subpackages:
   - cmd/interfacer
 - name: github.com/pborman/uuid
-  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
+  version: 5007efa264d92316c43112bc573e754bc889b7b1
 - name: github.com/russross/blackfriday
   version: a4dd8ad4a6fda03e68be3eacb71efbf51565415e
 - name: github.com/sectioneight/md-to-godoc

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,6 @@ import:
 - package: github.com/uber/jaeger-client-go
   version: ^1.6.0
 - package: github.com/stretchr/testify
-  version: ^1.1.3
   subpackages:
   - assert
   - require

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -30,7 +30,6 @@
 //     "io"
 //     "net/http"
 //
-//     "go.uber.org/fx"
 //     "go.uber.org/fx/modules/uhttp"
 //     "go.uber.org/fx/service"
 //   )
@@ -48,8 +47,7 @@
 //   }
 //
 //   func registerHTTP(service service.Host) []uhttp.RouteHandler {
-//     handleHome := http.HandlerFunc(func(ctx fx.Context, w http.ResponseWriter, r *http.Request) {
-//       ctx.Logger().Info("Inside the handler")
+//     handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 //       io.WriteString(w, "Hello, world")
 //     })
 //

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -30,6 +30,7 @@
 //     "io"
 //     "net/http"
 //
+//     "go.uber.org/fx"
 //     "go.uber.org/fx/modules/uhttp"
 //     "go.uber.org/fx/service"
 //   )
@@ -47,7 +48,8 @@
 //   }
 //
 //   func registerHTTP(service service.Host) []uhttp.RouteHandler {
-//     handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//     handleHome := http.HandlerFunc(func(ctx fx.Context, w http.ResponseWriter, r *http.Request) {
+//       ctx.Logger().Info("Inside the handler")
 //       io.WriteString(w, "Hello, world")
 //     })
 //

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -30,7 +30,6 @@
 //     "io"
 //     "net/http"
 //
-//     "go.uber.org/fx"
 //     "go.uber.org/fx/modules/uhttp"
 //     "go.uber.org/fx/service"
 //   )
@@ -48,8 +47,7 @@
 //   }
 //
 //   func registerHTTP(service service.Host) []uhttp.RouteHandler {
-//     handleHome := http.HandlerFunc(func(ctx fx.Context, w http.ResponseWriter, r *http.Request) {
-//       ctx.Logger().Info("Inside the handler")
+//     handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 //       io.WriteString(w, "Hello, world")
 //     })
 //
@@ -65,5 +63,5 @@
 //
 //
 //
-
+//
 package uhttp

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -30,6 +30,7 @@
 //     "io"
 //     "net/http"
 //
+//     "go.uber.org/fx"
 //     "go.uber.org/fx/modules/uhttp"
 //     "go.uber.org/fx/service"
 //   )
@@ -47,7 +48,8 @@
 //   }
 //
 //   func registerHTTP(service service.Host) []uhttp.RouteHandler {
-//     handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//     handleHome := http.HandlerFunc(func(ctx fx.Context, w http.ResponseWriter, r *http.Request) {
+//       ctx.Logger().Info("Inside the handler")
 //       io.WriteString(w, "Hello, world")
 //     })
 //
@@ -63,4 +65,5 @@
 //
 //
 //
+
 package uhttp

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -65,5 +65,4 @@
 //
 //
 //
-//
 package uhttp


### PR DESCRIPTION
We will be able to get access not only to leaf nodes of the parse tree and look up is going to be faster.

The changes are done only for yaml provider. We can update ProviderGroups later.