### PR TITLE
Remove Consume method from the async task Backend

### DIFF
--- a/modules/task/backend.go
+++ b/modules/task/backend.go
@@ -97,8 +97,10 @@ func (b *inMemBackend) Start(ready chan<- struct{}) <-chan error {
 	go func(buf chan []byte) {
 		for {
 			select {
-			case msg := <-buf:
-				errorCh <- Run(msg)
+			case msg, ok := <-buf:
+				if ok {
+					errorCh <- Run(msg)
+				}
 			case <-time.After(time.Second):
 				fmt.Println("Timed out after 1 second")
 			}

--- a/modules/task/backend.go
+++ b/modules/task/backend.go
@@ -100,6 +100,8 @@ func (b *inMemBackend) Start(ready chan<- struct{}) <-chan error {
 			case msg, ok := <-b.bufQueue:
 				if ok {
 					errorCh <- Run(msg)
+				} else {
+					return
 				}
 			case <-time.After(time.Second):
 				ulog.Logger().Error("Timed out after 1 second")

--- a/modules/task/backend.go
+++ b/modules/task/backend.go
@@ -94,10 +94,10 @@ func (b *inMemBackend) Name() string {
 func (b *inMemBackend) Start(ready chan<- struct{}) <-chan error {
 	b.isRunning = true
 	errorCh := make(chan error, 2)
-	go func(buf chan []byte) {
+	go func() {
 		for {
 			select {
-			case msg, ok := <-buf:
+			case msg, ok := <-b.bufQueue:
 				if ok {
 					errorCh <- Run(msg)
 				}
@@ -105,7 +105,7 @@ func (b *inMemBackend) Start(ready chan<- struct{}) <-chan error {
 				fmt.Println("Timed out after 1 second")
 			}
 		}
-	}(b.bufQueue)
+	}()
 	return errorCh
 }
 

--- a/modules/task/backend.go
+++ b/modules/task/backend.go
@@ -21,10 +21,10 @@
 package task
 
 import (
-	"fmt"
 	"time"
 
 	"go.uber.org/fx/service"
+	"go.uber.org/fx/ulog"
 )
 
 var gobEncoding = &GobEncoding{}
@@ -102,7 +102,7 @@ func (b *inMemBackend) Start(ready chan<- struct{}) <-chan error {
 					errorCh <- Run(msg)
 				}
 			case <-time.After(time.Second):
-				fmt.Println("Timed out after 1 second")
+				ulog.Logger().Error("Timed out after 1 second")
 			}
 		}
 	}()

--- a/modules/task/backend.go
+++ b/modules/task/backend.go
@@ -21,7 +21,8 @@
 package task
 
 import (
-	"errors"
+	"fmt"
+	"time"
 
 	"go.uber.org/fx/service"
 )
@@ -33,7 +34,6 @@ type Backend interface {
 	service.Module
 	Encoder() Encoding
 	Publish(message []byte, userContext map[string]string) error
-	Consume() error
 }
 
 // NopBackend is a noop implementation of the Backend interface
@@ -41,11 +41,6 @@ type NopBackend struct{}
 
 // Publish implements the Backend interface
 func (b NopBackend) Publish(message []byte, userContext map[string]string) error {
-	return nil
-}
-
-// Consume  implements the Backend interface
-func (b NopBackend) Consume() error {
 	return nil
 }
 
@@ -85,26 +80,6 @@ func NewInMemBackend() Backend {
 	return &inMemBackend{bufQueue: make(chan []byte, 2)}
 }
 
-// Publish implements the Backend interface
-func (b *inMemBackend) Publish(message []byte, userContext map[string]string) error {
-	b.bufQueue <- message
-	return nil
-}
-
-// Consume  implements the Backend interface
-func (b *inMemBackend) Consume() error {
-	select {
-	case v, ok := <-b.bufQueue:
-		if ok {
-			return Run(v)
-		}
-		return errors.New("The bufQueue channel has been closed")
-	default:
-		// No value ready in channel, moving on
-	}
-	return nil
-}
-
 // Encoder implements the Backend interface
 func (b *inMemBackend) Encoder() Encoding {
 	return gobEncoding
@@ -118,7 +93,26 @@ func (b *inMemBackend) Name() string {
 // Start implements the Module interface
 func (b *inMemBackend) Start(ready chan<- struct{}) <-chan error {
 	b.isRunning = true
-	return make(chan error)
+	errorCh := make(chan error, 2)
+	go func(buf chan []byte) {
+		for {
+			select {
+			case msg := <-buf:
+				errorCh <- Run(msg)
+			case <-time.After(time.Second):
+				fmt.Println("Timed out after 1 second")
+			}
+		}
+	}(b.bufQueue)
+	return errorCh
+}
+
+// Publish implements the Backend interface
+func (b *inMemBackend) Publish(message []byte, userContext map[string]string) error {
+	go func() {
+		b.bufQueue <- message
+	}()
+	return nil
 }
 
 // Stop implements the Module interface

--- a/modules/task/backend_test.go
+++ b/modules/task/backend_test.go
@@ -39,6 +39,7 @@ func TestInMemBackend(t *testing.T) {
 	publishEncodedVal(t, b, errorCh)
 	publishEncodedVal(t, b, errorCh)
 
+	assert.Equal(t, errorCh, b.Start(make(chan struct{})))
 	assert.NoError(t, b.Stop())
 	assert.False(t, b.IsRunning())
 }

--- a/modules/task/execution.go
+++ b/modules/task/execution.go
@@ -37,14 +37,14 @@ type fnRegister struct {
 
 var fnLookup = fnRegister{fnNameMap: make(map[string]interface{})}
 
-// FnSignature represents a function and its arguments
-type FnSignature struct {
+// fnSignature represents a function and its arguments
+type fnSignature struct {
 	FnName string
 	Args   []interface{}
 }
 
 // Execute executes the function
-func (s *FnSignature) Execute() ([]reflect.Value, error) {
+func (s *fnSignature) Execute() ([]reflect.Value, error) {
 	targetArgs := make([]reflect.Value, 0, len(s.Args))
 	for _, arg := range s.Args {
 		targetArgs = append(targetArgs, reflect.ValueOf(arg))
@@ -74,7 +74,7 @@ func Enqueue(fn interface{}, args ...interface{}) error {
 		return err
 	}
 	// Publish function to the backend
-	s := FnSignature{FnName: fnName, Args: args}
+	s := fnSignature{FnName: fnName, Args: args}
 
 	sBytes, err := GlobalBackend().Encoder().Marshal(s)
 	if err != nil {
@@ -113,7 +113,7 @@ func Register(fn interface{}) error {
 
 // Run decodes the message and executes as a task
 func Run(message []byte) error {
-	var s FnSignature
+	var s fnSignature
 	if err := GlobalBackend().Encoder().Unmarshal(message, &s); err != nil {
 		return errors.Wrap(err, "unable to decode the message")
 	}

--- a/modules/task/execution.go
+++ b/modules/task/execution.go
@@ -37,14 +37,14 @@ type fnRegister struct {
 
 var fnLookup = fnRegister{fnNameMap: make(map[string]interface{})}
 
-// fnSignature represents a function and its arguments
-type fnSignature struct {
+// FnSignature represents a function and its arguments
+type FnSignature struct {
 	FnName string
 	Args   []interface{}
 }
 
 // Execute executes the function
-func (s *fnSignature) Execute() ([]reflect.Value, error) {
+func (s *FnSignature) Execute() ([]reflect.Value, error) {
 	targetArgs := make([]reflect.Value, 0, len(s.Args))
 	for _, arg := range s.Args {
 		targetArgs = append(targetArgs, reflect.ValueOf(arg))
@@ -74,7 +74,7 @@ func Enqueue(fn interface{}, args ...interface{}) error {
 		return err
 	}
 	// Publish function to the backend
-	s := fnSignature{FnName: fnName, Args: args}
+	s := FnSignature{FnName: fnName, Args: args}
 
 	sBytes, err := GlobalBackend().Encoder().Marshal(s)
 	if err != nil {
@@ -113,7 +113,7 @@ func Register(fn interface{}) error {
 
 // Run decodes the message and executes as a task
 func Run(message []byte) error {
-	var s fnSignature
+	var s FnSignature
 	if err := GlobalBackend().Encoder().Unmarshal(message, &s); err != nil {
 		return errors.Wrap(err, "unable to decode the message")
 	}


### PR DESCRIPTION
When the Start method is called on backend, it should kick off the listen stream and start consuming messages. A separate method is not required as part of the interface