### PR TITLE
Hold on to http.Server in prep for graceful shutdown

### DIFF
--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -198,11 +198,10 @@ func (m *Module) Start(ready chan<- struct{}) <-chan error {
 	go func() {
 		listener := m.accessListener()
 		ready <- struct{}{}
-		if err := m.srv.Serve(listener); err != nil {
+		err := m.srv.Serve(listener)
+		ret <- err
+		if err != nil {
 			m.log.Error("HTTP Serve error", "error", err)
-			ret <- err
-		} else {
-			ret <- nil
 		}
 	}()
 	return ret


### PR DESCRIPTION
In Go 1.8, we'll be able to call Shutdown(ctx) on the *http.Server
object.

Also fix a minor issue in error handling.