### PR TITLE
Added metrics around http filters and handles

### DIFF
--- a/modules/module_tags.go
+++ b/modules/module_tags.go
@@ -21,12 +21,16 @@
 package modules
 
 var (
-	moduleTag = "Module"
-	typeTag   = "Type"
+	//TagModule is module tag for metrics
+	TagModule = "module"
+	// TagType is either request or response
+	TagType = "type"
+	// TagStatus is status of the request
+	TagStatus = "status"
 )
 
 // HTTPTags creates metrics scope with defined tags
 var HTTPTags = map[string]string{
-	moduleTag: "http",
-	typeTag:   "request",
+	TagModule: "http",
+	TagType:   "request",
 }

--- a/modules/module_tags.go
+++ b/modules/module_tags.go
@@ -20,7 +20,7 @@
 
 package modules
 
-var (
+const (
 	//TagModule is module tag for metrics
 	TagModule = "module"
 	// TagType is either request or response

--- a/modules/module_tags.go
+++ b/modules/module_tags.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package modules
+
+var (
+	moduleTag = "Module"
+	typeTag   = "Type"
+)
+
+// HTTPTags creates metrics scope with defined tags
+var HTTPTags = map[string]string{
+	moduleTag: "http",
+	typeTag:   "request",
+}

--- a/modules/uhttp/filterchain_builder.go
+++ b/modules/uhttp/filterchain_builder.go
@@ -52,7 +52,7 @@ type filterChainBuilder struct {
 
 func defaultFilterChainBuilder(host service.Host) filterChainBuilder {
 	fcb := newFilterChainBuilder(host)
-	return fcb.AddFilters(contextFilter(host), panicFilter(host), tracingServerFilter(host), authorizationFilter(host))
+	return fcb.AddFilters(panicFilter{host}, metricsFilter{host}, tracingServerFilter{host}, authorizationFilter{host})
 }
 
 // NewFilterChainBuilder creates an empty filterChainBuilder for setup

--- a/modules/uhttp/filterchain_builder.go
+++ b/modules/uhttp/filterchain_builder.go
@@ -54,7 +54,8 @@ type filterChainBuilder struct {
 func defaultFilterChainBuilder(host service.Host) filterChainBuilder {
 	fcb := newFilterChainBuilder(host)
 	scope := host.Metrics().Tagged(modules.HTTPTags)
-	return fcb.AddFilters(panicFilter{scope},
+	return fcb.AddFilters(
+		panicFilter{scope},
 		metricsFilter{scope},
 		tracingServerFilter{scope},
 		authorizationFilter{

--- a/modules/uhttp/filterchain_builder.go
+++ b/modules/uhttp/filterchain_builder.go
@@ -55,12 +55,12 @@ func defaultFilterChainBuilder(host service.Host) filterChainBuilder {
 	fcb := newFilterChainBuilder(host)
 	scope := host.Metrics().Tagged(modules.HTTPTags)
 	return fcb.AddFilters(
-		panicFilter{scope},
+		panicFilter{scope.Counter("panic")},
 		metricsFilter{scope},
 		tracingServerFilter{scope},
 		authorizationFilter{
-			scope:      scope,
-			authClient: host.AuthClient(),
+			authClient:  host.AuthClient(),
+			authCounter: scope.Counter("auth.fail"),
 		})
 }
 

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -105,7 +105,7 @@ func (f panicFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Reques
 	defer func() {
 		if err := recover(); err != nil {
 			ctx.Logger().Error("Panic recovered serving request", "error", err, "url", r.URL)
-			f.Host.Metrics().Counter("http.panic").Inc(1)
+			f.Host.Metrics().SubScope("http").Counter("panic").Inc(1)
 			w.Header().Add(ContentType, ContentTypeText)
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "Server error: %+v", err)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -104,7 +104,6 @@ func (f panicFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Reques
 			w.Header().Add(ContentType, ContentTypeText)
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "Server error: %+v", err)
-			tally.DefaultSeparator
 		}
 	}()
 	next.ServeHTTP(ctx, w, r)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -64,10 +64,11 @@ func (f tracingServerFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *htt
 	ext.HTTPUrl.Set(span, r.URL.String())
 	defer span.Finish()
 
-	ctx = ctx.(*fxcontext.Context).WithContextAwareLogger(span)
-	ctx = &fxcontext.Context{
+	yoctx = fxcontext.Context{
 		Context: opentracing.ContextWithSpan(ctx, span),
 	}
+	ctx = ctx.(*fxcontext.Context).WithContextAwareLogger(span)
+
 	r = r.WithContext(ctx)
 	next.ServeHTTP(ctx, w, r)
 }
@@ -103,6 +104,7 @@ func (f panicFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Reques
 			w.Header().Add(ContentType, ContentTypeText)
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "Server error: %+v", err)
+			tally.DefaultSeparator
 		}
 	}()
 	next.ServeHTTP(ctx, w, r)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -64,7 +64,7 @@ func (f tracingServerFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *htt
 	ext.HTTPUrl.Set(span, r.URL.String())
 	defer span.Finish()
 
-	yoctx = fxcontext.Context{
+	ctx = &fxcontext.Context{
 		Context: opentracing.ContextWithSpan(ctx, span),
 	}
 	ctx = ctx.(*fxcontext.Context).WithContextAwareLogger(span)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -48,76 +48,82 @@ func (f FilterFunc) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Request
 	f(ctx, w, r, next)
 }
 
-// contextFilter updates context to fx.Context
-func contextFilter(host service.Host) FilterFunc {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
-		fxctx := fxcontext.New(ctx, host)
-		next.ServeHTTP(fxctx, w, r)
-	}
+type tracingServerFilter struct {
+	service.Host
 }
 
-func tracingServerFilter(host service.Host) FilterFunc {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
-		// TODO:(anup) GFM-257 benchmark performance comparing with using type assertion
-		fxctx := &fxcontext.Context{
-			Context: ctx,
-		}
-		operationName := r.Method
-		carrier := opentracing.HTTPHeadersCarrier(r.Header)
-		spanCtx, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, carrier)
-		if err != nil && err != opentracing.ErrSpanContextNotFound {
-			fxctx.Logger().Info("Malformed inbound tracing context: ", "error", err.Error())
-		}
-		span := opentracing.GlobalTracer().StartSpan(operationName, ext.RPCServerOption(spanCtx))
-		ext.HTTPUrl.Set(span, r.URL.String())
-		defer func() {
-			span.Finish()
-			fxctx.Logger().Debug("Span finished")
-		}()
-
-		fxctx = fxctx.WithContextAwareLogger(span)
-		fxctx = &fxcontext.Context{
-			Context: opentracing.ContextWithSpan(fxctx, span),
-		}
-		r = r.WithContext(fxctx)
-		next.ServeHTTP(fxctx, w, r)
+func (f tracingServerFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+	stopWatch := f.Host.Metrics().SubScope("http").SubScope("request").Timer("tracing").Start()
+	operationName := r.Method
+	carrier := opentracing.HTTPHeadersCarrier(r.Header)
+	spanCtx, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, carrier)
+	if err != nil && err != opentracing.ErrSpanContextNotFound {
+		ctx.Logger().Info("Malformed inbound tracing context: ", "error", err.Error())
 	}
+	span := opentracing.GlobalTracer().StartSpan(operationName, ext.RPCServerOption(spanCtx))
+	ext.HTTPUrl.Set(span, r.URL.String())
+	defer func() {
+		span.Finish()
+		ctx.Logger().Debug("Span finished")
+	}()
+
+	ctx = ctx.(*fxcontext.Context).WithContextAwareLogger(span)
+	ctx = &fxcontext.Context{
+		Context: opentracing.ContextWithSpan(ctx, span),
+	}
+	r = r.WithContext(ctx)
+	stopWatch.Stop()
+	next.ServeHTTP(ctx, w, r)
 }
 
 // authorizationFilter authorizes services based on configuration
-func authorizationFilter(host service.Host) FilterFunc {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
-		fxctx := &fxcontext.Context{
-			Context: ctx,
-		}
+type authorizationFilter struct {
+	service.Host
+}
 
-		if err := host.AuthClient().Authorize(fxctx); err != nil {
-			host.Metrics().SubScope("http").SubScope("auth").Counter("fail").Inc(1)
-			fxctx.Logger().Error(auth.ErrAuthorization, "error", err)
-			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprintf(w, "Unauthorized access: %+v", err)
-			return
-		}
-		next.ServeHTTP(fxctx, w, r)
+func (f authorizationFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+	stopWatch := f.Host.Metrics().SubScope("http").SubScope("request").Timer("auth").Start()
+	if err := f.Host.AuthClient().Authorize(ctx); err != nil {
+		f.Host.Metrics().SubScope("http").SubScope("auth").Counter("fail").Inc(1)
+		ctx.Logger().Error(auth.ErrAuthorization, "error", err)
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintf(w, "Unauthorized access: %+v", err)
+		stopWatch.Stop()
+		return
 	}
+	stopWatch.Stop()
+	next.ServeHTTP(ctx, w, r)
 }
 
 // panicFilter handles any panics and return an error
 // panic filter should be added at the end of filter chain to catch panics
-func panicFilter(host service.Host) FilterFunc {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
-		fxctx := &fxcontext.Context{
-			Context: ctx,
+type panicFilter struct {
+	service.Host
+}
+
+func (f panicFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+	defer func() {
+		if err := recover(); err != nil {
+			ctx.Logger().Error("Panic recovered serving request", "error", err, "url", r.URL)
+			f.Host.Metrics().Counter("http.panic").Inc(1)
+			w.Header().Add(ContentType, ContentTypeText)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Server error: %+v", err)
 		}
-		defer func() {
-			if err := recover(); err != nil {
-				fxctx.Logger().Error("Panic recovered serving request", "error", err, "url", r.URL)
-				host.Metrics().Counter("http.panic").Inc(1)
-				w.Header().Add(ContentType, ContentTypeText)
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintf(w, "Server error: %+v", err)
-			}
-		}()
-		next.ServeHTTP(fxctx, w, r)
-	}
+	}()
+	next.ServeHTTP(ctx, w, r)
+}
+
+// metricsFilter adds any default metrics related to HTTP
+type metricsFilter struct {
+	service.Host
+}
+
+func (f metricsFilter) Apply(ctx fx.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+	stopwatch := f.Host.Metrics().SubScope("http").SubScope(r.Method).Timer("sla").Start()
+	defer func() {
+		f.Host.Metrics().SubScope("http").SubScope("status").Counter(w.Header().Get("Status")).Inc(1)
+		stopwatch.Stop()
+	}()
+	next.ServeHTTP(ctx, w, r)
 }

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -67,7 +67,7 @@ func TestTracingFilterWithLogs(t *testing.T) {
 		defer opentracing.InitGlobalTracer(opentracing.NoopTracer{})
 
 		host := service.NopHostConfigured(auth.NopClient, loggerWithZap, tracer)
-		chain := newFilterChainBuilder(host).AddFilters([]Filter{tracingServerFilter(host)}...).Build(getNopHandler(host))
+		chain := newFilterChainBuilder(host).AddFilters([]Filter{tracingServerFilter{host}}...).Build(getNopHandler(host))
 		response := testServeHTTP(chain, host)
 		assert.Contains(t, response.Body.String(), "filters ok")
 		assert.True(t, len(buf.Lines()) > 0)
@@ -86,9 +86,8 @@ func TestTracingFilterWithLogs(t *testing.T) {
 func TestFilterChainFilters(t *testing.T) {
 	host := service.NopHost()
 	chain := newFilterChainBuilder(host).AddFilters(
-		contextFilter(host),
-		tracingServerFilter(host),
-		authorizationFilter(host)).Build(getNopHandler(host))
+		tracingServerFilter{host},
+		authorizationFilter{host}).Build(getNopHandler(host))
 
 	response := testServeHTTP(chain, host)
 	assert.Contains(t, response.Body.String(), "filters ok")
@@ -97,9 +96,8 @@ func TestFilterChainFilters(t *testing.T) {
 func TestFilterChainFilters_AuthFailure(t *testing.T) {
 	host := service.NopHostAuthFailure()
 	chain := newFilterChainBuilder(host).AddFilters(
-		contextFilter(host),
-		tracingServerFilter(host),
-		authorizationFilter(host)).Build(getNopHandler(host))
+		tracingServerFilter{host},
+		authorizationFilter{host}).Build(getNopHandler(host))
 	response := testServeHTTP(chain, host)
 	assert.Contains(t, "Unauthorized access: Error authorizing the service", response.Body.String())
 	assert.Equal(t, 401, response.Code)

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -67,7 +67,7 @@ func TestTracingFilterWithLogs(t *testing.T) {
 		defer opentracing.InitGlobalTracer(opentracing.NoopTracer{})
 
 		host := service.NopHostConfigured(auth.NopClient, loggerWithZap, tracer)
-		chain := newFilterChainBuilder(host).AddFilters([]Filter{tracingServerFilter{host}}...).Build(getNopHandler(host))
+		chain := newFilterChainBuilder(host).AddFilters([]Filter{tracingServerFilter{host.Metrics()}}...).Build(getNopHandler(host))
 		response := testServeHTTP(chain, host)
 		assert.Contains(t, response.Body.String(), "filters ok")
 		assert.True(t, len(buf.Lines()) > 0)
@@ -86,8 +86,11 @@ func TestTracingFilterWithLogs(t *testing.T) {
 func TestFilterChainFilters(t *testing.T) {
 	host := service.NopHost()
 	chain := newFilterChainBuilder(host).AddFilters(
-		tracingServerFilter{host},
-		authorizationFilter{host}).Build(getNopHandler(host))
+		tracingServerFilter{host.Metrics()},
+		authorizationFilter{
+			scope:      host.Metrics(),
+			authClient: host.AuthClient(),
+		}).Build(getNopHandler(host))
 
 	response := testServeHTTP(chain, host)
 	assert.Contains(t, response.Body.String(), "filters ok")
@@ -96,8 +99,11 @@ func TestFilterChainFilters(t *testing.T) {
 func TestFilterChainFilters_AuthFailure(t *testing.T) {
 	host := service.NopHostAuthFailure()
 	chain := newFilterChainBuilder(host).AddFilters(
-		tracingServerFilter{host},
-		authorizationFilter{host}).Build(getNopHandler(host))
+		tracingServerFilter{host.Metrics()},
+		authorizationFilter{
+			scope:      host.Metrics(),
+			authClient: host.AuthClient(),
+		}).Build(getNopHandler(host))
 	response := testServeHTTP(chain, host)
 	assert.Contains(t, "Unauthorized access: Error authorizing the service", response.Body.String())
 	assert.Equal(t, 401, response.Code)

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -71,15 +71,18 @@ func TestTracingFilterWithLogs(t *testing.T) {
 		response := testServeHTTP(chain, host)
 		assert.Contains(t, response.Body.String(), "filters ok")
 		assert.True(t, len(buf.Lines()) > 0)
-		var spanFinished bool
+		var tracecount = 0
+		var spancount = 0
 		for _, line := range buf.Lines() {
-			if strings.Contains(line, "Span finished") {
-				assert.Contains(t, line, "traceID")
-				assert.Contains(t, line, "spanID")
-				spanFinished = true
+			if strings.Contains(line, "traceID") {
+				tracecount++
+			}
+			if strings.Contains(line, "spanID") {
+				spancount++
 			}
 		}
-		assert.True(t, spanFinished)
+		assert.Equal(t, tracecount, 1)
+		assert.Equal(t, spancount, 1)
 	})
 }
 

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -91,8 +91,8 @@ func TestFilterChainFilters(t *testing.T) {
 	chain := newFilterChainBuilder(host).AddFilters(
 		tracingServerFilter{host.Metrics()},
 		authorizationFilter{
-			scope:      host.Metrics(),
-			authClient: host.AuthClient(),
+			authCounter: host.Metrics().Counter("auth.fail"),
+			authClient:  host.AuthClient(),
 		}).Build(getNopHandler(host))
 
 	response := testServeHTTP(chain, host)
@@ -104,8 +104,8 @@ func TestFilterChainFilters_AuthFailure(t *testing.T) {
 	chain := newFilterChainBuilder(host).AddFilters(
 		tracingServerFilter{host.Metrics()},
 		authorizationFilter{
-			scope:      host.Metrics(),
-			authClient: host.AuthClient(),
+			authCounter: host.Metrics().Counter("auth.fail"),
+			authClient:  host.AuthClient(),
 		}).Build(getNopHandler(host))
 	response := testServeHTTP(chain, host)
 	assert.Contains(t, "Unauthorized access: Error authorizing the service", response.Body.String())

--- a/modules/uhttp/handler.go
+++ b/modules/uhttp/handler.go
@@ -59,5 +59,7 @@ type handlerWrapper struct {
 // ServeHTTP calls Handler.ServeHTTP(ctx, w, r) and injects a new service context for use.
 func (h *handlerWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := fxcontext.New(context.Background(), h.host)
+	stopwatch := h.host.Metrics().SubScope("http").SubScope("handle").Timer("sla").Start()
+	defer stopwatch.Stop()
 	h.handler.ServeHTTP(ctx, w, r)
 }

--- a/modules/uhttp/handler.go
+++ b/modules/uhttp/handler.go
@@ -59,7 +59,7 @@ type handlerWrapper struct {
 // ServeHTTP calls Handler.ServeHTTP(ctx, w, r) and injects a new service context for use.
 func (h *handlerWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := fxcontext.New(context.Background(), h.host)
-	stopwatch := h.host.Metrics().SubScope("http").SubScope("handle").Timer("sla").Start()
+	stopwatch := h.host.Metrics().Timer("http." + r.Method + ".latency").Start()
 	defer stopwatch.Stop()
 	h.handler.ServeHTTP(ctx, w, r)
 }

--- a/modules/uhttp/handler.go
+++ b/modules/uhttp/handler.go
@@ -59,7 +59,7 @@ type handlerWrapper struct {
 // ServeHTTP calls Handler.ServeHTTP(ctx, w, r) and injects a new service context for use.
 func (h *handlerWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := fxcontext.New(context.Background(), h.host)
-	stopwatch := h.host.Metrics().Timer("http." + r.Method + ".latency").Start()
+	stopwatch := h.host.Metrics().Timer("http." + r.Method + ".time").Start()
 	defer stopwatch.Stop()
 	h.handler.ServeHTTP(ctx, w, r)
 }

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -298,5 +298,4 @@ func verifyMetrics(t *testing.T, scope tally.Scope) {
 	assert.NotNil(t, timers["http.GET.sla"].Values())
 	assert.NotNil(t, timers["http.request.tracing"].Values())
 	assert.NotNil(t, timers["http.request.auth"].Values())
-	fmt.Println(timers)
 }

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -50,7 +50,6 @@ func TestNew_OK(t *testing.T) {
 	WithService(New(registerNothing, nil), nil, []service.Option{configOption()}, func(s service.Owner) {
 		assert.NotNil(t, s, "Should create a module")
 	})
-
 }
 
 func TestNew_WithOptions(t *testing.T) {
@@ -296,6 +295,6 @@ func verifyMetrics(t *testing.T, scope tally.Scope) {
 	timers := snapshot.Timers()
 	counters := snapshot.Counters()
 
-	assert.NotNil(t, timers["http.GET.latency"].Values())
+	assert.NotNil(t, timers["http.GET.time"].Values())
 	assert.NotNil(t, counters["auth.fail"].Value())
 }

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -295,7 +295,7 @@ func verifyMetrics(t *testing.T, scope tally.Scope) {
 	snapshot := scope.(tally.TestScope).Snapshot()
 	timers := snapshot.Timers()
 
-	assert.NotNil(t, timers["http.GET.sla"].Values())
-	assert.NotNil(t, timers["http.request.tracing"].Values())
-	assert.NotNil(t, timers["http.request.auth"].Values())
+	assert.NotNil(t, timers["GET.sla"].Values())
+	assert.NotNil(t, timers["tracing"].Values())
+	assert.NotNil(t, timers["auth"].Values())
 }

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -294,8 +294,8 @@ func userPanicFilter() FilterFunc {
 func verifyMetrics(t *testing.T, scope tally.Scope) {
 	snapshot := scope.(tally.TestScope).Snapshot()
 	timers := snapshot.Timers()
+	counters := snapshot.Counters()
 
-	assert.NotNil(t, timers["GET.sla"].Values())
-	assert.NotNil(t, timers["tracing"].Values())
-	assert.NotNil(t, timers["auth"].Values())
+	assert.NotNil(t, timers["http.GET.latency"].Values())
+	assert.NotNil(t, counters["auth.fail"].Value())
 }


### PR DESCRIPTION
GFM-247

Some cleanup around how filters are initialized, so we don't have to `fxcontext.Context{}` everywhere. 
```
Basic timers added - 
http.METHOD.time
http.request.auth

Basic Counter  - http.request.status.STATUS_CODE
```