### PR TITLE
Benchmark http client

### DIFF
--- a/modules/uhttp/README.md
+++ b/modules/uhttp/README.md
@@ -43,3 +43,40 @@ HTTP handlers are set up with filters that inject tracing, authentication inform
 request context. Request tracing, authentication and context-aware logging are set up by default.
 With context-aware logging, all log statements include trace information such as traceID and spanID.
 This allows service owners to easily find logs corresponding to a request within and even across services.
+
+## HTTP Client
+
+The http client serves similar purpose as http module, but for making requests. 
+It has a set of auth and tracing filters for http requests and a default timeout set to 2 minutes. 
+
+```go
+package main
+
+import (
+  "log"
+  "net/http"
+
+  "go.uber.org/fx/modules/uhttp/client"
+  "go.uber.org/fx/service"
+)
+
+func main() {
+  svc, err := service.WithModules().Build()
+
+  if err != nil {
+    log.Fatal("Could not initialize service: ", err)
+  }
+
+  client := client.New(svc)
+  client.Get("https://www.uber.com")
+}
+``` 
+
+### Benchmark results:
+```
+Current performance benchmark data:
+BenchmarkClientFilters/empty-8         	  500000	      3517 ns/op	     256 B/op	       2 allocs/op
+BenchmarkClientFilters/tracing-8       	   20000	     64421 ns/op	    1729 B/op	      29 allocs/op
+BenchmarkClientFilters/auth-8          	   50000	     36574 ns/op	     728 B/op	      16 allocs/op
+BenchmarkClientFilters/default-8       	   10000	    104374 ns/op	    2275 B/op	      43 allocs/op
+```

--- a/modules/uhttp/client/client_filters_benchmark_test.go
+++ b/modules/uhttp/client/client_filters_benchmark_test.go
@@ -22,18 +22,17 @@ package client
 
 import (
 	"context"
+	"net/http/httptest"
 	"testing"
 
+	"go.uber.org/fx/auth"
+	"go.uber.org/fx/internal/fxcontext"
 	"go.uber.org/fx/tracing"
 	"go.uber.org/fx/ulog"
 
-	"github.com/uber-go/tally"
-
-	jconfig "github.com/uber/jaeger-client-go/config"
-	"net/http/httptest"
-	"go.uber.org/fx/auth"
-	"go.uber.org/fx/internal/fxcontext"
 	"github.com/opentracing/opentracing-go"
+	"github.com/uber-go/tally"
+	jconfig "github.com/uber/jaeger-client-go/config"
 )
 
 // BenchmarkClientFilters/empty-8         	  500000	      3517 ns/op	     256 B/op	       2 allocs/op
