### PR TITLE
Cleanup and simplify auth.Client initialization

### DIFF
--- a/auth/localauth.go
+++ b/auth/localauth.go
@@ -22,8 +22,6 @@ package auth
 
 import "context"
 
-var _std Client
-
 var _ Client = &defaultClient{}
 
 type defaultClient struct {
@@ -36,11 +34,6 @@ func defaultAuth(info CreateAuthInfo) Client {
 	return &defaultClient{
 		authClient: NopClient,
 	}
-}
-
-// Instance returns initialized instance of auth client
-func Instance() Client {
-	return _std
 }
 
 func (*defaultClient) Name() string {

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -63,26 +63,21 @@ func RegisterClient(registerFunc RegisterFunc) {
 	_registerFunc = registerFunc
 }
 
-// UnregisterClient unregisters auth RegisterFunc for testing and resets to nopClient
+// UnregisterClient unregisters auth RegisterFunc for testing
 func UnregisterClient() {
 	_setupMu.Lock()
 	defer _setupMu.Unlock()
 	_registerFunc = nil
-	_std = nil
 }
 
-// SetupClient creates a Client instance based on registered auth client implementation
-func SetupClient(info CreateAuthInfo) {
+// Load returns a Client instance based on registered auth client implementation
+func Load(info CreateAuthInfo) Client {
 	_setupMu.Lock()
 	defer _setupMu.Unlock()
-	if _std != nil {
-		return
-	}
 	if _registerFunc != nil {
-		_std = _registerFunc(info)
-	} else {
-		_std = NopClient
+		return _registerFunc(info)
 	}
+	return NopClient
 }
 
 // Client is an interface to perform authorization and authentication

--- a/auth/uauth_test.go
+++ b/auth/uauth_test.go
@@ -34,14 +34,12 @@ import (
 func withAuthClientSetup(t *testing.T, registerFunc RegisterFunc, info CreateAuthInfo, fn func()) {
 	UnregisterClient()
 	RegisterClient(registerFunc)
-	SetupClient(info)
 	fn()
 }
 
 func TestUauth_Stub(t *testing.T) {
 	RegisterClient(defaultAuth)
-	SetupClient(nil)
-	authClient := Instance()
+	authClient := Load(fakeAuthInfo{})
 	assert.Equal(t, "auth", authClient.Name())
 	assert.NotNil(t, authClient)
 	assert.Nil(t, authClient.Authorize(context.Background()))
@@ -54,7 +52,7 @@ func TestUauth_Stub(t *testing.T) {
 
 func TestUauth_Register(t *testing.T) {
 	withAuthClientSetup(t, FakeFailureClient, fakeAuthInfo{}, func() {
-		authClient := Instance()
+		authClient := Load(fakeAuthInfo{})
 		assert.Equal(t, "failure", authClient.Name())
 		assert.NotNil(t, authClient)
 		err := authClient.Authorize(context.Background())
@@ -77,7 +75,7 @@ func TestUauth_RegisterPanic(t *testing.T) {
 
 func TestUauth_Default(t *testing.T) {
 	withAuthClientSetup(t, nil, fakeAuthInfo{}, func() {
-		assert.Equal(t, "nop", Instance().Name())
+		assert.Equal(t, "nop", Load(fakeAuthInfo{}).Name())
 	})
 }
 

--- a/modules/rpc/handler.go
+++ b/modules/rpc/handler.go
@@ -126,8 +126,7 @@ func authorize(ctx context.Context, host service.Host) (fx.Context, error) {
 	fxctx := &fxcontext.Context{
 		Context: ctx,
 	}
-	authClient := auth.Instance()
-	if err := authClient.Authorize(fxctx); err != nil {
+	if err := host.AuthClient().Authorize(fxctx); err != nil {
 		host.Metrics().SubScope("rpc").SubScope("auth").Counter("fail").Inc(1)
 		fxctx.Logger().Error(auth.ErrAuthorization, "error", err)
 		// TODO(anup): GFM-255 update returned error to transport.BadRequestError (user error than server error)

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -61,6 +61,7 @@ func New(info auth.CreateAuthInfo, client *http.Client, filters ...Filter) *Clie
 func (c *Client) Do(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
 	filters := c.filters
 	if c.defaultFiltersAdded == false {
+		// TODO(anup): GFM-289 Update uhttp client to not return exported struct
 		filters = append(filters, tracingFilter(), authenticationFilter(c.info))
 		c.defaultFiltersAdded = true
 	}

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"go.uber.org/fx"
+	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -39,16 +40,18 @@ var (
 // Client wraps around a http client
 type Client struct {
 	*http.Client
+	info                auth.CreateAuthInfo
 	filters             []Filter
 	defaultFiltersAdded bool
 }
 
 // New creates a new instance of uhttp Client
-func New(cfg config.Provider, client *http.Client, filters ...Filter) *Client {
-	_serviceName = cfg.Get(config.ApplicationIDKey).AsString()
-	filters = append(filters, FilterFunc(tracingFilter), FilterFunc(authenticationFilter))
+func New(info auth.CreateAuthInfo, client *http.Client, filters ...Filter) *Client {
+	_serviceName = info.Config().Get(config.ApplicationIDKey).AsString()
+	filters = append(filters, tracingFilter(), authenticationFilter(info))
 	return &Client{
 		Client:              client,
+		info:                info,
 		filters:             filters,
 		defaultFiltersAdded: true,
 	}
@@ -58,7 +61,7 @@ func New(cfg config.Provider, client *http.Client, filters ...Filter) *Client {
 func (c *Client) Do(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
 	filters := c.filters
 	if c.defaultFiltersAdded == false {
-		filters = append(filters, FilterFunc(tracingFilter), FilterFunc(authenticationFilter))
+		filters = append(filters, tracingFilter(), authenticationFilter(c.info))
 		c.defaultFiltersAdded = true
 	}
 	execChain := newExecutionChain(filters, BasicClientFunc(c.do))

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -27,8 +27,6 @@ import (
 	"time"
 
 	"go.uber.org/fx"
-	"go.uber.org/fx/auth"
-	"go.uber.org/fx/config"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,17 +36,17 @@ applicationID: test
 `)
 
 var _defaultHTTPClient = &http.Client{Timeout: 2 * time.Second}
-var _defaultUHTTPClient = New(config.NewYAMLProviderFromBytes(testYaml), _defaultHTTPClient)
+var _defaultUHTTPClient = New(fakeAuthInfo{yaml: testYaml}, _defaultHTTPClient)
 
 func TestNew(t *testing.T) {
-	uhttpClient := New(config.NewYAMLProviderFromBytes(testYaml), _defaultHTTPClient)
+	uhttpClient := New(fakeAuthInfo{yaml: testYaml}, _defaultHTTPClient)
 	assert.Equal(t, _defaultHTTPClient, uhttpClient.Client)
 	assert.Equal(t, 2, len(uhttpClient.filters))
 }
 
 func TestNew_Panic(t *testing.T) {
 	assert.Panics(t, func() {
-		New(config.NewYAMLProviderFromBytes([]byte(``)), _defaultHTTPClient)
+		New(fakeAuthInfo{yaml: []byte(``)}, _defaultHTTPClient)
 	})
 }
 
@@ -120,7 +118,6 @@ func checkOKResponse(t *testing.T, resp *http.Response, err error) {
 }
 
 func startServer() *httptest.Server {
-	auth.SetupClient(nil)
 	return httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 }
 

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -88,7 +88,7 @@ func authorizationFilter(host service.Host) FilterFunc {
 			Context: ctx,
 		}
 
-		if err := auth.Instance().Authorize(fxctx); err != nil {
+		if err := host.AuthClient().Authorize(fxctx); err != nil {
 			host.Metrics().SubScope("http").SubScope("auth").Counter("fail").Inc(1)
 			fxctx.Logger().Error(auth.ErrAuthorization, "error", err)
 			w.WriteHeader(http.StatusUnauthorized)

--- a/service/host_mock_test.go
+++ b/service/host_mock_test.go
@@ -30,3 +30,9 @@ func TestNopHost_OK(t *testing.T) {
 	sh := NopHost()
 	assert.Equal(t, "dummy", sh.Name())
 }
+
+func TestNopHost_AuthFailures(t *testing.T) {
+	sh := NopHostAuthFailure()
+	assert.Equal(t, "dummy", sh.Name())
+	assert.Equal(t, "failure", sh.AuthClient().Name())
+}

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -117,6 +117,5 @@ func (svc *serviceCore) setupAuthClient(cfg config.Provider) {
 	if svc.authClient != nil {
 		return
 	}
-	auth.SetupClient(svc)
-	svc.authClient = auth.Instance()
+	svc.authClient = auth.Load(svc)
 }


### PR DESCRIPTION
auth.Instance() global instance is harder to manage in code, and more so in tests. 
I removed any instance of auth.Instance() usage, and pull `auth.Client` from the service host itself. 
For tests, we can now use `host.NopHost()` for simple nop auth, and `host.NopHostAuthFailure()` to invoke auth failures.