### PR TITLE
Automatically emits metrics with log counts by level

### DIFF
--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -1,8 +1,15 @@
 .PHONY: libdeps
 libdeps:
 	@$(call label,Installing Glide and locked dependencies...)
-	$(ECHO_V)glide --version 2>/dev/null || go get -u -f github.com/Masterminds/glide
+	$(ECHO_V)glide --version 2>/dev/null ||	$(MAKE) getglide
 	$(ECHO_V)glide install
+
+# Temporarily work around glide master issues to installing specific tag
+.PHONY: getglide
+getglide:
+	go get -v github.com/Masterminds/glide
+	cd $(GOPATH)/src/github.com/Masterminds/glide && git checkout tags/v0.12.3 && go install && cd -
+
 
 .PHONY: dependencies
 dependencies: libdeps

--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -1,15 +1,8 @@
 .PHONY: libdeps
 libdeps:
 	@$(call label,Installing Glide and locked dependencies...)
-	$(ECHO_V)glide --version 2>/dev/null ||	$(MAKE) getglide
+	$(ECHO_V)glide --version 2>/dev/null ||	go get -v github.com/Masterminds/glide
 	$(ECHO_V)glide install
-
-# Temporarily work around glide master issues to installing specific tag
-.PHONY: getglide
-getglide:
-	go get -v github.com/Masterminds/glide
-	cd $(GOPATH)/src/github.com/Masterminds/glide && git checkout tags/v0.12.3 && go install && cd -
-
 
 .PHONY: dependencies
 dependencies: libdeps

