### PR TITLE
Remove Initialize method from Module

### DIFF
--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -59,7 +59,6 @@ func TestThrfitModule_Error(t *testing.T) {
 
 func testInitRunModule(t *testing.T, mod service.Module, mci service.ModuleCreateInfo) {
 	readyCh := make(chan struct{}, 1)
-	assert.NoError(t, mod.Initialize(mci.Host))
 	assert.NoError(t, mod.Stop())
 	errs := mod.Start(readyCh)
 	defer func() {

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -118,11 +118,6 @@ func newYarpcModule(
 	return module, err
 }
 
-// Initialize sets up a YARPC-backed module
-func (m *YarpcModule) Initialize(service service.Host) error {
-	return nil
-}
-
 // Start begins serving requests over YARPC
 func (m *YarpcModule) Start(readyCh chan<- struct{}) <-chan error {
 	m.stateMu.Lock()

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -154,12 +154,6 @@ func newModule(
 	return module, nil
 }
 
-// Initialize sets up an HTTP-backed module
-// TODO(madhu): Do we need this? newModule seems to be taking care of initialization
-func (m *Module) Initialize(host service.Host) error {
-	return nil
-}
-
 // Start begins serving requests over HTTP
 func (m *Module) Start(ready chan<- struct{}) <-chan error {
 	m.mux = http.NewServeMux()

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -163,7 +163,6 @@ func withModule(
 
 	// us an ephemeral port on tests
 	mod.config.Port = 0
-	require.NoError(t, mod.Initialize(mi.Host), "Expected initialize to succeed")
 
 	errs := make(chan error, 1)
 	readyChan := make(chan struct{}, 1)

--- a/service/host.go
+++ b/service/host.go
@@ -65,7 +65,7 @@ func (s *host) addModule(module Module) error {
 		return fmt.Errorf("can't add module: service already started")
 	}
 	s.modules = append(s.modules, module)
-	return module.Initialize(s)
+	return nil
 }
 
 func (s *host) supportsRole(roles ...string) bool {

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -266,8 +266,8 @@ func TestAddModule_Locked(t *testing.T) {
 }
 
 func TestAddModule_NotLocked(t *testing.T) {
-	mod := NewStubModule()
 	sh := &host{}
+	mod := NewStubModule(sh)
 	assert.NoError(t, sh.addModule(mod))
 	assert.Equal(t, sh, mod.Host)
 }
@@ -285,7 +285,7 @@ func TestStartStopRegressionDeadlock(t *testing.T) {
 
 func TestStartModule_NoErrors(t *testing.T) {
 	s := makeHost()
-	mod := NewStubModule()
+	mod := NewStubModule(s)
 	require.NoError(t, s.addModule(mod))
 
 	control := s.StartAsync()
@@ -304,7 +304,7 @@ func TestStartModule_NoErrors(t *testing.T) {
 
 func TestStartHost_WithErrors(t *testing.T) {
 	s := makeHost()
-	mod := NewStubModule()
+	mod := NewStubModule(s)
 	mod.StartError = errors.New("can't start this")
 	require.NoError(t, s.addModule(mod))
 

--- a/service/module.go
+++ b/service/module.go
@@ -25,7 +25,6 @@ type ModuleType string
 
 // A Module is the basic building block of an UberFx service
 type Module interface {
-	Initialize(host Host) error
 	Type() string
 	Name() string
 	Start(ready chan<- struct{}) <-chan error

--- a/service/stub_module.go
+++ b/service/stub_module.go
@@ -33,14 +33,8 @@ type StubModule struct {
 var _ Module = &StubModule{}
 
 // NewStubModule generates a Module for use in testing
-func NewStubModule() *StubModule {
-	return &StubModule{}
-}
-
-// Initialize fakes an init call on the module
-func (s *StubModule) Initialize(host Host) error {
-	s.Host = host
-	return s.InitError
+func NewStubModule(host Host) *StubModule {
+	return &StubModule{Host: host}
 }
 
 // Start mimics startup

--- a/service/stub_module_test.go
+++ b/service/stub_module_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStubodule_StartError(t *testing.T) {
-	s := NewStubModule()
+func TestStubModule_StartError(t *testing.T) {
+	s := NewStubModule(NullHost())
 	s.StartError = errors.New("blargh")
 	readyCh := make(chan struct{}, 1)
 
@@ -36,7 +36,7 @@ func TestStubodule_StartError(t *testing.T) {
 }
 
 func TestStubModule_Accessors(t *testing.T) {
-	s := NewStubModule()
+	s := NewStubModule(NullHost())
 	assert := assert.New(t)
 
 	assert.Empty(s.Type())


### PR DESCRIPTION
We use New methods to initialize modules. The Initialize method is a Noop for existing modules and appears redundant. Removed the Initialize method.