### PR TITLE
Remove the Type function from Module interface

### DIFF
--- a/modules/modules.go
+++ b/modules/modules.go
@@ -34,14 +34,12 @@ type ModuleConfig struct {
 
 // ModuleBase is an embeddable base for all UberFx modules
 type ModuleBase struct {
-	// TODO(madhu): moduleType does not seem to be used anywhere. Remove?
-	moduleType string
-	name       string
-	host       service.Host
-	isRunning  bool
-	roles      []string
-	scope      tally.Scope
-	tracer     opentracing.Tracer
+	name      string
+	host      service.Host
+	isRunning bool
+	roles     []string
+	scope     tally.Scope
+	tracer    opentracing.Tracer
 }
 
 // NewModuleBase configures a new ModuleBase
@@ -52,12 +50,11 @@ func NewModuleBase(
 	roles []string,
 ) *ModuleBase {
 	return &ModuleBase{
-		moduleType: moduleType,
-		name:       name,
-		host:       service,
-		roles:      roles,
-		scope:      service.Metrics().SubScope(name),
-		tracer:     service.Tracer(),
+		name:   name,
+		host:   service,
+		roles:  roles,
+		scope:  service.Metrics().SubScope(name),
+		tracer: service.Tracer(),
 	}
 }
 
@@ -69,11 +66,6 @@ func (mb ModuleBase) Host() service.Host {
 // Roles returns the module's roles
 func (mb ModuleBase) Roles() []string {
 	return mb.roles
-}
-
-// Type returns the module's type
-func (mb ModuleBase) Type() string {
-	return mb.moduleType
 }
 
 // Name returns the module's name

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -44,7 +44,6 @@ type ModuleBase struct {
 
 // NewModuleBase configures a new ModuleBase
 func NewModuleBase(
-	moduleType string,
 	name string,
 	service service.Host,
 	roles []string,

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -38,11 +38,6 @@ func TestModuleBase_Roles(t *testing.T) {
 	assert.Nil(t, mb.Roles())
 }
 
-func TestNewModuleBase_Type(t *testing.T) {
-	mb := nmb("test", "foo", nil)
-	assert.Equal(t, "test", mb.Type())
-}
-
 func TestNewModuleBase_Name(t *testing.T) {
 	mb := nmb("test", "foo", nil)
 	assert.Equal(t, "foo", mb.Name())

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -29,35 +29,34 @@ import (
 )
 
 func TestNewModuleBase(t *testing.T) {
-	mb := nmb("test", "foo", nil)
+	mb := nmb("foo", nil)
 	assert.NotNil(t, mb)
 }
 
 func TestModuleBase_Roles(t *testing.T) {
-	mb := nmb("test", "foo", nil)
+	mb := nmb("foo", nil)
 	assert.Nil(t, mb.Roles())
 }
 
 func TestNewModuleBase_Name(t *testing.T) {
-	mb := nmb("test", "foo", nil)
+	mb := nmb("foo", nil)
 	assert.Equal(t, "foo", mb.Name())
 }
 
 func TestNewModuleBase_Host(t *testing.T) {
-	mb := nmb("test", "foo", nil)
+	mb := nmb("foo", nil)
 	assert.NotNil(t, mb.Host())
 }
 
 func TestNewModuleBase_Tracer(t *testing.T) {
-	mb := nmb("test", "foo", nil)
+	mb := nmb("foo", nil)
 	assert.NotNil(t, mb.Tracer())
 }
 
-func nmb(moduleType, name string, roles []string) *ModuleBase {
+func nmb(name string, roles []string) *ModuleBase {
 	host := service.NopHost()
 
 	return NewModuleBase(
-		moduleType,
 		name,
 		host,
 		roles,

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -56,9 +56,6 @@ var (
 
 type registerServiceFunc func(module *YarpcModule)
 
-// RPCModuleType represents the type of an RPC module
-const RPCModuleType = "rpc"
-
 type yarpcConfig struct {
 	modules.ModuleConfig
 	Bind          string `yaml:"bind"`
@@ -81,7 +78,7 @@ func newYarpcModule(
 	}
 
 	module := &YarpcModule{
-		ModuleBase: *modules.NewModuleBase(RPCModuleType, name, mi.Host, []string{}),
+		ModuleBase: *modules.NewModuleBase(name, mi.Host, []string{}),
 		register:   reg,
 		config:     *cfg,
 	}

--- a/modules/task/backend.go
+++ b/modules/task/backend.go
@@ -54,11 +54,6 @@ func (b NopBackend) Encoder() Encoding {
 	return &NopEncoding{}
 }
 
-// Type implements the Module interface
-func (b NopBackend) Type() string {
-	return "nop"
-}
-
 // Name implements the Module interface
 func (b NopBackend) Name() string {
 	return "nop"
@@ -113,11 +108,6 @@ func (b *inMemBackend) Consume() error {
 // Encoder implements the Backend interface
 func (b *inMemBackend) Encoder() Encoding {
 	return gobEncoding
-}
-
-// Type implements the Module interface
-func (b *inMemBackend) Type() string {
-	return "inMem"
 }
 
 // Name implements the Module interface

--- a/modules/task/backend_test.go
+++ b/modules/task/backend_test.go
@@ -43,7 +43,6 @@ func TestInMemBackendConsumeAfterClose(t *testing.T) {
 
 func testBackendMethods(t *testing.T, b Backend) {
 	assert.NotEmpty(t, b.Name())
-	assert.NotEmpty(t, b.Type())
 	assert.NotNil(t, b.Encoder())
 	assert.NotNil(t, b.Start(make(chan struct{})))
 	assert.True(t, b.IsRunning())

--- a/modules/task/task.go
+++ b/modules/task/task.go
@@ -27,9 +27,6 @@ import (
 	"go.uber.org/fx/service"
 )
 
-// ModuleType represents the task module type
-const ModuleType = "task"
-
 type globalBackend struct {
 	backend Backend
 	sync.RWMutex
@@ -71,7 +68,7 @@ func newAsyncModule(mi service.ModuleCreateInfo, backend Backend) service.Module
 	_globalBackendMu.Unlock()
 	return &AsyncModule{
 		Backend: backend,
-		modBase: *modules.NewModuleBase(ModuleType, "task", mi.Host, []string{}),
+		modBase: *modules.NewModuleBase("task", mi.Host, []string{}),
 	}
 }
 

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -35,9 +35,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ModuleType is a human-friendly representation of the module
-const ModuleType = "HTTP"
-
 const (
 	// ContentType is the header key that contains the body type
 	ContentType = "Content-Type"
@@ -126,7 +123,7 @@ func newModule(
 
 	// TODO (madhu): Add other middleware - logging, metrics.
 	module := &Module{
-		ModuleBase: *modules.NewModuleBase(ModuleType, mi.Name, mi.Host, []string{}),
+		ModuleBase: *modules.NewModuleBase(mi.Name, mi.Host, []string{}),
 		handlers:   handlers,
 		fcb:        defaultFilterChainBuilder(mi.Host),
 	}

--- a/service/module.go
+++ b/service/module.go
@@ -25,7 +25,6 @@ type ModuleType string
 
 // A Module is the basic building block of an UberFx service
 type Module interface {
-	Type() string
 	Name() string
 	Start(ready chan<- struct{}) <-chan error
 	Stop() error

--- a/service/stub_module.go
+++ b/service/stub_module.go
@@ -22,12 +22,12 @@ package service
 
 // A StubModule implements the Module interface for testing
 type StubModule struct {
-	Host             Host
-	InitError        error
-	TypeVal, NameVal string
-	StartError       error
-	StopError        error
-	Running          bool
+	Host       Host
+	InitError  error
+	NameVal    string
+	StartError error
+	StopError  error
+	Running    bool
 }
 
 var _ Module = &StubModule{}

--- a/service/stub_module.go
+++ b/service/stub_module.go
@@ -46,9 +46,6 @@ func (s *StubModule) Start(ready chan<- struct{}) <-chan error {
 	return errs
 }
 
-// Type returns the type of the module
-func (s *StubModule) Type() string { return s.TypeVal }
-
 // Name returns the name of the module
 func (s *StubModule) Name() string { return s.NameVal }
 

--- a/service/stub_module_test.go
+++ b/service/stub_module_test.go
@@ -39,7 +39,6 @@ func TestStubModule_Accessors(t *testing.T) {
 	s := NewStubModule(NopHost())
 	assert := assert.New(t)
 
-	assert.Empty(s.Type())
 	assert.Empty(s.Name())
 	assert.False(s.IsRunning())
 	assert.NoError(s.Stop())


### PR DESCRIPTION
The Type function/variable is unused and seems to be a duplicate of Name. Removed it from all modules and the interface. Feedback welcome.