### PR TITLE
Use custom RoundTripper interface for http.Client

### DIFF
--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -21,20 +21,20 @@
 package client
 
 import (
-	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"go.uber.org/fx"
 	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 
 	"golang.org/x/net/context/ctxhttp"
+	"sync"
 )
 
 var (
-	_serviceName string
+	_serviceName   string
+	_uFilters      sync.Mutex
+	_filterTripper filterTripper
 )
 
 // Client wraps around a http client
@@ -43,6 +43,27 @@ type Client struct {
 	info                auth.CreateAuthInfo
 	filters             []Filter
 	defaultFiltersAdded bool
+}
+
+type filterTripper struct {
+	oldTripper http.RoundTripper
+	chain      executionChain
+}
+
+// UpdateDefaultFilters updates filters for the default RoundTripper
+func UpdateDefaultFilters(filters ...Filter) {
+	_uFilters.Lock()
+	_filterTripper.chain = newExecutionChain(filters, _filterTripper.oldTripper)
+	_uFilters.Unlock()
+}
+
+func (t *filterTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	return t.oldTripper.RoundTrip(req)
+}
+
+func init() {
+	http.DefaultTransport = &filterTripper{oldTripper: http.DefaultTransport}
 }
 
 // New creates a new instance of uhttp Client
@@ -57,79 +78,14 @@ func New(info auth.CreateAuthInfo, client *http.Client, filters ...Filter) *Clie
 	}
 }
 
