### PR TITLE
Lonely dispatcher

### DIFF
--- a/modules/rpc/handler.go
+++ b/modules/rpc/handler.go
@@ -46,7 +46,6 @@ func (f UnaryHandlerFunc) Handle(ctx fx.Context, body wire.Value) (thrift.Respon
 }
 
 // WrapUnary wraps the unary handler and returns a thrift.UnaryHandlerFunc for yarpc calls
-// TODO(anup): GFM-255 Remove host parameter once updated yarpc plugin is imported in the repo
 func WrapUnary(h UnaryHandlerFunc) thrift.UnaryHandler {
 	return func(ctx context.Context, body wire.Value) (thrift.Response, error) {
 		fxctx := &fxcontext.Context{
@@ -70,7 +69,6 @@ func (f OnewayHandlerFunc) HandleOneway(ctx fx.Context, body wire.Value) error {
 }
 
 // WrapOneway wraps the oneway handler and returns a thrift.OnewayHandlerFunc for yarpc calls
-// TODO(anup): GFM-255 Remove host parameter once updated yarpc plugin is imported in the repo
 func WrapOneway(h OnewayHandlerFunc) thrift.OnewayHandler {
 	return func(ctx context.Context, body wire.Value) error {
 		fxctx := &fxcontext.Context{
@@ -130,6 +128,7 @@ func authorize(ctx context.Context, host service.Host) (fx.Context, error) {
 		host.Metrics().SubScope("rpc").SubScope("auth").Counter("fail").Inc(1)
 		fxctx.Logger().Error(auth.ErrAuthorization, "error", err)
 		// TODO(anup): GFM-255 update returned error to transport.BadRequestError (user error than server error)
+		// These ^ are internal YARPC errors, should we reference it?
 		return nil, err
 	}
 	return fxctx, nil

--- a/modules/rpc/handler.go
+++ b/modules/rpc/handler.go
@@ -128,7 +128,7 @@ func authorize(ctx context.Context, host service.Host) (fx.Context, error) {
 		host.Metrics().SubScope("rpc").SubScope("auth").Counter("fail").Inc(1)
 		fxctx.Logger().Error(auth.ErrAuthorization, "error", err)
 		// TODO(anup): GFM-255 update returned error to transport.BadRequestError (user error than server error)
-		// These ^ are internal YARPC errors, should we reference it?
+		// https://github.com/yarpc/yarpc-go/issues/687
 		return nil, err
 	}
 	return fxctx, nil

--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -38,7 +38,7 @@ type CreateThriftServiceFunc func(svc service.Host) ([]transport.Procedure, erro
 // ThriftModule creates a Thrift Module from a service func
 func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) service.ModuleCreateFunc {
 	return func(mi service.ModuleCreateInfo) ([]service.Module, error) {
-		mod, err := newYarpcThriftModule(mi, hookup, options...)
+		mod, err := newYARPCThriftModule(mi, hookup, options...)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to instantiate Thrift module")
 		}
@@ -47,11 +47,11 @@ func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) ser
 	}
 }
 
-func newYarpcThriftModule(
+func newYARPCThriftModule(
 	mi service.ModuleCreateInfo,
 	createService CreateThriftServiceFunc,
 	options ...modules.Option,
-) (*YarpcModule, error) {
+) (*YARPCModule, error) {
 	registrants, err := createService(mi.Host)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create YARPC thrift handler")
@@ -60,7 +60,7 @@ func newYarpcThriftModule(
 	reg := func(mod *YarpcModule) {
 		_setupMu.Lock()
 		defer _setupMu.Unlock()
-		mod.rpc.Register(registrants)
+		_dispatcher.Register(registrants)
 	}
-	return newYarpcModule(mi, reg, options...)
+	return newYARPCModule(mi, reg, options...)
 }

--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -57,10 +57,11 @@ func newYARPCThriftModule(
 		return nil, errors.Wrap(err, "unable to create YARPC thrift handler")
 	}
 
-	reg := func(mod *YarpcModule) {
+	reg := func(mod *YARPCModule) {
 		_setupMu.Lock()
 		defer _setupMu.Unlock()
-		_dispatcher.Register(registrants)
+		Dispatcher().Register(registrants)
 	}
+
 	return newYARPCModule(mi, reg, options...)
 }

--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -90,7 +90,7 @@ func errorOption(_ *service.ModuleCreateInfo) error {
 
 func okCreate(_ service.Host) ([]transport.Procedure, error) {
 	reg := thrift.BuildProcedures(thrift.Service{
-		Name: "",
+		Name: "foo",
 	})
 	return reg, nil
 }

--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -34,14 +34,20 @@ import (
 )
 
 func TestThriftModule_OK(t *testing.T) {
-	modCreate := ThriftModule(okCreate, modules.WithRoles("test"))
-	mci := mch()
-	mods, err := modCreate(mch())
-	require.NoError(t, err)
-	assert.NotEmpty(t, mods)
+	chip := ThriftModule(okCreate, modules.WithRoles("rescue"))
+	dale := ThriftModule(okCreate, modules.WithRoles("ranges"))
 
-	mod := mods[0]
-	testInitRunModule(t, mod, mci)
+	mci := mch()
+	goofy, err := chip(mch())
+	require.NoError(t, err)
+	assert.NotEmpty(t, goofy)
+
+	gopher, err := dale(mch())
+	require.NoError(t, err)
+	assert.NotEmpty(t, gopher)
+
+	testInitRunModule(t, goofy[0], mci)
+	testInitRunModule(t, gopher[0], mci)
 }
 
 func TestThriftModule_BadOptions(t *testing.T) {
@@ -66,6 +72,9 @@ func testInitRunModule(t *testing.T, mod service.Module, mci service.ModuleCreat
 	}()
 	assert.True(t, mod.IsRunning())
 	assert.NoError(t, <-errs)
+
+	c := mod.Start(make(chan struct{}))
+	assert.Error(t, <-c)
 }
 
 func mch() service.ModuleCreateInfo {
@@ -81,7 +90,7 @@ func errorOption(_ *service.ModuleCreateInfo) error {
 
 func okCreate(_ service.Host) ([]transport.Procedure, error) {
 	reg := thrift.BuildProcedures(thrift.Service{
-		Name: "foo",
+		Name: "",
 	})
 	return reg, nil
 }

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -140,7 +140,7 @@ func newYARPCModule(
 	}
 
 	module := &YARPCModule{
-		ModuleBase: *modules.NewModuleBase("", name, mi.Host, []string{}),
+		ModuleBase: *modules.NewModuleBase(name, mi.Host, []string{}),
 		register:   reg,
 		config: yarpcConfig{
 			AdvertiseName: mi.Host.Name(),

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -22,7 +22,6 @@ package rpc
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"go.uber.org/fx/modules"
@@ -36,66 +35,138 @@ import (
 	tch "go.uber.org/yarpc/transport/tchannel"
 )
 
-// YarpcModule is an implementation of a core module using YARPC
-type YarpcModule struct {
+// YARPCModule is an implementation of a core module using YARPC.
+// All the YARPC modules share the same dispatcher and middleware.
+type YARPCModule struct {
 	modules.ModuleBase
-	rpc                      *yarpc.Dispatcher
-	register                 registerServiceFunc
-	config                   yarpcConfig
-	log                      ulog.Log
-	stateMu                  sync.RWMutex
-	inboundMiddlewares       []middleware.UnaryInbound
-	onewayInboundMiddlewares []middleware.OnewayInbound
+	register  registerServiceFunc
+	config    yarpcConfig
+	log       ulog.Log
+	stateMu   sync.RWMutex
+	isRunning bool
 }
 
 var (
-	_dispatcherFn = defaultYarpcDispatcher
+	_dispatcherFn = defaultYARPCDispatcher
 
-	_ service.Module = &YarpcModule{}
+	_ service.Module = &YARPCModule{}
+
+	// Represents the global dispatcher used by all started modules.
+	_dispatcher   *yarpc.Dispatcher
+	_muDispatcher sync.RWMutex
+
+	_configsOnce sync.Once
+	_configs     configCollection
 )
 
-type registerServiceFunc func(module *YarpcModule)
+type registerServiceFunc func(module *YARPCModule)
 
 type yarpcConfig struct {
 	modules.ModuleConfig
-	Bind          string `yaml:"bind"`
-	AdvertiseName string `yaml:"advertiseName"`
+	Bind                    string `yaml:"bind"`
+	AdvertiseName           string `yaml:"advertiseName"`
+	inboundMiddleware       []middleware.UnaryInbound
+	onewayInboundMiddleware []middleware.OnewayInbound
+	inbounds                []transport.Inbound
 }
 
-func newYarpcModule(
+// Stores a collection of all modules configs and provides
+// operations that are safe to call from multiple go routines.
+type configCollection struct {
+	sync.RWMutex
+	configs []*yarpcConfig
+}
+
+func (c *configCollection) addConfig(config *yarpcConfig) error {
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.configs) > 0 && config.AdvertiseName != c.configs[0].AdvertiseName {
+		return errors.New("Name mismatch")
+	}
+
+	c.configs = append(c.configs, config)
+	return nil
+}
+
+func (c *configCollection) removeConfig(config *yarpcConfig) error {
+	c.Lock()
+	defer c.Unlock()
+
+	for i := range c.configs {
+		if c.configs[i] == config {
+			c.configs = append(c.configs[:i], c.configs[i+1:]...)
+			return nil
+		}
+	}
+
+	return errors.New("config not found")
+}
+
+func (c *configCollection) mergeConfigs() (conf yarpc.Config, err error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if len(c.configs) <= 1 {
+		err = errors.New("empty configs")
+		return
+	}
+
+	conf.Name = c.configs[0].AdvertiseName
+	var inboundMiddleware []middleware.UnaryInbound
+	var onewayInboundMiddleware []middleware.OnewayInbound
+	for _, cfg := range c.configs {
+		conf.Inbounds = append(conf.Inbounds, cfg.inbounds...)
+		inboundMiddleware = append(inboundMiddleware, cfg.inboundMiddleware...)
+		onewayInboundMiddleware = append(onewayInboundMiddleware, cfg.onewayInboundMiddleware...)
+	}
+
+	conf.InboundMiddleware = yarpc.InboundMiddleware{
+		Unary:  yarpc.UnaryInboundMiddleware(inboundMiddleware...),
+		Oneway: yarpc.OnewayInboundMiddleware(onewayInboundMiddleware...),
+	}
+
+	return conf, nil
+}
+
+func newYARPCModule(
 	mi service.ModuleCreateInfo,
 	reg registerServiceFunc,
 	options ...modules.Option,
-) (*YarpcModule, error) {
-	cfg := &yarpcConfig{
-		AdvertiseName: mi.Host.Name(),
-		Bind:          ":0",
-	}
-
+) (*YARPCModule, error) {
 	name := "yarpc"
 	if mi.Name != "" {
 		name = mi.Name
 	}
 
-	module := &YarpcModule{
-		ModuleBase: *modules.NewModuleBase(name, mi.Host, []string{}),
+	module := &YARPCModule{
+		ModuleBase: *modules.NewModuleBase("", name, mi.Host, []string{}),
 		register:   reg,
-		config:     *cfg,
+		config: yarpcConfig{
+			AdvertiseName: mi.Host.Name(),
+		},
 	}
 
-	options = append([]modules.Option{WithInboundMiddleware(fxContextInboundMiddleware{
-		Host: mi.Host,
-	}),
-		WithInboundMiddleware(authInboundMiddleware{
-			Host: mi.Host,
-		}),
-		WithOnewayInboundMiddleware(fxContextOnewayInboundMiddleware{
-			Host: mi.Host,
-		}),
-		WithOnewayInboundMiddleware(authOnewayInboundMiddleware{
-			Host: mi.Host,
-		}),
-	}, options...)
+	var err error
+	_configsOnce.Do(func() {
+		// All the modules are going to share the same middleware. This middleware is going to be the first:
+		err = _configs.addConfig(&yarpcConfig{
+			AdvertiseName: mi.Host.Name(),
+			inboundMiddleware: []middleware.UnaryInbound{
+				fxContextInboundMiddleware{mi.Host},
+				authInboundMiddleware{mi.Host},
+			},
+			onewayInboundMiddleware: []middleware.OnewayInbound{
+				fxContextOnewayInboundMiddleware{mi.Host},
+				authOnewayInboundMiddleware{mi.Host},
+			},
+		})
+	})
+
+	if err != nil {
+		module.log.Error("Unable to create a config for common middleware", "error", err)
+		return module, errs.Wrap(err, "unable to create config with the common middleware for YARPC module")
+	}
 
 	module.log = ulog.Logger().With("moduleName", name)
 	for _, opt := range options {
@@ -105,78 +176,105 @@ func newYarpcModule(
 		}
 	}
 
-	err := module.Host().Config().Get(fmt.Sprintf("modules.%s", module.Name())).PopulateStruct(cfg)
-	// found values, update module
-	module.config = *cfg
+	err = module.Host().Config().Scope("modules").Get(module.Name()).PopulateStruct(&module.config)
+	if err != nil {
+		return module, err
+	}
 
-	module.inboundMiddlewares = inboundMiddlewaresFromCreateInfo(mi)
-	module.onewayInboundMiddlewares = onewayInboundMiddlewaresFromCreateInfo(mi)
+	module.config.inboundMiddleware = inboundMiddlewareFromCreateInfo(mi)
+	module.config.onewayInboundMiddleware = onewayInboundMiddlewareFromCreateInfo(mi)
+
+	tchTransport, err := tch.NewChannelTransport(
+		tch.ServiceName(module.config.AdvertiseName),
+		tch.ListenAddr(module.config.Bind),
+	)
+
+	module.config.inbounds = []transport.Inbound{tchTransport.NewInbound()}
 
 	return module, err
 }
 
-// Start begins serving requests over YARPC
-func (m *YarpcModule) Start(readyCh chan<- struct{}) <-chan error {
+// Start begins serving requests over RPC. It first stops the current dispatcher, merges configs from the global
+// collection and then starts the new dispatcher.
+func (m *YARPCModule) Start(readyCh chan<- struct{}) <-chan error {
+	if m.IsRunning() {
+		panic("module is already running")
+	}
+
 	m.stateMu.Lock()
 	defer m.stateMu.Unlock()
 
-	interceptor := yarpc.UnaryInboundMiddleware(m.inboundMiddlewares...)
-	onewayInterceptor := yarpc.OnewayInboundMiddleware(m.onewayInboundMiddlewares...)
-
 	ret := make(chan error, 1)
-	tchTransport, err := tch.NewChannelTransport(
-		tch.ServiceName(m.config.AdvertiseName),
-		tch.ListenAddr(m.config.Bind),
-	)
-	if err != nil {
-		ret <- errors.New("Unable to create TChannel transport " + err.Error())
+	if err := _configs.addConfig(&m.config); err != nil {
+		ret <- errors.New("can't add module config " + err.Error())
 		return ret
 	}
 
-	m.rpc, err = _dispatcherFn(m.Host(), yarpc.Config{
-		Name: m.config.AdvertiseName,
-		Inbounds: []transport.Inbound{
-			tchTransport.NewInbound(),
-		},
-		InboundMiddleware: yarpc.InboundMiddleware{
-			Unary:  interceptor,
-			Oneway: onewayInterceptor,
-		},
-		Tracer: m.Tracer(),
-	})
+	config, err := _configs.mergeConfigs()
 
+	if err != nil {
+		ret <- errors.New("unable to merge configs from multiple modules " + err.Error())
+		return ret
+	}
+
+	dispatcher, err := _dispatcherFn(m.Host(), config)
 	if err != nil {
 		ret <- err
 		return ret
 	}
 
-	m.register(m)
-	// TODO update log object to be accessed via context.Context #74
-	m.log.Info("Service started", "service", m.config.AdvertiseName, "port", m.config.Bind)
+	if err := resetDispatcher(dispatcher); err != nil {
+		ret <- err
+		return ret
+	}
 
-	ret <- m.rpc.Start()
+	m.register(m)
+	m.Host().Logger().Info("Module started",
+		"name", m.config.AdvertiseName,
+		"port", m.config.Bind)
+
+	m.isRunning = true
 	readyCh <- struct{}{}
 	return ret
 }
 
 // Stop shuts down a YARPC module
-func (m *YarpcModule) Stop() error {
+func (m *YARPCModule) Stop() error {
+	if !m.IsRunning() {
+		panic("module is not running")
+	}
+
 	m.stateMu.Lock()
 	defer m.stateMu.Unlock()
 
-	if m.rpc != nil {
-		err := m.rpc.Stop()
-		m.rpc = nil
+	if err := _configs.removeConfig(&m.config); err != nil {
 		return err
 	}
+
+	config, err := _configs.mergeConfigs()
+
+	if err != nil {
+		return errors.New("unable to merge configs from multiple modules " + err.Error())
+	}
+
+	dispatcher, err := _dispatcherFn(m.Host(), config)
+	if err != nil {
+		return err
+	}
+
+	if err := resetDispatcher(dispatcher); err != nil {
+		return err
+	}
+
+	m.isRunning = false
 	return nil
 }
 
 // IsRunning returns whether a module is running
-func (m *YarpcModule) IsRunning() bool {
+func (m *YARPCModule) IsRunning() bool {
 	m.stateMu.RLock()
 	defer m.stateMu.RUnlock()
-	return m.rpc != nil
+	return m.isRunning
 }
 
 type yarpcDispatcherFn func(service.Host, yarpc.Config) (*yarpc.Dispatcher, error)
@@ -186,6 +284,32 @@ func RegisterDispatcher(dispatchFn yarpcDispatcherFn) {
 	_dispatcherFn = dispatchFn
 }
 
-func defaultYarpcDispatcher(_ service.Host, cfg yarpc.Config) (*yarpc.Dispatcher, error) {
+func defaultYARPCDispatcher(_ service.Host, cfg yarpc.Config) (*yarpc.Dispatcher, error) {
 	return yarpc.NewDispatcher(cfg), nil
+}
+
+// Dispatcher returns a dispatcher that can be used to create clients.
+// It should be called after all modules have been started, because
+// the each module start creates a new dispatcher and stops previous.
+func Dispatcher() *yarpc.Dispatcher {
+	_muDispatcher.RLock()
+	defer _muDispatcher.RUnlock()
+	return _dispatcher
+}
+
+// Stops the current dispatcher, sets the new one and starts it.
+func resetDispatcher(d *yarpc.Dispatcher) error {
+	_muDispatcher.Lock()
+	defer _muDispatcher.Unlock()
+	if _dispatcher == nil {
+		_dispatcher = d
+		return _dispatcher.Start()
+	}
+
+	if err := _dispatcher.Stop(); err != nil {
+		return err
+	}
+
+	_dispatcher = d
+	return _dispatcher.Start()
 }

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -49,6 +49,7 @@ type YARPCModule struct {
 
 var (
 	_dispatcherFn = defaultYARPCDispatcher
+	_dispatcherMu sync.Mutex
 
 	_ service.Module = &YARPCModule{}
 
@@ -133,6 +134,8 @@ func (c *configCollection) Start(host service.Host) error {
 			return
 		}
 
+		_dispatcherMu.Lock()
+		defer _dispatcherMu.Unlock()
 		if c.dispatcher, err = _dispatcherFn(host, cfg); err != nil {
 			return
 		}
@@ -285,6 +288,8 @@ type yarpcDispatcherFn func(service.Host, yarpc.Config) (*yarpc.Dispatcher, erro
 
 // RegisterDispatcher allows you to override the YARPC dispatcher registration
 func RegisterDispatcher(dispatchFn yarpcDispatcherFn) {
+	_dispatcherMu.Lock()
+	defer _dispatcherMu.Unlock()
 	_dispatcherFn = dispatchFn
 }
 

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -78,9 +78,6 @@ type dispatcherController struct {
 	// sync configs
 	sync.RWMutex
 
-	// sync start/stop errors
-	errorMu sync.RWMutex
-
 	// idempotent start and stop
 	start      sync.Once
 	stop       sync.Once
@@ -132,9 +129,6 @@ func (c *dispatcherController) addDefaultMiddleware(host service.Host) error {
 // Starts the dispatcher: wait until all modules call start, create a single dispatcher and then start it.
 // Once started the collection will not start the dispatcher again.
 func (c *dispatcherController) Start(host service.Host) error {
-	c.errorMu.Lock()
-	defer c.errorMu.Unlock()
-
 	c.start.Do(func() {
 		var err error
 		if err = c.addDefaultMiddleware(host); err != nil {
@@ -165,8 +159,6 @@ func (c *dispatcherController) Start(host service.Host) error {
 // No-op on subsequent calls.
 // TODO: update readme/docs/examples GFM(339)
 func (c *dispatcherController) Stop() error {
-	c.errorMu.Lock()
-	defer c.errorMu.Unlock()
 	c.stop.Do(func() {
 		c.stopError = c.dispatcher.Stop()
 	})

--- a/modules/rpc/yarpc_options.go
+++ b/modules/rpc/yarpc_options.go
@@ -31,28 +31,28 @@ const (
 	_onewayInterceptorKey = "yarpcOnewayInboundMiddleware"
 )
 
-// WithInboundMiddleware adds custom YARPC inboundMiddlewares to the module
+// WithInboundMiddleware adds custom YARPC inboundMiddleware to the module
 func WithInboundMiddleware(i ...middleware.UnaryInbound) modules.Option {
 	return func(mci *service.ModuleCreateInfo) error {
-		inboundMiddlewares := inboundMiddlewaresFromCreateInfo(*mci)
-		inboundMiddlewares = append(inboundMiddlewares, i...)
-		mci.Items[_interceptorKey] = inboundMiddlewares
+		inboundMiddleware := inboundMiddlewareFromCreateInfo(*mci)
+		inboundMiddleware = append(inboundMiddleware, i...)
+		mci.Items[_interceptorKey] = inboundMiddleware
 
 		return nil
 	}
 }
 
-// WithOnewayInboundMiddleware adds custom YARPC inboundMiddlewares to the module
+// WithOnewayInboundMiddleware adds custom YARPC inboundMiddleware to the module
 func WithOnewayInboundMiddleware(i ...middleware.OnewayInbound) modules.Option {
 	return func(mci *service.ModuleCreateInfo) error {
-		inboundMiddlewares := onewayInboundMiddlewaresFromCreateInfo(*mci)
-		inboundMiddlewares = append(inboundMiddlewares, i...)
-		mci.Items[_onewayInterceptorKey] = inboundMiddlewares
+		inboundMiddleware := onewayInboundMiddlewareFromCreateInfo(*mci)
+		inboundMiddleware = append(inboundMiddleware, i...)
+		mci.Items[_onewayInterceptorKey] = inboundMiddleware
 		return nil
 	}
 }
 
-func inboundMiddlewaresFromCreateInfo(mci service.ModuleCreateInfo) []middleware.UnaryInbound {
+func inboundMiddlewareFromCreateInfo(mci service.ModuleCreateInfo) []middleware.UnaryInbound {
 	items, ok := mci.Items[_interceptorKey]
 	if !ok {
 		return nil
@@ -62,7 +62,7 @@ func inboundMiddlewaresFromCreateInfo(mci service.ModuleCreateInfo) []middleware
 	return items.([]middleware.UnaryInbound)
 }
 
-func onewayInboundMiddlewaresFromCreateInfo(mci service.ModuleCreateInfo) []middleware.OnewayInbound {
+func onewayInboundMiddlewareFromCreateInfo(mci service.ModuleCreateInfo) []middleware.OnewayInbound {
 	items, ok := mci.Items[_onewayInterceptorKey]
 	if !ok {
 		return nil

--- a/modules/rpc/yarpc_options_test.go
+++ b/modules/rpc/yarpc_options_test.go
@@ -37,7 +37,7 @@ func TestWithInboundMiddleware_OK(t *testing.T) {
 	}
 
 	require.NoError(t, opt(mc))
-	assert.Equal(t, 1, len(inboundMiddlewaresFromCreateInfo(*mc)))
+	assert.Equal(t, 1, len(inboundMiddlewareFromCreateInfo(*mc)))
 }
 
 func TestWithOnewayInboundMiddleware_OK(t *testing.T) {
@@ -46,7 +46,7 @@ func TestWithOnewayInboundMiddleware_OK(t *testing.T) {
 		Items: make(map[string]interface{}),
 	}
 	require.NoError(t, opt(mc))
-	assert.Equal(t, 1, len(onewayInboundMiddlewaresFromCreateInfo(*mc)))
+	assert.Equal(t, 1, len(onewayInboundMiddlewareFromCreateInfo(*mc)))
 }
 
 func TestWithInboundMiddleware_PanicsBadData(t *testing.T) {

--- a/modules/rpc/yarpc_test.go
+++ b/modules/rpc/yarpc_test.go
@@ -61,4 +61,5 @@ func TestMergeOfEmptyConfigCollectionReturnsError(t *testing.T) {
 	c := dispatcherController{}
 	_, err := c.mergeConfigs()
 	assert.Error(t, err)
+	assert.Error(t, c.Start(service.NopHost()))
 }

--- a/modules/rpc/yarpc_test.go
+++ b/modules/rpc/yarpc_test.go
@@ -49,7 +49,7 @@ func TestDifferentAdvertiseNameReturnsError(t *testing.T) {
 	c := configCollection{}
 	cfg := yarpcConfig{
 		AdvertiseName: "fx",
-		inbounds: []transport.Inbound{http.NewTransport().NewInbound("")},
+		inbounds:      []transport.Inbound{http.NewTransport().NewInbound("")},
 	}
 
 	require.NoError(t, c.addConfig(cfg))

--- a/modules/rpc/yarpc_test.go
+++ b/modules/rpc/yarpc_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestRegisterDispatcher_OK(t *testing.T) {
-	RegisterDispatcher(defaultYarpcDispatcher)
+	RegisterDispatcher(defaultYARPCDispatcher)
 }
 
 func makeRequest() *transport.Request {

--- a/modules/rpc/yarpc_test.go
+++ b/modules/rpc/yarpc_test.go
@@ -21,42 +21,44 @@
 package rpc
 
 import (
-	"bytes"
-	"context"
 	"testing"
 
+	"go.uber.org/fx/service"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/transport/http"
 )
 
 func TestRegisterDispatcher_OK(t *testing.T) {
+	t.Parallel()
 	RegisterDispatcher(defaultYARPCDispatcher)
 }
 
-func makeRequest() *transport.Request {
-	return &transport.Request{
-		Caller:    "the test suite",
-		Service:   "any service",
-		Encoding:  raw.Encoding,
-		Procedure: "hello",
-		Body:      bytes.NewReader([]byte{1, 2, 3}),
+func TestDispatcher(t *testing.T) {
+	t.Parallel()
+	c := configCollection{}
+	host := service.NopHost()
+	require.NoError(t, c.addConfig(yarpcConfig{AdvertiseName: host.Name(), inbounds: []transport.Inbound{}}))
+	assert.NoError(t, c.Start(host))
+}
+
+func TestDifferentAdvertiseNameReturnsError(t *testing.T) {
+	t.Parallel()
+	c := configCollection{}
+	cfg := yarpcConfig{
+		AdvertiseName: "fx",
+		inbounds: []transport.Inbound{http.NewTransport().NewInbound("")},
 	}
+
+	require.NoError(t, c.addConfig(cfg))
+	assert.Error(t, c.Start(service.NopHost()))
 }
 
-func makeHandler(err error) transport.UnaryHandler {
-	return dummyHandler{
-		err: err,
-	}
-}
-
-type dummyHandler struct {
-	err error
-}
-
-func (d dummyHandler) Handle(
-	ctx context.Context,
-	r *transport.Request,
-	w transport.ResponseWriter,
-) error {
-	return d.err
+func TestMergeOfEmptyConfigCollectionReturnsError(t *testing.T) {
+	t.Parallel()
+	c := configCollection{}
+	_, err := c.mergeConfigs()
+	assert.Error(t, err)
 }

--- a/modules/rpc/yarpc_test.go
+++ b/modules/rpc/yarpc_test.go
@@ -38,7 +38,7 @@ func TestRegisterDispatcher_OK(t *testing.T) {
 
 func TestDispatcher(t *testing.T) {
 	t.Parallel()
-	c := configCollection{}
+	c := dispatcherController{}
 	host := service.NopHost()
 	require.NoError(t, c.addConfig(yarpcConfig{AdvertiseName: host.Name(), inbounds: []transport.Inbound{}}))
 	assert.NoError(t, c.Start(host))
@@ -46,7 +46,7 @@ func TestDispatcher(t *testing.T) {
 
 func TestDifferentAdvertiseNameReturnsError(t *testing.T) {
 	t.Parallel()
-	c := configCollection{}
+	c := dispatcherController{}
 	cfg := yarpcConfig{
 		AdvertiseName: "fx",
 		inbounds:      []transport.Inbound{http.NewTransport().NewInbound("")},
@@ -58,7 +58,7 @@ func TestDifferentAdvertiseNameReturnsError(t *testing.T) {
 
 func TestMergeOfEmptyConfigCollectionReturnsError(t *testing.T) {
 	t.Parallel()
-	c := configCollection{}
+	c := dispatcherController{}
 	_, err := c.mergeConfigs()
 	assert.Error(t, err)
 }


### PR DESCRIPTION
Make a single global dispatcher that will be shared across multiple rpc modules.

The dispatcher is created when any YARPC module is started. The expected use case is:
1. Create all modules
2. Start them(the very first start will actually start the dispatcher)
...
4. Receive a shutdown signal and stop the dispatcher.

We can't start and stop multiple times because some of the transports (e.g. [http](https://github.com/yarpc/yarpc-go/blob/dev/transport/http/outbound.go#L158)) are idempotent, so we have to work with the YARPC modules in the same way.

If a user needs to create a rpc client they can use the yarpc.Dispatcher().