### PR TITLE
Rename Noop to Nop for consistency

### DIFF
--- a/auth/auth_stub.go
+++ b/auth/auth_stub.go
@@ -23,31 +23,31 @@ package auth
 import "context"
 
 var (
-	// NoopClient is used for testing and no-op integration
-	NoopClient = noopClient(nil)
+	// NopClient is used for testing and no-op integration
+	NopClient = nopClient(nil)
 
-	_ Client = &noop{}
+	_ Client = &nop{}
 )
 
-type noop struct {
+type nop struct {
 }
 
-func noopClient(info CreateAuthInfo) Client {
-	return &noop{}
+func nopClient(info CreateAuthInfo) Client {
+	return &nop{}
 }
 
-func (*noop) Name() string {
-	return "noop"
+func (*nop) Name() string {
+	return "nop"
 }
 
-func (*noop) Authenticate(ctx context.Context) (context.Context, error) {
+func (*nop) Authenticate(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
-func (*noop) Authorize(ctx context.Context) error {
+func (*nop) Authorize(ctx context.Context) error {
 	return nil
 }
 
-func (*noop) SetAttribute(ctx context.Context, key, value string) context.Context {
+func (*nop) SetAttribute(ctx context.Context, key, value string) context.Context {
 	return ctx
 }

--- a/auth/localauth.go
+++ b/auth/localauth.go
@@ -34,7 +34,7 @@ type defaultClient struct {
 // TODO(anup): add configurable authentication, whether a service needs one or not
 func defaultAuth(info CreateAuthInfo) Client {
 	return &defaultClient{
-		authClient: NoopClient,
+		authClient: NopClient,
 	}
 }
 

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -63,7 +63,7 @@ func RegisterClient(registerFunc RegisterFunc) {
 	_registerFunc = registerFunc
 }
 
-// UnregisterClient unregisters auth RegisterFunc for testing and resets to noopClient
+// UnregisterClient unregisters auth RegisterFunc for testing and resets to nopClient
 func UnregisterClient() {
 	_setupMu.Lock()
 	defer _setupMu.Unlock()
@@ -81,7 +81,7 @@ func SetupClient(info CreateAuthInfo) {
 	if _registerFunc != nil {
 		_std = _registerFunc(info)
 	} else {
-		_std = NoopClient
+		_std = NopClient
 	}
 }
 

--- a/auth/uauth_test.go
+++ b/auth/uauth_test.go
@@ -77,7 +77,7 @@ func TestUauth_RegisterPanic(t *testing.T) {
 
 func TestUauth_Default(t *testing.T) {
 	withAuthClientSetup(t, nil, fakeAuthInfo{}, func() {
-		assert.Equal(t, "noop", Instance().Name())
+		assert.Equal(t, "nop", Instance().Name())
 	})
 }
 
@@ -88,5 +88,5 @@ func (fakeAuthInfo) Config() config.Provider {
 }
 
 func (fakeAuthInfo) Logger() ulog.Log {
-	return ulog.NoopLogger
+	return ulog.NopLogger
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -38,7 +38,7 @@ type Provider interface {
 	Scope(prefix string) Provider
 
 	// A RegisterChangeCallback provides callback registration for config providers.
-	// These callbacks are noop if a dynamic provider is not configured for the service.
+	// These callbacks are nop if a dynamic provider is not configured for the service.
 	RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error
 	UnregisterChangeCallback(token string) error
 }

--- a/context.go
+++ b/context.go
@@ -33,13 +33,13 @@ type Context interface {
 	Logger() ulog.Log
 }
 
-// NoopContext is defined for testing purpose
-var NoopContext = noopContext{gcontext.Background()}
+// NopContext is defined for testing purpose
+var NopContext = nopContext{gcontext.Background()}
 
-type noopContext struct {
+type nopContext struct {
 	gcontext.Context
 }
 
-func (noopContext) Logger() ulog.Log {
-	return ulog.NoopLogger
+func (nopContext) Logger() ulog.Log {
+	return ulog.NopLogger
 }

--- a/internal/fxcontext/context_benchmark_test.go
+++ b/internal/fxcontext/context_benchmark_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func withContext(t *testing.B, f func(fxctx fx.Context)) {
-	f(New(context.Background(), service.NullHost()))
+	f(New(context.Background(), service.NopHost()))
 }
 
 func BenchmarkContext_TypeConversion(b *testing.B) {

--- a/internal/fxcontext/context_test.go
+++ b/internal/fxcontext/context_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestContext_HostAccess(t *testing.T) {
-	ctx := New(gcontext.Background(), service.NullHost())
+	ctx := New(gcontext.Background(), service.NopHost())
 	assert.NotNil(t, ctx)
 	assert.NotNil(t, ctx.Logger())
 	assert.NotNil(t, ctx.Value(_fxContextStore))
@@ -42,7 +42,7 @@ func TestContext_HostAccess(t *testing.T) {
 
 func TestWithContext(t *testing.T) {
 	gctx := gcontext.WithValue(gcontext.Background(), "key", "val")
-	ctx := New(gctx, service.NullHost())
+	ctx := New(gctx, service.NopHost())
 	assert.Equal(t, "val", ctx.Value("key"))
 
 	gctx1 := gcontext.WithValue(gcontext.Background(), "key1", "val1")
@@ -83,7 +83,7 @@ func TestWithContext_NilHost(t *testing.T) {
 }
 
 func TestContext_Convert(t *testing.T) {
-	host := service.NullHost()
+	host := service.NopHost()
 	ctx := New(gcontext.Background(), host)
 	logger := ctx.Logger()
 	assert.Equal(t, host.Logger(), logger)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -76,7 +76,7 @@ func TestRegisterBadReporterPanics(t *testing.T) {
 }
 
 func goodScope(i ScopeInit) (tally.Scope, tally.StatsReporter, io.Closer, error) {
-	return tally.NoopScope, tally.NullStatsReporter, testutils.NoopCloser{}, nil
+	return tally.NoopScope, tally.NullStatsReporter, testutils.NopCloser{}, nil
 }
 
 func badScope(i ScopeInit) (tally.Scope, tally.StatsReporter, io.Closer, error) {

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -59,7 +59,7 @@ func TestNewModuleBase_Tracer(t *testing.T) {
 }
 
 func nmb(moduleType, name string, roles []string) *ModuleBase {
-	host := service.NullHost()
+	host := service.NopHost()
 
 	return NewModuleBase(
 		moduleType,

--- a/modules/options_test.go
+++ b/modules/options_test.go
@@ -49,6 +49,6 @@ func TestWithRoles_OK(t *testing.T) {
 
 func mci() *service.ModuleCreateInfo {
 	return &service.ModuleCreateInfo{
-		Host: service.NullHost(),
+		Host: service.NopHost(),
 	}
 }

--- a/modules/rpc/handler_test.go
+++ b/modules/rpc/handler_test.go
@@ -90,7 +90,7 @@ func TestWrapOneway_error(t *testing.T) {
 
 func TestInboundMiddleware_fxContext(t *testing.T) {
 	unary := fxContextInboundMiddleware{
-		Host: service.NullHost(),
+		Host: service.NopHost(),
 	}
 	err := unary.Handle(context.Background(), &transport.Request{}, nil, &fakeUnaryHandler{t: t})
 	assert.Equal(t, "handle", err.Error())
@@ -98,7 +98,7 @@ func TestInboundMiddleware_fxContext(t *testing.T) {
 
 func TestOnewayInboundMiddleware_fxContext(t *testing.T) {
 	oneway := fxContextOnewayInboundMiddleware{
-		Host: service.NullHost(),
+		Host: service.NopHost(),
 	}
 	err := oneway.HandleOneway(context.Background(), &transport.Request{}, &fakeOnewayHandler{t: t})
 	assert.Equal(t, "oneway handle", err.Error())
@@ -107,7 +107,7 @@ func TestOnewayInboundMiddleware_fxContext(t *testing.T) {
 func TestInboundMiddleware_auth(t *testing.T) {
 	withAuthClient(t, nil, func() {
 		unary := authInboundMiddleware{
-			Host: service.NullHost(),
+			Host: service.NopHost(),
 		}
 		err := unary.Handle(context.Background(), &transport.Request{}, nil, &fakeUnaryHandler{t: t})
 		assert.EqualError(t, err, "handle")
@@ -117,7 +117,7 @@ func TestInboundMiddleware_auth(t *testing.T) {
 func TestInboundMiddleware_authFailure(t *testing.T) {
 	withAuthClient(t, auth.FakeFailureClient, func() {
 		unary := authInboundMiddleware{
-			Host: service.NullHost(),
+			Host: service.NopHost(),
 		}
 		err := unary.Handle(context.Background(), &transport.Request{}, nil, &fakeUnaryHandler{t: t})
 		assert.EqualError(t, err, "Error authorizing the service")
@@ -127,7 +127,7 @@ func TestInboundMiddleware_authFailure(t *testing.T) {
 func TestOnewayInboundMiddleware_auth(t *testing.T) {
 	withAuthClient(t, nil, func() {
 		oneway := authOnewayInboundMiddleware{
-			Host: service.NullHost(),
+			Host: service.NopHost(),
 		}
 		err := oneway.HandleOneway(context.Background(), &transport.Request{}, &fakeOnewayHandler{t: t})
 		assert.EqualError(t, err, "oneway handle")
@@ -138,7 +138,7 @@ func TestOnewayInboundMiddleware_auth(t *testing.T) {
 func TestOnewayInboundMiddleware_authFailure(t *testing.T) {
 	withAuthClient(t, auth.FakeFailureClient, func() {
 		oneway := authOnewayInboundMiddleware{
-			Host: service.NullHost(),
+			Host: service.NopHost(),
 		}
 		err := oneway.HandleOneway(context.Background(), &transport.Request{}, &fakeOnewayHandler{t: t})
 		assert.EqualError(t, err, "Error authorizing the service")
@@ -148,7 +148,7 @@ func TestOnewayInboundMiddleware_authFailure(t *testing.T) {
 func withAuthClient(t *testing.T, registerFunc auth.RegisterFunc, fn func()) {
 	auth.UnregisterClient()
 	auth.RegisterClient(registerFunc)
-	auth.SetupClient(service.NullHost())
+	auth.SetupClient(service.NopHost())
 	fn()
 }
 

--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -71,7 +71,7 @@ func testInitRunModule(t *testing.T, mod service.Module, mci service.ModuleCreat
 func mch() service.ModuleCreateInfo {
 	return service.ModuleCreateInfo{
 		Items: make(map[string]interface{}),
-		Host:  service.NullHost(),
+		Host:  service.NopHost(),
 	}
 }
 

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -48,17 +48,17 @@ var (
 )
 
 func TestExecutionChain(t *testing.T) {
-	execChain := newExecutionChain([]Filter{}, getNoopClient())
-	resp, err := execChain.Do(fxcontext.New(context.Background(), service.NullHost()), _req)
+	execChain := newExecutionChain([]Filter{}, getNopClient())
+	resp, err := execChain.Do(fxcontext.New(context.Background(), service.NopHost()), _req)
 	assert.NoError(t, err)
 	assert.Equal(t, _respOK, resp)
 }
 
 func TestExecutionChainFilters(t *testing.T) {
 	execChain := newExecutionChain(
-		[]Filter{FilterFunc(tracingFilter)}, getNoopClient(),
+		[]Filter{FilterFunc(tracingFilter)}, getNopClient(),
 	)
-	ctx := fx.NoopContext
+	ctx := fx.NopContext
 	resp, err := execChain.Do(ctx, _req)
 	assert.NoError(t, err)
 	assert.Equal(t, _respOK, resp)
@@ -68,14 +68,14 @@ func TestExecutionChainFiltersError(t *testing.T) {
 	execChain := newExecutionChain(
 		[]Filter{FilterFunc(tracingFilter)}, getErrorClient(),
 	)
-	resp, err := execChain.Do(fx.NoopContext, _req)
+	resp, err := execChain.Do(fx.NopContext, _req)
 	assert.Error(t, err)
 	assert.Equal(t, errClient, err)
 	assert.Nil(t, resp)
 }
 
 func withOpentracingSetup(t *testing.T, registerFunc auth.RegisterFunc, fn func(tracer opentracing.Tracer)) {
-	tracer, closer, err := tracing.InitGlobalTracer(&jconfig.Configuration{}, "Test", ulog.NoopLogger, tally.NullStatsReporter)
+	tracer, closer, err := tracing.InitGlobalTracer(&jconfig.Configuration{}, "Test", ulog.NopLogger, tally.NullStatsReporter)
 	defer closer.Close()
 	assert.NotNil(t, closer)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func getContextPropogationClient(t *testing.T) BasicClient {
 	)
 }
 
-func getNoopClient() BasicClient {
+func getNopClient() BasicClient {
 	return BasicClientFunc(
 		func(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
 			return _respOK, nil

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -55,7 +55,7 @@ func TestNew_Panic(t *testing.T) {
 func TestClientDo(t *testing.T) {
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
-	resp, err := _defaultUHTTPClient.Do(fx.NoopContext, req)
+	resp, err := _defaultUHTTPClient.Do(fx.NopContext, req)
 	checkOKResponse(t, resp, err)
 }
 
@@ -63,49 +63,49 @@ func TestClientDoWithoutFilters(t *testing.T) {
 	uhttpClient := &Client{Client: _defaultHTTPClient}
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
-	resp, err := uhttpClient.Do(fx.NoopContext, req)
+	resp, err := uhttpClient.Do(fx.NopContext, req)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientGet(t *testing.T) {
 	svr := startServer()
-	resp, err := _defaultUHTTPClient.Get(fx.NoopContext, svr.URL)
+	resp, err := _defaultUHTTPClient.Get(fx.NopContext, svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientGetError(t *testing.T) {
 	// Causing newRequest to fail, % does not parse as URL
-	resp, err := _defaultUHTTPClient.Get(fx.NoopContext, "%")
+	resp, err := _defaultUHTTPClient.Get(fx.NopContext, "%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientHead(t *testing.T) {
 	svr := startServer()
-	resp, err := _defaultUHTTPClient.Head(fx.NoopContext, svr.URL)
+	resp, err := _defaultUHTTPClient.Head(fx.NopContext, svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientHeadError(t *testing.T) {
 	// Causing newRequest to fail, % does not parse as URL
-	resp, err := _defaultUHTTPClient.Head(fx.NoopContext, "%")
+	resp, err := _defaultUHTTPClient.Head(fx.NopContext, "%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientPost(t *testing.T) {
 	svr := startServer()
-	resp, err := _defaultUHTTPClient.Post(fx.NoopContext, svr.URL, "", nil)
+	resp, err := _defaultUHTTPClient.Post(fx.NopContext, svr.URL, "", nil)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientPostError(t *testing.T) {
-	resp, err := _defaultUHTTPClient.Post(fx.NoopContext, "%", "", nil)
+	resp, err := _defaultUHTTPClient.Post(fx.NopContext, "%", "", nil)
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientPostForm(t *testing.T) {
 	svr := startServer()
 	var urlValues map[string][]string
-	resp, err := _defaultUHTTPClient.PostForm(fx.NoopContext, svr.URL, urlValues)
+	resp, err := _defaultUHTTPClient.PostForm(fx.NopContext, svr.URL, urlValues)
 	checkOKResponse(t, resp, err)
 }
 

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -150,7 +150,7 @@ func withModule(
 	fn func(*Module),
 ) {
 	mi := service.ModuleCreateInfo{
-		Host: service.NullHost(),
+		Host: service.NopHost(),
 	}
 	mod, err := newModule(mi, hookup, options...)
 	if expectError {

--- a/modules/uhttp/router_test.go
+++ b/modules/uhttp/router_test.go
@@ -42,7 +42,7 @@ func serve(t *testing.T, h http.Handler) net.Listener {
 }
 
 func withRouter(t *testing.T, f func(r *Router, l net.Listener)) {
-	r := NewRouter(service.NullHost())
+	r := NewRouter(service.NopHost())
 	l := serve(t, r)
 	defer l.Close()
 	r.Handle("/foo/baz/quokka",

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -48,7 +48,7 @@ func TestNewBuilder_WithConfig(t *testing.T) {
 func TestBuilder_WithModules(t *testing.T) {
 	_, err := NewBuilder(
 		WithConfiguration(StaticAppData(nil)),
-	).WithModules(noopModule).Build()
+	).WithModules(nopModule).Build()
 	assert.NoError(t, err)
 }
 
@@ -63,18 +63,18 @@ func TestBuilder_SkipsModulesBadInit(t *testing.T) {
 	empty := ""
 	_, err := NewBuilder(
 		WithConfiguration(StaticAppData(&empty)),
-	).WithModules(noopModule).Build()
+	).WithModules(nopModule).Build()
 	assert.Error(t, err, "Expected service name to be provided")
 }
 
 func TestWithModules_OK(t *testing.T) {
-	_, err := WithModules(noopModule).WithOptions(
+	_, err := WithModules(nopModule).WithOptions(
 		WithConfiguration(StaticAppData(nil)),
 	).Build()
 	assert.NoError(t, err)
 }
 
-func noopModule(_ ModuleCreateInfo) ([]Module, error) {
+func nopModule(_ ModuleCreateInfo) ([]Module, error) {
 	return nil, nil
 }
 

--- a/service/core_test.go
+++ b/service/core_test.go
@@ -38,13 +38,13 @@ func TestHostContainer_SetContainer(t *testing.T) {
 }
 
 func TestCoreDescription(t *testing.T) {
-	sh := NullHost().(*serviceCore)
+	sh := NopHost().(*serviceCore)
 
 	assert.Equal(t, sh.standardConfig.ServiceDescription, sh.Description())
 }
 
 func TestCoreOwner(t *testing.T) {
-	sh := NullHost().(*serviceCore)
+	sh := NopHost().(*serviceCore)
 
 	assert.Equal(t, sh.standardConfig.ServiceOwner, sh.Owner())
 }
@@ -68,7 +68,7 @@ func TestCoreRoles(t *testing.T) {
 }
 
 func TestCoreConfig(t *testing.T) {
-	sh := NullHost()
+	sh := NopHost()
 	cfg := sh.Config()
 
 	assert.Equal(t, "static", cfg.Name())

--- a/service/host_mock.go
+++ b/service/host_mock.go
@@ -28,13 +28,13 @@ import (
 	"github.com/uber-go/tally"
 )
 
-// NullHost is to be used in tests
-func NullHost() Host {
-	return NullHostConfigured(ulog.NoopLogger, opentracing.NoopTracer{})
+// NopHost is to be used in tests
+func NopHost() Host {
+	return NopHostConfigured(ulog.NopLogger, opentracing.NoopTracer{})
 }
 
-// NullHostConfigured is a noop host with set logger and tracer for tests
-func NullHostConfigured(logger ulog.Log, tracer opentracing.Tracer) Host {
+// NopHostConfigured is a nop host with set logger and tracer for tests
+func NopHostConfigured(logger ulog.Log, tracer opentracing.Tracer) Host {
 	return &serviceCore{
 		configProvider: config.NewStaticProvider(nil),
 		standardConfig: serviceConfig{

--- a/service/host_mock_test.go
+++ b/service/host_mock_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNullHost_OK(t *testing.T) {
-	sh := NullHost()
+func TestNopHost_OK(t *testing.T) {
+	sh := NopHost()
 	assert.Equal(t, "dummy", sh.Name())
 }

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -170,7 +170,7 @@ func TestOnCriticalError_ObserverShutdown(t *testing.T) {
 		observer: o,
 		serviceCore: serviceCore{
 			loggingCore: loggingCore{
-				log: ulog.NoopLogger,
+				log: ulog.NopLogger,
 			},
 		},
 	}
@@ -196,11 +196,11 @@ func TestHostShutdown_CloseSuccessful(t *testing.T) {
 	sh := makeRunningHost()
 	sh.serviceCore.metricsCore = metricsCore{
 		metrics:          tally.NoopScope,
-		metricsCloser:    testutils.NoopCloser{},
+		metricsCloser:    testutils.NopCloser{},
 		runtimeCollector: metrics.NewRuntimeCollector(tally.NoopScope, time.Millisecond),
 	}
 	sh.serviceCore.tracerCore = tracerCore{
-		tracerCloser: testutils.NoopCloser{},
+		tracerCloser: testutils.NopCloser{},
 	}
 	checkShutdown(t, sh, false)
 }
@@ -325,7 +325,7 @@ func makeHost() *host {
 	return &host{
 		serviceCore: serviceCore{
 			loggingCore: loggingCore{
-				log: ulog.NoopLogger,
+				log: ulog.NopLogger,
 			},
 		},
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -123,8 +123,8 @@ func New(options ...Option) (Owner, error) {
 		return nil, err
 	}
 
-	// Initialize metrics. If no metrics reporters were Registered, do noop
-	// TODO(glib): add a logging reporter and use it by default, rather than noop
+	// Initialize metrics. If no metrics reporters were Registered, do nop
+	// TODO(glib): add a logging reporter and use it by default, rather than nop
 	svc.setupMetrics()
 
 	if err := svc.setupRuntimeMetricsCollector(svc.Config()); err != nil {

--- a/service/stub_module_test.go
+++ b/service/stub_module_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestStubModule_StartError(t *testing.T) {
-	s := NewStubModule(NullHost())
+	s := NewStubModule(NopHost())
 	s.StartError = errors.New("blargh")
 	readyCh := make(chan struct{}, 1)
 
@@ -36,7 +36,7 @@ func TestStubModule_StartError(t *testing.T) {
 }
 
 func TestStubModule_Accessors(t *testing.T) {
-	s := NewStubModule(NullHost())
+	s := NewStubModule(NopHost())
 	assert := assert.New(t)
 
 	assert.Empty(s.Type())

--- a/service/testutils/README.md
+++ b/service/testutils/README.md
@@ -2,7 +2,7 @@
 
 ## WithService
 
-`WithService` provides a noop service for you to test service lifecycle
+`WithService` provides a nop service for you to test service lifecycle
 functions if you'd like to perform end-to-end testing of your service. This
 generally isn't necessary from a service-owner perspective, but is used
 internally.

--- a/service/testutils/doc.go
+++ b/service/testutils/doc.go
@@ -22,7 +22,7 @@
 //
 // WithService
 //
-// WithService provides a noop service for you to test service lifecycle
+// WithService provides a nop service for you to test service lifecycle
 // functions if you'd like to perform end-to-end testing of your service. This
 // generally isn't necessary from a service-owner perspective, but is used
 // internally.

--- a/testutils/in_memory_log.go
+++ b/testutils/in_memory_log.go
@@ -33,7 +33,7 @@ type TestBuffer struct {
 	bytes.Buffer
 }
 
-// Sync is a noop to conform to zap.WriteSyncer interface
+// Sync is a nop to conform to zap.WriteSyncer interface
 func (b *TestBuffer) Sync() error {
 	return nil
 }

--- a/testutils/metrics.go
+++ b/testutils/metrics.go
@@ -24,15 +24,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NoopCloser is a noop implementation of io.Closer
-type NoopCloser struct{}
+// NopCloser is a nop implementation of io.Closer
+type NopCloser struct{}
 
 // Close implements io.Closer
-func (nc NoopCloser) Close() error {
+func (nc NopCloser) Close() error {
 	return nil
 }
 
-// ErrorCloser is a noop implementation of io.Closer
+// ErrorCloser is a nop implementation of io.Closer
 type ErrorCloser struct{}
 
 // Close implements io.Closer

--- a/ulog/nop_logger.go
+++ b/ulog/nop_logger.go
@@ -22,11 +22,11 @@ package ulog
 
 import "github.com/uber-go/zap"
 
-func noopLogger() Log {
+func nopLogger() Log {
 	return &baseLogger{
 		log: zap.New(zap.NullEncoder()),
 	}
 }
 
-// NoopLogger should be used in tests if you wish to discard the output
-var NoopLogger = noopLogger()
+// NopLogger should be used in tests if you wish to discard the output
+var NopLogger = nopLogger()


### PR DESCRIPTION
```
ulog.NoopLogger -> NopLogger
service.NullHost -> NopHost
auth.NoopClient -> NopClient
testutils.NoopCloser -> NopCloser
```