--- a/config/config.go
+++ b/config/config.go
@@ -25,8 +25,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-
-	"github.com/uber-go/tally"
 )
 
 const (

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/uber-go/tally"
 )
 
 const (

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -81,7 +81,7 @@ func RegisterRootScope(scopeFunc ScopeFunc) {
 
 	if _scopeFunc != nil {
 		// TODO(glib): consider a "force" flag, or some way to clear out and replace the reporter
-		panic("There can be only one metrics reporter")
+		panic("There can be only one metrics root scope")
 	}
 
 	_scopeFunc = scopeFunc

--- a/service/service.go
+++ b/service/service.go
@@ -114,6 +114,11 @@ func New(options ...Option) (Owner, error) {
 		svc.configProvider = config.Load()
 	}
 
+	// load standard config
+	if err := svc.setupStandardConfig(); err != nil {
+		return nil, err
+	}
+
 	// Initialize metrics. If no metrics reporters were Registered, do nop
 	// TODO(glib): add a logging reporter and use it by default, rather than nop
 	svc.setupMetrics()
@@ -121,11 +126,6 @@ func New(options ...Option) (Owner, error) {
 	svc.setupLogging()
 
 	svc.setupAuthClient()
-
-	// load standard config
-	if err := svc.setupStandardConfig(); err != nil {
-		return nil, err
-	}
 
 	if err := svc.setupRuntimeMetricsCollector(); err != nil {
 		return nil, err

--- a/service/service.go
+++ b/service/service.go
@@ -114,30 +114,30 @@ func New(options ...Option) (Owner, error) {
 		svc.configProvider = config.Load()
 	}
 
-	svc.setupLogging(svc.configProvider)
-
-	svc.setupAuthClient(svc.configProvider)
-
-	// load standard config
-	if err := svc.setupStandardConfig(svc.Config()); err != nil {
-		return nil, err
-	}
-
 	// Initialize metrics. If no metrics reporters were Registered, do nop
 	// TODO(glib): add a logging reporter and use it by default, rather than nop
 	svc.setupMetrics()
 
-	if err := svc.setupRuntimeMetricsCollector(svc.Config()); err != nil {
+	svc.setupLogging()
+
+	svc.setupAuthClient()
+
+	// load standard config
+	if err := svc.setupStandardConfig(); err != nil {
 		return nil, err
 	}
 
-	if err := svc.setupTracer(svc.Config()); err != nil {
+	if err := svc.setupRuntimeMetricsCollector(); err != nil {
+		return nil, err
+	}
+
+	if err := svc.setupTracer(); err != nil {
 		return nil, err
 	}
 
 	// if we have an observer, look for a property called "config" and load the service
 	// node into that config.
-	svc.setupObserver(svc.Config())
+	svc.setupObserver()
 
 	// Put service into Initialized state
 	svc.transitionState(Initialized)

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -35,13 +35,12 @@ import (
 
 func (svc *serviceCore) setupLogging() {
 	if svc.log == nil {
-		logBuilder := ulog.Builder().WithScope(svc.metrics)
-
 		err := svc.configProvider.Get("logging").PopulateStruct(&svc.logConfig)
 		if err != nil {
 			ulog.Logger().Info("Logging configuration is not provided, setting to default logger", "error", err)
 		}
 
+		logBuilder := ulog.Builder().WithScope(svc.metrics)
 		svc.log = logBuilder.WithConfiguration(svc.logConfig).Build()
 	} else {
 		svc.log.Debug("Using custom log provider due to service.WithLogger option")

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -33,7 +33,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (svc *serviceCore) setupLogging(cfg config.Provider) {
+func (svc *serviceCore) setupLogging() {
 	if svc.log == nil {
 		logBuilder := ulog.Builder()
 		// load and configure logging
@@ -47,8 +47,8 @@ func (svc *serviceCore) setupLogging(cfg config.Provider) {
 	}
 }
 
-func (svc *serviceCore) setupStandardConfig(cfg config.Provider) error {
-	if err := cfg.Get(config.Root).PopulateStruct(&svc.standardConfig); err != nil {
+func (svc *serviceCore) setupStandardConfig() error {
+	if err := svc.configProvider.Get(config.Root).PopulateStruct(&svc.standardConfig); err != nil {
 		return errors.Wrap(err, "unable to load standard configuration")
 	}
 
@@ -66,13 +66,13 @@ func (svc *serviceCore) setupMetrics() {
 	}
 }
 
-func (svc *serviceCore) setupRuntimeMetricsCollector(cfg config.Provider) error {
+func (svc *serviceCore) setupRuntimeMetricsCollector() error {
 	if svc.RuntimeMetricsCollector() != nil {
 		return nil
 	}
 
 	var runtimeMetricsConfig metrics.RuntimeConfig
-	err := cfg.Get("metrics.runtime").PopulateStruct(&runtimeMetricsConfig)
+	err := svc.configProvider.Get("metrics.runtime").PopulateStruct(&runtimeMetricsConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to load runtime metrics configuration")
 	}
@@ -82,11 +82,11 @@ func (svc *serviceCore) setupRuntimeMetricsCollector(cfg config.Provider) error 
 	return nil
 }
 
-func (svc *serviceCore) setupTracer(cfg config.Provider) error {
+func (svc *serviceCore) setupTracer() error {
 	if svc.Tracer() != nil {
 		return nil
 	}
-	if err := cfg.Get("tracing").PopulateStruct(&svc.tracerConfig); err != nil {
+	if err := svc.configProvider.Get("tracing").PopulateStruct(&svc.tracerConfig); err != nil {
 		return errors.Wrap(err, "unable to load tracing configuration")
 	}
 	tracer, closer, err := tracing.InitGlobalTracer(
@@ -103,7 +103,7 @@ func (svc *serviceCore) setupTracer(cfg config.Provider) error {
 	return nil
 }
 
-func (svc *serviceCore) setupObserver(cfg config.Provider) {
+func (svc *serviceCore) setupObserver() {
 	if svc.observer != nil {
 		loadInstanceConfig(svc.configProvider, "service", svc.observer)
 
@@ -113,7 +113,7 @@ func (svc *serviceCore) setupObserver(cfg config.Provider) {
 	}
 }
 
-func (svc *serviceCore) setupAuthClient(cfg config.Provider) {
+func (svc *serviceCore) setupAuthClient() {
 	if svc.authClient != nil {
 		return
 	}

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -35,12 +35,13 @@ import (
 
 func (svc *serviceCore) setupLogging() {
 	if svc.log == nil {
-		logBuilder := ulog.Builder()
-		// load and configure logging
+		logBuilder := ulog.Builder().WithScope(svc.metrics)
+
 		err := svc.configProvider.Get("logging").PopulateStruct(&svc.logConfig)
 		if err != nil {
 			ulog.Logger().Info("Logging configuration is not provided, setting to default logger", "error", err)
 		}
+
 		svc.log = logBuilder.WithConfiguration(svc.logConfig).Build()
 	} else {
 		svc.log.Debug("Using custom log provider due to service.WithLogger option")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestServiceCreation(t *testing.T) {
 	r := metrics.NewTestStatsReporter()
-	r.Cw.Add(1)
+	r.CountersWG.Add(1)
 	scope, closer := tally.NewRootScope("", nil, r, 50*time.Millisecond)
 	defer closer.Close()
 	svc, err := New(
@@ -44,7 +44,7 @@ func TestServiceCreation(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.NotNil(t, svc, "Service should be created")
-	r.Cw.Wait()
+	r.CountersWG.Wait()
 
 	assert.Equal(t, r.Counters["boot"], int64(1))
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/uber-go/tally"
 )
 
-
 func TestServiceCreation(t *testing.T) {
 	r := metrics.NewTestStatsReporter()
 	r.Cw.Add(1)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -22,67 +22,21 @@ package service
 
 import (
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
 	"go.uber.org/fx/config"
+	"go.uber.org/fx/testutils/metrics"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 )
 
-type testStatsReporter struct {
-	m sync.Mutex
-
-	cw sync.WaitGroup
-	gw sync.WaitGroup
-	tw sync.WaitGroup
-
-	counters map[string]int64
-	gauges   map[string]float64
-	timers   map[string]time.Duration
-}
-
-func (r *testStatsReporter) ReportCounter(name string, tags map[string]string, value int64) {
-	r.m.Lock()
-	r.counters[name] += value
-	r.cw.Done()
-	r.m.Unlock()
-}
-
-func (r *testStatsReporter) ReportGauge(name string, tags map[string]string, value float64) {
-	r.m.Lock()
-	r.gauges[name] = value
-	r.gw.Done()
-	r.m.Unlock()
-}
-
-func (r *testStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
-	r.m.Lock()
-	r.timers[name] = interval
-	r.tw.Done()
-	r.m.Unlock()
-}
-
-func (r *testStatsReporter) Capabilities() tally.Capabilities {
-	return nil
-}
-
-func (r *testStatsReporter) Flush() {}
-
-func newTestStatsReporter() *testStatsReporter {
-	return &testStatsReporter{
-		counters: make(map[string]int64),
-		gauges:   make(map[string]float64),
-		timers:   make(map[string]time.Duration),
-	}
-}
 
 func TestServiceCreation(t *testing.T) {
-	r := newTestStatsReporter()
-	r.cw.Add(1)
+	r := metrics.NewTestStatsReporter()
+	r.Cw.Add(1)
 	scope, closer := tally.NewRootScope("", nil, r, 50*time.Millisecond)
 	defer closer.Close()
 	svc, err := New(
@@ -91,9 +45,9 @@ func TestServiceCreation(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.NotNil(t, svc, "Service should be created")
-	r.cw.Wait()
+	r.Cw.Wait()
 
-	assert.Equal(t, r.counters["boot"], int64(1))
+	assert.Equal(t, r.Counters["boot"], int64(1))
 }
 
 func TestWithObserver_Nil(t *testing.T) {

--- a/testutils/metrics/metrics.go
+++ b/testutils/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/testutils/metrics/metrics.go
+++ b/testutils/metrics/metrics.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/testutils/metrics/metrics.go
+++ b/testutils/metrics/metrics.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+// TestStatsReporter allows for easy testing of any metrics related functionality
+type TestStatsReporter struct {
+	m sync.Mutex
+
+	Cw sync.WaitGroup
+	Gw sync.WaitGroup
+	Tw sync.WaitGroup
+
+	Counters map[string]int64
+	Gauges   map[string]float64
+	Timers   map[string]time.Duration
+}
+
+// ReportCounter collects all the counters into a map
+func (r *TestStatsReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	r.m.Lock()
+	r.Counters[name] += value
+	r.Cw.Done()
+	r.m.Unlock()
+}
+
+// ReportGauge collects all the gauges into a map
+func (r *TestStatsReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	r.m.Lock()
+	r.Gauges[name] = value
+	r.Gw.Done()
+	r.m.Unlock()
+}
+
+
+// ReportTimer collects all the timers into a map
+func (r *TestStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+	r.m.Lock()
+	r.Timers[name] = interval
+	r.Tw.Done()
+	r.m.Unlock()
+}
+
+// Capabilities is a nop in this case
+func (r *TestStatsReporter) Capabilities() tally.Capabilities {
+	return nil
+}
+
+// Flush is a nop
+func (r *TestStatsReporter) Flush() {}
+
+// NewTestStatsReporter returns new instance of test stats reporter
+func NewTestStatsReporter() *TestStatsReporter {
+	return &TestStatsReporter{
+		Counters: make(map[string]int64),
+		Gauges:   make(map[string]float64),
+		Timers:   make(map[string]time.Duration),
+	}
+}
+
+// NewTestScope returns a pair of scope and reporter that can be used for testing
+func NewTestScope() (tally.Scope, *TestStatsReporter) {
+	r := NewTestStatsReporter()
+	scope, _ := tally.NewRootScope("", nil, r, 100*time.Millisecond)
+	return scope, r
+}

--- a/testutils/metrics/metrics.go
+++ b/testutils/metrics/metrics.go
@@ -31,9 +31,9 @@ import (
 type TestStatsReporter struct {
 	m sync.Mutex
 
-	Cw sync.WaitGroup
-	Gw sync.WaitGroup
-	Tw sync.WaitGroup
+	CountersWG sync.WaitGroup
+	GaugesWG   sync.WaitGroup
+	TimersWG   sync.WaitGroup
 
 	Counters map[string]int64
 	Gauges   map[string]float64
@@ -44,7 +44,7 @@ type TestStatsReporter struct {
 func (r *TestStatsReporter) ReportCounter(name string, tags map[string]string, value int64) {
 	r.m.Lock()
 	r.Counters[name] += value
-	r.Cw.Done()
+	r.CountersWG.Done()
 	r.m.Unlock()
 }
 
@@ -52,16 +52,15 @@ func (r *TestStatsReporter) ReportCounter(name string, tags map[string]string, v
 func (r *TestStatsReporter) ReportGauge(name string, tags map[string]string, value float64) {
 	r.m.Lock()
 	r.Gauges[name] = value
-	r.Gw.Done()
+	r.GaugesWG.Done()
 	r.m.Unlock()
 }
-
 
 // ReportTimer collects all the timers into a map
 func (r *TestStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
 	r.m.Lock()
 	r.Timers[name] = interval
-	r.Tw.Done()
+	r.TimersWG.Done()
 	r.m.Unlock()
 }
 

--- a/ulog/builder.go
+++ b/ulog/builder.go
@@ -40,6 +40,9 @@ type Configuration struct {
 	Stdout  bool
 	Verbose bool
 
+	// Do not automatically emit metrics for logging counts
+	DisableMetrics bool
+
 	Sentry *sentry.Configuration
 
 	prefixWithFileLine *bool `yaml:"prefix_with_fileline"`
@@ -161,7 +164,7 @@ func (lb *LogBuilder) Configure() zap.Logger {
 		}
 	}
 
-	if lb.scope != nil {
+	if lb.scope != nil && !lb.logConfig.DisableMetrics {
 		sub := lb.scope.SubScope("logging")
 		options = append(options, metrics.Hook(sub))
 	}

--- a/ulog/builder.go
+++ b/ulog/builder.go
@@ -146,7 +146,16 @@ func (lb *LogBuilder) defaultLogger() zap.Logger {
 // Configure Log object with the provided log.Configuration
 func (lb *LogBuilder) Configure() zap.Logger {
 	lb.log = lb.defaultLogger()
+	options := lb.zapOptions()
 
+	if lb.logConfig.TextFormatter != nil && *lb.logConfig.TextFormatter {
+		return zap.New(zap.NewTextEncoder(), options...)
+	}
+	return zap.New(zap.NewJSONEncoder(), options...)
+}
+
+// Return the list of zap options based on the logger configuration
+func (lb *LogBuilder) zapOptions() []zap.Option {
 	var options []zap.Option
 	if lb.logConfig.Verbose {
 		options = append(options, zap.DebugLevel)
@@ -175,10 +184,7 @@ func (lb *LogBuilder) Configure() zap.Logger {
 		options = append(options, zap.Output(lb.fileOutput(lb.logConfig.File, lb.logConfig.Stdout, lb.logConfig.Verbose)))
 	}
 
-	if lb.logConfig.TextFormatter != nil && *lb.logConfig.TextFormatter {
-		return zap.New(zap.NewTextEncoder(), options...)
-	}
-	return zap.New(zap.NewJSONEncoder(), options...)
+	return options
 }
 
 func (lb *LogBuilder) fileOutput(cfg *FileConfiguration, stdout bool, verbose bool) zap.WriteSyncer {

--- a/ulog/builder.go
+++ b/ulog/builder.go
@@ -26,11 +26,11 @@ import (
 	"path"
 
 	"go.uber.org/fx/config"
-	"go.uber.org/fx/ulog/sentry"
 	"go.uber.org/fx/ulog/metrics"
+	"go.uber.org/fx/ulog/sentry"
 
-	"github.com/uber-go/zap"
 	"github.com/uber-go/tally"
+	"github.com/uber-go/zap"
 )
 
 // Configuration for logging with UberFx
@@ -58,7 +58,7 @@ type LogBuilder struct {
 	log        zap.Logger
 	logConfig  Configuration
 	sentryHook *sentry.Hook
-	scope 		 tally.Scope
+	scope      tally.Scope
 }
 
 // Builder creates an empty builder for building ulog.Log object
@@ -77,7 +77,7 @@ func (lb *LogBuilder) WithConfiguration(logConfig Configuration) *LogBuilder {
 	return lb
 }
 
-// WithConfiguration sets up configuration for the log builder
+// WithScope sets up configuration for the log builder
 func (lb *LogBuilder) WithScope(s tally.Scope) *LogBuilder {
 	lb.scope = s
 	return lb

--- a/ulog/builder_test.go
+++ b/ulog/builder_test.go
@@ -157,9 +157,9 @@ func TestMetricsHook(t *testing.T) {
 	s, r := metrics.NewTestScope()
 	l := Builder().WithScope(s).Build()
 
-	r.Cw.Add(1)
+	r.CountersWG.Add(1)
 	l.Warn("Warning log!")
-	r.Cw.Wait()
+	r.CountersWG.Wait()
 
 	assert.Equal(t, 1, len(r.Counters))
 }

--- a/ulog/builder_test.go
+++ b/ulog/builder_test.go
@@ -164,6 +164,33 @@ func TestMetricsHook(t *testing.T) {
 	assert.Equal(t, 1, len(r.Counters))
 }
 
+func TestLoggingDisabled(t *testing.T) {
+	tests := []struct {
+		res  bool
+		data []byte
+	}{
+		{
+			false,
+			[]byte("logging:\n  lalala: foo"),
+		},
+		{
+			false,
+			[]byte("logging:\n  disableMetrics: false"),
+		},
+		{
+			true,
+			[]byte("logging:\n  disableMetrics: true"),
+		},
+	}
+
+	for _, tt := range tests {
+		logCfg := Configuration{}
+		logYamlCfg := config.NewYAMLProviderFromBytes(tt.data)
+		logYamlCfg.Get("logging").PopulateStruct(&logCfg)
+		assert.Equal(t, tt.res, logCfg.DisableMetrics)
+	}
+}
+
 func testSentry(t *testing.T, dsn string, isValid bool) {
 	withLogger(t, func(builder *LogBuilder, tmpDir string, logFile string) {
 		txt := false

--- a/ulog/metrics/metrics.go
+++ b/ulog/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/ulog/metrics/metrics.go
+++ b/ulog/metrics/metrics.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/ulog/metrics/metrics.go
+++ b/ulog/metrics/metrics.go
@@ -21,8 +21,8 @@
 package metrics
 
 import (
-	"github.com/uber-go/zap"
 	"github.com/uber-go/tally"
+	"github.com/uber-go/zap"
 )
 
 // Hook counts the number of logging messages per level

--- a/ulog/metrics/metrics.go
+++ b/ulog/metrics/metrics.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"github.com/uber-go/zap"
+	"github.com/uber-go/tally"
+)
+
+// Hook counts the number of logging messages per level
+func Hook(s tally.Scope) zap.Hook {
+	return zap.Hook(func(e *zap.Entry) error {
+		// TODO: consider not using .Counter method which does a map lookup
+		// and just create objects for a counter of each type and retain in a struct
+		s.Counter(e.Level.String()).Inc(1)
+		return nil
+	})
+}

--- a/ulog/metrics/metrics.go
+++ b/ulog/metrics/metrics.go
@@ -28,8 +28,10 @@ import (
 // Hook counts the number of logging messages per level
 func Hook(s tally.Scope) zap.Hook {
 	return zap.Hook(func(e *zap.Entry) error {
-		// TODO: consider not using .Counter method which does a map lookup
-		// and just create objects for a counter of each type and retain in a struct
+		// TODO: `.Counter()` method is not necessary here and can be optimized
+		// There is a finite number of counters here: one for each logging level.
+		// If performance per log needs to be optimized this is one of the places
+		// to look. Though it won't save much (estimated ~10ns/call)
 		s.Counter(e.Level.String()).Inc(1)
 		return nil
 	})

--- a/ulog/metrics/metrics.go
+++ b/ulog/metrics/metrics.go
@@ -21,13 +21,23 @@
 package metrics
 
 import (
+	"errors"
+
 	"github.com/uber-go/tally"
 	"github.com/uber-go/zap"
+)
+
+var (
+	errHookNilEntry = errors.New("can't call a hook on a nil *Entry")
 )
 
 // Hook counts the number of logging messages per level
 func Hook(s tally.Scope) zap.Hook {
 	return zap.Hook(func(e *zap.Entry) error {
+		if e == nil {
+			return errHookNilEntry
+		}
+
 		// TODO: `.Counter()` method is not necessary here and can be optimized
 		// There is a finite number of counters here: one for each logging level.
 		// If performance per log needs to be optimized this is one of the places

--- a/ulog/metrics/metrics_test.go
+++ b/ulog/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/ulog/metrics/metrics_test.go
+++ b/ulog/metrics/metrics_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/ulog/metrics/metrics_test.go
+++ b/ulog/metrics/metrics_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/fx/testutils/metrics"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
 	"github.com/uber-go/zap"
 )
 
@@ -47,4 +48,9 @@ func TestSomething(t *testing.T) {
 	assert.Equal(t, 2, len(r.Counters))
 	assert.Equal(t, int64(1), r.Counters["info"])
 	assert.Equal(t, int64(2), r.Counters["error"])
+}
+
+func TestNilEntryHook(t *testing.T) {
+	h := Hook(tally.NoopScope)
+	assert.Error(t, errHookNilEntry, h(nil))
 }

--- a/ulog/metrics/metrics_test.go
+++ b/ulog/metrics/metrics_test.go
@@ -1,0 +1,30 @@
+package metrics
+
+import (
+	"testing"
+
+	"go.uber.org/fx/testutils/metrics"
+
+	"github.com/uber-go/zap"
+	"github.com/stretchr/testify/assert"
+)
+
+func hookedLogger() (zap.Logger, *metrics.TestStatsReporter) {
+	s, r := metrics.NewTestScope()
+	return zap.New(zap.NewJSONEncoder(), Hook(s)), r
+}
+
+func TestSomething(t *testing.T) {
+	l, r := hookedLogger()
+
+	r.Cw.Add(2)
+	l.Info("Info message.")
+
+	l.Error("Error message 1.")
+	l.Error("Error message 2.")
+	r.Cw.Wait()
+
+	assert.Equal(t, 2, len(r.Counters))
+	assert.Equal(t, int64(1), r.Counters["info"])
+	assert.Equal(t, int64(2), r.Counters["error"])
+}

--- a/ulog/metrics/metrics_test.go
+++ b/ulog/metrics/metrics_test.go
@@ -25,8 +25,8 @@ import (
 
 	"go.uber.org/fx/testutils/metrics"
 
-	"github.com/uber-go/zap"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/zap"
 )
 
 func hookedLogger() (zap.Logger, *metrics.TestStatsReporter) {

--- a/ulog/metrics/metrics_test.go
+++ b/ulog/metrics/metrics_test.go
@@ -38,12 +38,12 @@ func hookedLogger() (zap.Logger, *metrics.TestStatsReporter) {
 func TestSomething(t *testing.T) {
 	l, r := hookedLogger()
 
-	r.Cw.Add(2)
+	r.CountersWG.Add(2)
 	l.Info("Info message.")
 
 	l.Error("Error message 1.")
 	l.Error("Error message 2.")
-	r.Cw.Wait()
+	r.CountersWG.Wait()
 
 	assert.Equal(t, 2, len(r.Counters))
 	assert.Equal(t, int64(1), r.Counters["info"])


### PR DESCRIPTION
The idea here is that we'll be getting a strong signal post deploy
if the distribution of `error` logs shoots up - probably revert is 
on the cards.

GFM-154