### PR TITLE
Allow int and floats when config values are fetched as float64

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -206,6 +206,22 @@ func TestGetAsIntegerValue(t *testing.T) {
 	}
 }
 
+func TestGetAsFloatValue(t *testing.T) {
+	testCases := []struct {
+		value interface{}
+	}{
+		{float32(2)},
+		{float64(2)},
+		{int(2)},
+		{int32(2)},
+		{int64(2)},
+	}
+	for _, tc := range testCases {
+		cv := NewValue(NewStaticProvider(nil), "key", tc.value, true, Float, nil)
+		assert.Equal(t, float64(2), cv.AsFloat())
+	}
+}
+
 func TestNestedStructs(t *testing.T) {
 	provider := NewProviderGroup(
 		"test",

--- a/config/value.go
+++ b/config/value.go
@@ -49,9 +49,13 @@ const (
 	Slice
 	// Dictionary contains words and their definitions
 	Dictionary
+	// Zero constants
+	_float64Zero = float64(0)
 )
 
-var _typeTimeDuration = reflect.TypeOf(time.Duration(0))
+var (
+	_typeTimeDuration = reflect.TypeOf(time.Duration(0))
+)
 
 // GetType returns GO type of the provided object
 func GetType(value interface{}) ValueType {
@@ -201,9 +205,8 @@ func (cv Value) TryAsBool() (bool, bool) {
 
 // TryAsFloat attempts to return the configuration value as a float
 func (cv Value) TryAsFloat() (float64, bool) {
-	f := float64(0)
 	v := cv.Value()
-	if val, err := convertValue(v, reflect.TypeOf(f)); v != nil && err == nil {
+	if val, err := convertValue(v, reflect.TypeOf(_float64Zero)); v != nil && err == nil {
 		return val.(float64), true
 	}
 	switch val := v.(type) {
@@ -216,7 +219,7 @@ func (cv Value) TryAsFloat() (float64, bool) {
 	case float32:
 		return float64(val), true
 	default:
-		return f, false
+		return _float64Zero, false
 	}
 }
 

--- a/config/value.go
+++ b/config/value.go
@@ -206,7 +206,18 @@ func (cv Value) TryAsFloat() (float64, bool) {
 	if val, err := convertValue(v, reflect.TypeOf(f)); v != nil && err == nil {
 		return val.(float64), true
 	}
-	return f, false
+	switch val := v.(type) {
+	case int:
+		return float64(val), true
+	case int32:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case float32:
+		return float64(val), true
+	default:
+		return f, false
+	}
 }
 
 // AsString returns the configuration value as a string, or panics if not

--- a/config/value.go
+++ b/config/value.go
@@ -53,9 +53,7 @@ const (
 	_float64Zero = float64(0)
 )
 
-var (
-	_typeTimeDuration = reflect.TypeOf(time.Duration(0))
-)
+var _typeTimeDuration = reflect.TypeOf(time.Duration(0))
 
 // GetType returns GO type of the provided object
 func GetType(value interface{}) ValueType {


### PR DESCRIPTION
Wish there was a better way than switch statements but oh well.. Copying this format from TryAsInt