### PR TITLE
Fix jaeger to zap logger conversion

### DIFF
--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -21,6 +21,7 @@
 package tracing
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -77,14 +78,8 @@ func (jl *jaegerLogger) Error(msg string) {
 
 // Infof logs an info message with args as key value pairs
 func (jl *jaegerLogger) Infof(msg string, args ...interface{}) {
-	// TODO (madhu) Zap logger requires even number of arguments, add a key to each arg
-	// This is a hack in place till jaeger directly takes a zap logger
-	targetLen := len(args) * 2
-	targetArgs := make([]interface{}, 0, targetLen)
-	for _, arg := range args {
-		targetArgs = append(targetArgs, "arg", arg)
-	}
-	jl.log.Info(msg, targetArgs...)
+	logMsg := fmt.Sprintf(msg, args...)
+	jl.log.Info(logMsg)
 }
 
 type jaegerReporter struct {

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -94,12 +94,12 @@ func TestJaegerLogger(t *testing.T) {
 	testutils.WithInMemoryLogger(t, nil, func(zapLogger zap.Logger, buf *testutils.TestBuffer) {
 		loggerWithZap := ulog.Builder().SetLogger(zapLogger).Build()
 		jLogger := jaegerLogger{log: loggerWithZap}
-		jLogger.Infof("info message", "oddArg")
-		jLogger.Infof("info message", "value1", "value2")
+		jLogger.Infof("info message: %s", "oddArg")
+		jLogger.Infof("info message: %s %s", "value1", "value2")
 		jLogger.Error("error message")
 		assert.Equal(t, []string{
-			`{"level":"info","msg":"info message","arg":"oddArg"}`,
-			`{"level":"info","msg":"info message","arg":"value1","arg":"value2"}`,
+			`{"level":"info","msg":"info message: oddArg"}`,
+			`{"level":"info","msg":"info message: value1 value2"}`,
 			`{"level":"error","msg":"error message"}`,
 		}, buf.Lines(), "Incorrect output from logger")
 	})

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -94,10 +94,12 @@ func TestJaegerLogger(t *testing.T) {
 	testutils.WithInMemoryLogger(t, nil, func(zapLogger zap.Logger, buf *testutils.TestBuffer) {
 		loggerWithZap := ulog.Builder().SetLogger(zapLogger).Build()
 		jLogger := jaegerLogger{log: loggerWithZap}
+		jLogger.Infof("info message")
 		jLogger.Infof("info message: %s", "oddArg")
 		jLogger.Infof("info message: %s %s", "value1", "value2")
 		jLogger.Error("error message")
 		assert.Equal(t, []string{
+			`{"level":"info","msg":"info message"}`,
 			`{"level":"info","msg":"info message: oddArg"}`,
 			`{"level":"info","msg":"info message: value1 value2"}`,
 			`{"level":"error","msg":"error message"}`,


### PR DESCRIPTION
Earlier I was translating the formatted string as a structured zap message. Converting it into a string and logging that is way cleaner.