### PR TITLE
Update make timeout for sentry tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor \
 	-e "examples/keyvalue/.*" \
 	-e ".*/_.*")
 
-TEST_TIMEOUT := "-timeout=3s"
+TEST_TIMEOUT := "-timeout=10s"
 
 .PHONY: test
 test: examples $(COV_REPORT)


### PR DESCRIPTION
GFM-280
Sentry tests are slow and causing test timeout while running on travis. (try `make test RACE=-race` on local machine)