### PR TITLE
Fix APP_CONFIG_DIR usage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ const (
 	_environment = "_ENVIRONMENT"
 	_datacenter  = "_DATACENTER"
 	_configDir   = "_CONFIG_DIR"
-	_config      = "config"
+	_configRoot  = "./config"
 	_baseFile    = "base"
 	_secretsFile = "secrets"
 )
@@ -62,14 +62,18 @@ func getConfigFiles() []string {
 	env := Environment()
 	dc := os.Getenv(EnvironmentPrefix() + _datacenter)
 
-	var files []string
+	baseFiles := []string{_baseFile, env, _secretsFile}
 	if dc != "" && env != "" {
-		files = append(files, fmt.Sprintf("./%s/%s-%s.yaml", _config, env, dc))
+		baseFiles = append(baseFiles, fmt.Sprintf("%s-%s", env, dc))
 	}
-	files = append(files,
-		fmt.Sprintf("./%s/%s.yaml", _config, _baseFile),
-		fmt.Sprintf("./%s/%s.yaml", _config, env),
-		fmt.Sprintf("./%s/%s.yaml", _config, _secretsFile))
+
+	var files []string
+	dirs := []string{".", _configRoot}
+	for _, dir := range dirs {
+		for _, baseFile := range baseFiles {
+			files = append(files, fmt.Sprintf("%s/%s.yaml", dir, baseFile))
+		}
+	}
 
 	return files
 }
@@ -116,7 +120,7 @@ func IsDevelopmentEnv() bool {
 func Path() string {
 	configPath := os.Getenv(EnvironmentPrefix() + _configDir)
 	if configPath == "" {
-		configPath = _config
+		configPath = _configRoot
 	}
 	return configPath
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,8 +22,9 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"testing"
+
+	"go.uber.org/fx/testutils/env"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -357,11 +358,7 @@ func TestEnvProvider_Callbacks(t *testing.T) {
 
 func TestGetConfigFiles(t *testing.T) {
 	SetEnvironmentPrefix("TEST")
-	oldDC := os.Getenv(testDatacenter)
-	os.Setenv(testDatacenter, "dc")
-	defer func() {
-		os.Setenv(testDatacenter, oldDC)
-	}()
+	defer env.Override(t, testDatacenter, "dc")()
 
 	files := getConfigFiles()
 	assert.Contains(t, files, "./base.yaml")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,6 +96,8 @@ bool: true
 int: 123
 string: test string
 `)
+
+var testDatacenter = "TEST_DATACENTER"
 
 type arrayOfStructs struct {
 	Things []nested `yaml:"things"`
@@ -350,4 +353,23 @@ func TestEnvProvider_Callbacks(t *testing.T) {
 	p := NewEnvProvider("", nil)
 	assert.NoError(t, p.RegisterChangeCallback("test", nil))
 	assert.NoError(t, p.UnregisterChangeCallback("token"))
+}
+
+func TestGetConfigFiles(t *testing.T) {
+	SetEnvironmentPrefix("TEST")
+	oldDC := os.Getenv(testDatacenter)
+	os.Setenv(testDatacenter, "dc")
+	defer func() {
+		os.Setenv(testDatacenter, oldDC)
+	}()
+
+	files := getConfigFiles()
+	assert.Contains(t, files, "./base.yaml")
+	assert.Contains(t, files, "./development.yaml")
+	assert.Contains(t, files, "./secrets.yaml")
+	assert.Contains(t, files, "./development-dc.yaml")
+	assert.Contains(t, files, "./config/base.yaml")
+	assert.Contains(t, files, "./config/development.yaml")
+	assert.Contains(t, files, "./config/secrets.yaml")
+	assert.Contains(t, files, "./config/development-dc.yaml")
 }


### PR DESCRIPTION
The `APP_CONFIG_DIR` environment variable points directly to the the configuration directory. If we want to use this directory with the `FileResolver` we need to include file names without the `./config` prefix. This diff adds those files to the list of config files.