### PR TITLE
Call the uber-licence executable from node_modules/.bin

### DIFF
--- a/.build/check_license.sh
+++ b/.build/check_license.sh
@@ -9,7 +9,7 @@ run_uber_licence() {
   # Ok, somebody hasn't run `npm install -g uber-licence`, that's cool
   if ! which "$bin" >/dev/null ; then
     npm install "$bin" >/dev/null
-    bin="./node_modules/uber-licence/bin/licence"
+    bin="./node_modules/.bin/uber-licence"
   fi
 
   readonly local output=$("$bin" --file "*.go" | sed "s/^fix //")

--- a/.build/check_license.sh
+++ b/.build/check_license.sh
@@ -2,6 +2,10 @@
 set -eu
 set -o pipefail
 
+# add node_modules/.bin to the $PATH so we don't have to install the uber-licence
+# every time we run this script.
+PATH=$PATH:node_modules/.bin
+
 # Try to use npm/uber-licence if node is available
 LICENCE_BIN="uber-licence"
 run_uber_licence() {


### PR DESCRIPTION
The current bin path used in the script (`./node_modules/uber-licence/bin/licence`) did not work for me, because the file is now named [licence.js](https://github.com/uber/uber-licence/blob/master/bin/licence.js).  This updates the bin path to use the symlink in `node_modules/.bin`. This path will be less likely to change in the future.