-// Do is a context-aware, filter-enabled extension of Do() in http.Client
-func (c *Client) Do(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
-	filters := c.filters
-	if c.defaultFiltersAdded == false {
-		// TODO(anup): GFM-289 Update uhttp client to not return exported struct
-		filters = append(filters, tracingFilter(), authenticationFilter(c.info))
-		c.defaultFiltersAdded = true
-	}
-	execChain := newExecutionChain(filters, BasicClientFunc(c.do))
-	return execChain.Do(ctx, req)
-}
-
 func (c *Client) do(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
 	return ctxhttp.Do(ctx, c.Client, req)
-}
-
-// Get is a context-aware, filter-enabled extension of Get() in http.Client
-func (c *Client) Get(ctx fx.Context, url string) (resp *http.Response, err error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Do(ctx, req)
-}
-
-// Post is a context-aware, filter-enabled extension of Post() in http.Client
-func (c *Client) Post(
-	ctx fx.Context,
-	url string,
-	bodyType string,
-	body io.Reader,
-) (resp *http.Response, err error) {
-	req, err := http.NewRequest("POST", url, body)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", bodyType)
-	return c.Do(ctx, req)
-}
-
-// PostForm is a context-aware, filter-enabled extension of PostForm() in http.Client
-func (c *Client) PostForm(
-	ctx fx.Context,
-	url string,
-	data url.Values,
-) (resp *http.Response, err error) {
-	return c.Post(ctx, url, "application/x-www-form-urlencoded",
-		strings.NewReader(data.Encode()))
-}
-
-// Head is a context-aware, filter-enabled extension of Head() in http.Client
-func (c *Client) Head(ctx fx.Context, url string) (resp *http.Response, err error) {
-	req, err := http.NewRequest("HEAD", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	return c.Do(ctx, req)
-}
-
-// BasicClient is the simplest, context-aware HTTP client with a single method Do.
-type BasicClient interface {
-	// Do sends an HTTP request and returns an HTTP response, following
-	// policy (e.g. redirects, cookies, auth) as configured on the client.
-	Do(ctx fx.Context, req *http.Request) (resp *http.Response, err error)
 }
 
 // The BasicClientFunc type is an adapter to allow the use of ordinary functions as BasicClient.
 type BasicClientFunc func(ctx fx.Context, req *http.Request) (resp *http.Response, err error)
 
-// Do implements Do from the BasicClient interface
-func (f BasicClientFunc) Do(
-	ctx fx.Context, req *http.Request,
-) (resp *http.Response, err error) {
-	return f(ctx, req)
+// RoundTrip implements RoundTrip from the http.RoundTripper interface
+func (f BasicClientFunc) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	return f(req.Context().(fx.Context), req)
 }

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"go.uber.org/fx"
+	"go.uber.org/fx/internal/fxcontext"
 )
 
 var (
@@ -58,5 +59,5 @@ type BasicClientFunc func(ctx fx.Context, req *http.Request) (resp *http.Respons
 
 // RoundTrip implements RoundTrip from the http.RoundTripper interface
 func (f BasicClientFunc) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	return f(req.Context().(fx.Context), req)
+	return f(fxcontext.Context{Context:req.Context()}, req)
 }

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -25,6 +25,7 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/fx/auth"
+	"go.uber.org/fx/config"
 	"go.uber.org/fx/internal/fxcontext"
 
 	"fmt"
@@ -86,7 +87,7 @@ func authenticationFilter(info auth.CreateAuthInfo) FilterFunc {
 	return func(ctx fx.Context, req *http.Request, next http.RoundTripper,
 	) (resp *http.Response, err error) {
 		// Client needs to know what service it is to authenticate
-		authctx := authClient.SetAttribute(ctx, auth.ServiceAuth, _serviceName)
+		authctx := authClient.SetAttribute(ctx, auth.ServiceAuth, ctx.Value(config.ApplicationIDKey).(string))
 
 		authctx, err = authClient.Authenticate(authctx)
 		if err != nil {

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -38,7 +38,7 @@ type Executor interface {
 }
 
 // Filter applies filters on client requests and request's context such as
-// adding tracing to the context. Filters must call next.Send() at most once, calling it twice and more
+// adding tracing to the context. Filters must call next.Execute() at most once, calling it twice and more
 // will lead to an undefined behavior
 type Filter interface {
 	Apply(ctx fx.Context, r *http.Request, next Executor) (resp *http.Response, err error)

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -37,7 +37,7 @@ type Executor interface {
 	Execute(ctx fx.Context, r *http.Request) (resp *http.Response, err error)
 }
 
-// The SenderFunc type is an adapter to allow the use of ordinary functions as Executor
+// The ExecutorFunc type is an adapter to allow the use of ordinary functions as Executor
 type ExecutorFunc func(ctx fx.Context, req *http.Request) (resp *http.Response, err error)
 
 // Execute implements Executor interface for the SenderFunc

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -37,14 +37,6 @@ type Executor interface {
 	Execute(ctx fx.Context, r *http.Request) (resp *http.Response, err error)
 }
 
-// The ExecutorFunc type is an adapter to allow the use of ordinary functions as Executor
-type ExecutorFunc func(ctx fx.Context, req *http.Request) (resp *http.Response, err error)
-
-// Execute implements Executor interface for the SenderFunc
-func (f ExecutorFunc) Execute(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
-	return f(ctx, req)
-}
-
 // Filter applies filters on client requests and request's context such as
 // adding tracing to the context. Filters must call next.Send() at most once, calling it twice and more
 // will lead to an undefined behavior

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -28,31 +28,45 @@ import (
 	"go.uber.org/fx/config"
 	"go.uber.org/fx/internal/fxcontext"
 
-	"fmt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// Filter applies filters on client requests, request contexts such as
-// adding tracing to the context
+// Sender sends the http request. It is a simple wrapper around http.RoundTripper, so
+// Send must be safe to use by multiple go routines
+type Sender interface {
+	Send(ctx fx.Context, r *http.Request) (resp *http.Response, err error)
+}
+
+// The SenderFunc type is an adapter to allow the use of ordinary functions as Sender
+type SenderFunc func(ctx fx.Context, req *http.Request) (resp *http.Response, err error)
+
+// Send implements Sender interface for the SenderFunc
+func (f SenderFunc) Send(ctx fx.Context, req *http.Request) (resp *http.Response, err error) {
+	return f(ctx, req)
+}
+
+// Filter applies filters on client requests and request's context such as
+// adding tracing to the context. Filters must call next.Send() at most once, calling it twice and more
+// will lead to an undefined behavior
 type Filter interface {
-	Apply(ctx fx.Context, r *http.Request, next http.RoundTripper) (resp *http.Response, err error)
+	Apply(ctx fx.Context, r *http.Request, next Sender) (resp *http.Response, err error)
 }
 
 // FilterFunc is an adaptor to call normal functions to apply filters
 type FilterFunc func(
-	ctx fx.Context, r *http.Request, next http.RoundTripper,
+	ctx fx.Context, r *http.Request, next Sender,
 ) (resp *http.Response, err error)
 
 // Apply implements Apply from the Filter interface and simply delegates to the function
 func (f FilterFunc) Apply(
-	ctx fx.Context, r *http.Request, next http.RoundTripper,
+	ctx fx.Context, r *http.Request, next Sender,
 ) (resp *http.Response, err error) {
 	return f(ctx, r, next)
 }
 
 func tracingFilter() FilterFunc {
-	return func(ctx fx.Context, req *http.Request, next http.RoundTripper,
+	return func(ctx fx.Context, req *http.Request, next Sender,
 	) (resp *http.Response, err error) {
 		opName := req.Method
 		var parent opentracing.SpanContext
@@ -71,7 +85,7 @@ func tracingFilter() FilterFunc {
 			return nil, err
 		}
 
-		resp, err = next.RoundTrip(req)
+		resp, err = next.Send(ctx, req)
 		if resp != nil {
 			span.SetTag("http.status_code", resp.StatusCode)
 		}
@@ -82,28 +96,32 @@ func tracingFilter() FilterFunc {
 	}
 }
 
+// authenticationFilter on client side calls authenticate, and gets a claim that client is who they say they are
+// We only authorize with the claim on server side
 func authenticationFilter(info auth.CreateAuthInfo) FilterFunc {
 	authClient := auth.Load(info)
-	return func(ctx fx.Context, req *http.Request, next http.RoundTripper,
+	serviceName := info.Config().Get(config.ApplicationIDKey).AsString()
+	return func(ctx fx.Context, req *http.Request, next Sender,
 	) (resp *http.Response, err error) {
 		// Client needs to know what service it is to authenticate
-		authctx := authClient.SetAttribute(ctx, auth.ServiceAuth, ctx.Value(config.ApplicationIDKey).(string))
+		authCtx := authClient.SetAttribute(ctx, auth.ServiceAuth, serviceName)
 
-		authctx, err = authClient.Authenticate(authctx)
+		authCtx, err = authClient.Authenticate(authCtx)
 		if err != nil {
 			ctx.Logger().Error(auth.ErrAuthentication, "error", err)
 			return nil, err
 		}
 
-		span := opentracing.SpanFromContext(authctx)
+		span := opentracing.SpanFromContext(authCtx)
 		if err := injectSpanIntoHeaders(req.Header, span); err != nil {
 			ctx.Logger().Error("Error injecting auth context", "error", err)
 			return nil, err
 		}
 
-		return next.RoundTrip(req.WithContext(authctx))
+		return next.Send(&fxcontext.Context{Context: authCtx}, req)
 	}
 }
+
 func injectSpanIntoHeaders(header http.Header, span opentracing.Span) error {
 	carrier := opentracing.HTTPHeadersCarrier(header)
 	if err := span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier); err != nil {
@@ -111,34 +129,4 @@ func injectSpanIntoHeaders(header http.Header, span opentracing.Span) error {
 		return err
 	}
 	return nil
-}
-
-func newExecutionChain(
-	filters []Filter, finalClient http.RoundTripper,
-) executionChain {
-	return executionChain{
-		filters:     filters,
-		finalClient: finalClient,
-	}
-}
-
-type executionChain struct {
-	currentFilter int
-	filters       []Filter
-	finalClient   http.RoundTripper
-}
-
-func (ec *executionChain) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	if ec.currentFilter < len(ec.filters) {
-		filter := ec.filters[ec.currentFilter]
-		ec.currentFilter++
-
-		if ctx, ok := req.Context().(fx.Context); ok {
-			return filter.Apply(ctx, req, ec)
-		}
-
-		return nil, fmt.Errorf("Expected fx.Context, but received: %T", req.Context())
-	}
-
-	return ec.finalClient.RoundTrip(req)
 }

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -80,7 +80,6 @@ func withOpentracingSetup(t *testing.T, registerFunc auth.RegisterFunc, fn func(
 	assert.NotNil(t, closer)
 	require.NoError(t, err)
 
-	_serviceName = "test_service"
 	auth.UnregisterClient()
 	defer auth.UnregisterClient()
 	auth.RegisterClient(registerFunc)
@@ -93,7 +92,7 @@ func TestExecutionChainFilters_AuthContextPropagation(t *testing.T) {
 			[]Filter{authenticationFilter(fakeAuthInfo{})}, getContextPropogationClient(t),
 		)
 		span := tracer.StartSpan("test_method")
-		span.SetBaggageItem(auth.ServiceAuth, _serviceName)
+		span.SetBaggageItem(auth.ServiceAuth, "test_service")
 		ctx := &fxcontext.Context{
 			Context: opentracing.ContextWithSpan(context.Background(), span),
 		}

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/fx"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +34,6 @@ applicationID: test
 `)
 
 var _defaultHTTPClient = &http.Client{Timeout: 2 * time.Second}
-var _defaultUHTTPClient = New(fakeAuthInfo{yaml: testYaml}, _defaultHTTPClient)
 
 func TestNew(t *testing.T) {
 	uhttpClient := New(fakeAuthInfo{yaml: testYaml}, _defaultHTTPClient)
@@ -53,58 +50,41 @@ func TestNew_Panic(t *testing.T) {
 func TestClientDo(t *testing.T) {
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
-	resp, err := _defaultUHTTPClient.Do(fx.NopContext, req)
+	cl := http.Client{Timeout: 2 * time.Second}
+	resp, err := cl.Do(req)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientDoWithoutFilters(t *testing.T) {
-	uhttpClient := &Client{Client: _defaultHTTPClient}
+	uhttpClient := http.Client{Timeout: 2 * time.Second}
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
-	resp, err := uhttpClient.Do(fx.NopContext, req)
+	resp, err := uhttpClient.Do(req)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientGet(t *testing.T) {
 	svr := startServer()
-	resp, err := _defaultUHTTPClient.Get(fx.NopContext, svr.URL)
+	resp, err := _defaultHTTPClient.Get(svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientGetError(t *testing.T) {
 	// Causing newRequest to fail, % does not parse as URL
-	resp, err := _defaultUHTTPClient.Get(fx.NopContext, "%")
+	resp, err := _defaultHTTPClient.Get("%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientHead(t *testing.T) {
 	svr := startServer()
-	resp, err := _defaultUHTTPClient.Head(fx.NopContext, svr.URL)
+	resp, err := _defaultHTTPClient.Head(svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientHeadError(t *testing.T) {
 	// Causing newRequest to fail, % does not parse as URL
-	resp, err := _defaultUHTTPClient.Head(fx.NopContext, "%")
+	resp, err := _defaultHTTPClient.Head("%")
 	checkErrResponse(t, resp, err)
-}
-
-func TestClientPost(t *testing.T) {
-	svr := startServer()
-	resp, err := _defaultUHTTPClient.Post(fx.NopContext, svr.URL, "", nil)
-	checkOKResponse(t, resp, err)
-}
-
-func TestClientPostError(t *testing.T) {
-	resp, err := _defaultUHTTPClient.Post(fx.NopContext, "%", "", nil)
-	checkErrResponse(t, resp, err)
-}
-
-func TestClientPostForm(t *testing.T) {
-	svr := startServer()
-	var urlValues map[string][]string
-	resp, err := _defaultUHTTPClient.PostForm(fx.NopContext, svr.URL, urlValues)
-	checkOKResponse(t, resp, err)
 }
 
 func checkErrResponse(t *testing.T, resp *http.Response, err error) {


### PR DESCRIPTION
uhttp client is implemented as a custom struct right now and users have to to create it with New, provide an http.Client, there are also some thread safety issues.

http.Client is actually a high level facade and uses Transport to send requests, so we can provide a custom implementation of http.RoundTripper interface and filter requests before it will be send by an actual transport.