@@ -48,9 +47,9 @@ func BenchmarkClientFilters(b *testing.B) {
 
 	defer closer.Close()
 	bm := map[string][]Filter{
-		"empty": {},
+		"empty":   {},
 		"tracing": {tracingFilter()},
-		"auth": {authenticationFilter(fakeAuthInfo{_testYaml})},
+		"auth":    {authenticationFilter(fakeAuthInfo{_testYaml})},
 		"default": {tracingFilter(), authenticationFilter(fakeAuthInfo{_testYaml})},
 	}
 
@@ -66,7 +65,7 @@ func BenchmarkClientFilters(b *testing.B) {
 		req := httptest.NewRequest("", "http://localhost", nil).WithContext(ctx)
 
 		b.ResetTimer()
-		b.Run(name, func (b *testing.B) {
+		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if _, err := chain.RoundTrip(req); err != nil {
 					b.Error(err)

--- a/modules/uhttp/client/client_filters_benchmark_test.go
+++ b/modules/uhttp/client/client_filters_benchmark_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/fx/tracing"
+	"go.uber.org/fx/ulog"
+
+	"github.com/uber-go/tally"
+
+	jconfig "github.com/uber/jaeger-client-go/config"
+	"net/http/httptest"
+	"go.uber.org/fx/auth"
+	"go.uber.org/fx/internal/fxcontext"
+	"github.com/opentracing/opentracing-go"
+)
+
+// BenchmarkClientFilters/empty-8         	  500000	      3517 ns/op	     256 B/op	       2 allocs/op
+// BenchmarkClientFilters/tracing-8       	   20000	     64421 ns/op	    1729 B/op	      29 allocs/op
+// BenchmarkClientFilters/auth-8          	   50000	     36574 ns/op	     728 B/op	      16 allocs/op
+// BenchmarkClientFilters/default-8       	   10000	    104374 ns/op	    2275 B/op	      43 allocs/op
+func BenchmarkClientFilters(b *testing.B) {
+	tracer, closer, err := tracing.InitGlobalTracer(&jconfig.Configuration{}, "Test", ulog.NopLogger, tally.NullStatsReporter)
+	if err != nil {
+		b.Error(err)
+	}
+
+	defer closer.Close()
+	bm := map[string][]Filter{
+		"empty": {},
+		"tracing": {tracingFilter()},
+		"auth": {authenticationFilter(fakeAuthInfo{_testYaml})},
+		"default": {tracingFilter(), authenticationFilter(fakeAuthInfo{_testYaml})},
+	}
+
+	for name, filters := range bm {
+		chain := newExecutionChain(filters, nopTransport{})
+		span := tracer.StartSpan("test_method")
+		span.SetBaggageItem(auth.ServiceAuth, "testService")
+
+		ctx := &fxcontext.Context{
+			Context: opentracing.ContextWithSpan(context.Background(), span),
+		}
+
+		req := httptest.NewRequest("", "http://localhost", nil).WithContext(ctx)
+
+		b.ResetTimer()
+		b.Run(name, func (b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := chain.RoundTrip(req); err != nil {
+					b.Error(err)
+				}
+			}
+		})
+	}
+}

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -121,6 +121,44 @@ func TestExecutionChainFilters_AuthContextPropagationFailure(t *testing.T) {
 	})
 }
 
+func TestFiltersWithTracerErrors(t *testing.T) {
+	testCases := map[string]Filter{
+		"auth":authenticationFilter(fakeAuthInfo{_testYaml}),
+		"tracing":tracingFilter(),
+	}
+
+	for name, filter := range testCases {
+		op := func(tracer opentracing.Tracer) {
+			tr := &shadowTracer{
+				tracer,
+				func(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+					return errors.New("Very bad tracer")
+				},
+				nil,
+			}
+			opentracing.InitGlobalTracer(tr)
+
+			execChain := newExecutionChain(
+				[]Filter{filter}, nopTransport{})
+			span := tracer.StartSpan("test_method")
+			span.SetBaggageItem(auth.ServiceAuth, "testService")
+			sp := &shadowSpan{span, tr}
+			tr.span = sp
+
+			ctx := &fxcontext.Context{
+				Context: opentracing.ContextWithSpan(context.Background(), sp),
+			}
+
+			_, err := execChain.RoundTrip(_req.WithContext(ctx))
+			assert.EqualError(t, err, "Very bad tracer")
+
+			opentracing.InitGlobalTracer(tracer)
+		}
+
+		t.Run(name, func(t *testing.T) {withOpentracingSetup(t, nil, op)})
+	}
+}
+
 type fakeAuthInfo struct {
 	yaml []byte
 }
@@ -161,4 +199,27 @@ type errTransport struct{}
 
 func (tr errTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	return nil, errClient
+}
+
+type shadowTracer struct {
+	opentracing.Tracer
+	inject func(sm opentracing.SpanContext, format interface{}, carrier interface{}) error
+	span opentracing.Span
+}
+
+func (s *shadowTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	return s.inject(sm, format, carrier)
+}
+
+func (s *shadowTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	return s.span
+}
+
+type shadowSpan struct {
+	opentracing.Span
+	tracer opentracing.Tracer
+}
+
+func (s *shadowSpan) Tracer() opentracing.Tracer {
+	return s.tracer
 }

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -123,8 +123,8 @@ func TestExecutionChainFilters_AuthContextPropagationFailure(t *testing.T) {
 
 func TestFiltersWithTracerErrors(t *testing.T) {
 	testCases := map[string]Filter{
-		"auth":authenticationFilter(fakeAuthInfo{_testYaml}),
-		"tracing":tracingFilter(),
+		"auth":    authenticationFilter(fakeAuthInfo{_testYaml}),
+		"tracing": tracingFilter(),
 	}
 
 	for name, filter := range testCases {
@@ -155,7 +155,7 @@ func TestFiltersWithTracerErrors(t *testing.T) {
 			opentracing.InitGlobalTracer(tracer)
 		}
 
-		t.Run(name, func(t *testing.T) {withOpentracingSetup(t, nil, op)})
+		t.Run(name, func(t *testing.T) { withOpentracingSetup(t, nil, op) })
 	}
 }
 
@@ -204,7 +204,7 @@ func (tr errTransport) RoundTrip(req *http.Request) (resp *http.Response, err er
 type shadowTracer struct {
 	opentracing.Tracer
 	inject func(sm opentracing.SpanContext, format interface{}, carrier interface{}) error
-	span opentracing.Span
+	span   opentracing.Span
 }
 
 func (s *shadowTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -81,7 +81,7 @@ func TestClientGetTwiceExecutesAllFilters(t *testing.T) {
 	count := 0
 	var f FilterFunc = func(
 		ctx fx.Context, r *http.Request, next Executor,
-	) (resp *http.Response, err error){
+	) (resp *http.Response, err error) {
 		count++
 		return next.Execute(ctx, r)
 	}

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -64,5 +64,39 @@
 // This allows service owners to easily find logs corresponding to a request within and even across services.
 //
 //
+// HTTP Client
+//
+// The http client serves similar purpose as http module, but for making requests.It has a set of auth and tracing filters for http requests and a default timeout set to 2 minutes.
+//
+//
+//   package main
+//
+//   import (
+//     "log"
+//     "net/http"
+//
+//     "go.uber.org/fx/modules/uhttp/client"
+//     "go.uber.org/fx/service"
+//   )
+//
+//   func main() {
+//     svc, err := service.WithModules().Build()
+//
+//     if err != nil {
+//       log.Fatal("Could not initialize service: ", err)
+//     }
+//
+//     client := client.New(svc)
+//     client.Get("https://www.uber.com")
+//   }
+//
+// Benchmark results:
+//
+//   Current performance benchmark data:
+//   BenchmarkClientFilters/empty-8         	  500000	      3517 ns/op	     256 B/op	       2 allocs/op
+//   BenchmarkClientFilters/tracing-8       	   20000	     64421 ns/op	    1729 B/op	      29 allocs/op
+//   BenchmarkClientFilters/auth-8          	   50000	     36574 ns/op	     728 B/op	      16 allocs/op
+//   BenchmarkClientFilters/default-8       	   10000	    104374 ns/op	    2275 B/op	      43 allocs/op
+//
 //
 package uhttp


### PR DESCRIPTION
Add a benchmark test for the http client filters
Increase coverage for tracing errors
Ensure all filters are copied on subsequent calls in client