### PR TITLE
Thriftsync plugin to sync handlers with thrift file

### DIFF
--- a/examples/keyvalue/Makefile
+++ b/examples/keyvalue/Makefile
@@ -16,3 +16,6 @@ deps:
 
 	@echo "Installing thriftrw-plugin-yarpc..."
 	$(ECHO_V)go install ../../vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
+
+	@echo "Installing thriftrw-plugin-thriftsync..."
+	$(ECHO_V)go install ../../modules/rpc/thriftrw-plugin-thriftsync

--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -23,9 +23,10 @@ package main
 import (
 	"sync"
 
+	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
+
 	"go.uber.org/fx"
 	"go.uber.org/fx/examples/keyvalue/kv"
-	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
 	"go.uber.org/fx/service"
 	"go.uber.org/yarpc/api/transport"
 )
@@ -48,7 +49,6 @@ func (h *YarpcHandler) GetValue(ctx fx.Context, key *string) (string, error) {
 	if value, ok := h.items[*key]; ok {
 		return value, nil
 	}
-
 	return "", &kv.ResourceDoesNotExist{Key: *key}
 }
 

--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -23,10 +23,9 @@ package main
 import (
 	"sync"
 
-	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
-
 	"go.uber.org/fx"
 	"go.uber.org/fx/examples/keyvalue/kv"
+	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
 	"go.uber.org/fx/service"
 	"go.uber.org/yarpc/api/transport"
 )

--- a/modules/rpc/thriftrw-plugin-thriftsync/README.md
+++ b/modules/rpc/thriftrw-plugin-thriftsync/README.md
@@ -14,7 +14,7 @@ service TestService {
 }
 ```
 
-```lang=go
+```go
 package main
 
 import (
@@ -49,7 +49,7 @@ service TestService {
 }
 ```
 
-```lang=go
+```go
 package main
 
 import (
@@ -88,7 +88,7 @@ service TestService {
 }
 ```
 
-```lang=go
+```go
 package main
 
 import (
@@ -125,7 +125,7 @@ service TestService {
     string newtestFunction(1: string param, 2: string parameter2)
 }
 ```
-```lang=go
+```go
 package main
 
 import (

--- a/modules/rpc/thriftrw-plugin-thriftsync/README.md
+++ b/modules/rpc/thriftrw-plugin-thriftsync/README.md
@@ -1,0 +1,155 @@
+## Overview
+[thriftsync] is a thriftrw plugin to identify and generate handlers for the given input
+ *.thrift file. With the use of thriftsync plugin, a user who needs to build a service should be able
+ to auto generate the code and write service specific logic without worrying about underlying platform.
+
+## Example
+Following examples show how thriftsync syncs handler code with the updated thrift file:
+
+**New handler generation**
+
+```thrift
+service TestService {
+    string testFunction(1: string param)
+}
+```
+
+```lang=go
+package main
+
+import (
+	"go.uber.org/fx"
+	"testservice/testservice/testserviceserver"
+	"go.uber.org/fx/service"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type YARPCHandler struct {
+	// TODO: modify the TestService handler with your suitable structure
+}
+
+// NewYARPCThriftHandler for your service
+func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+	handler := &YARPCHandler{}
+	return testserviceserver.New(handler), nil
+}
+
+func (h *YARPCHandler) TestFunction(ctx fx.Context, param *string) (string, error) {
+	// TODO: write your code here
+	return "", nil
+}
+```
+**New function added to thrift file**
+
+```thrift
+service TestService {
+    string testFunction(1: string param)
+
+    string newtestFunction(1: string param)
+}
+```
+
+```lang=go
+package main
+
+import (
+	"go.uber.org/fx"
+	"testservice/testservice/testserviceserver"
+	"go.uber.org/fx/service"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type YARPCHandler struct {
+	// TODO: modify the TestService handler with your suitable structure
+}
+
+// NewYARPCThriftHandler for your service
+func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+	handler := &YARPCHandler{}
+	return testserviceserver.New(handler), nil
+}
+
+func (h *YARPCHandler) testFunction(ctx fx.Context, param string) (string, error) {
+    Return "", nil
+}
+
+func (h *YARPCHandler) newtestFunction(ctx fx.Context, param string) (string, error) {
+    Return "", nil
+}
+```
+
+**New parameter added to a function**
+
+```thrift
+service TestService {
+    string testFunction(1: string param)
+
+    string newtestFunction(1: string param, 2: string parameter2)
+}
+```
+
+```lang=go
+package main
+
+import (
+	"go.uber.org/fx"
+	"testservice/testservice/testserviceserver"
+	"go.uber.org/fx/service"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type YARPCHandler struct {
+	// TODO: modify the TestService handler with your suitable structure
+}
+
+// NewYARPCThriftHandler for your service
+func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+	handler := &YARPCHandler{}
+	return testserviceserver.New(handler), nil
+}
+
+func (h *YARPCHandler) testFunction(ctx fx.Context, param string) (string, error) {
+    Return "", nil
+}
+
+func (h *YARPCHandler) newtestFunction(ctx fx.Context, param string, parameter2 string) (string, error) {
+    Return "", nil
+}
+```
+**Updated parameter names and return types**
+
+```thrift
+service TestService {
+    i64 testFunction(1: string newparameterName)
+
+    string newtestFunction(1: string param, 2: string parameter2)
+}
+```
+```lang=go
+package main
+
+import (
+	"go.uber.org/fx"
+	"testservice/testservice/testserviceserver"
+	"go.uber.org/fx/service"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type YARPCHandler struct {
+	// TODO: modify the TestService handler with your suitable structure
+}
+
+// NewYARPCThriftHandler for your service
+func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+	handler := &YARPCHandler{}
+	return testserviceserver.New(handler), nil
+}
+
+func (h *YARPCHandler) testFunction(ctx fx.Context, newparameterName string) (int64, error) {
+    return nil, nil
+}
+
+func (h *YARPCHandler) newtestFunction(ctx fx.Context, param string, parameter2 string) (string, error) {
+    return "", nil
+}
+```

--- a/modules/rpc/thriftrw-plugin-thriftsync/doc.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/doc.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package main is the Overview.
+//
+// [thriftsync] is a thriftrw plugin to identify and generate handlers for the given input
+//  *.thrift file. With the use of thriftsync plugin, a user who needs to build a service should be able
+//  to auto generate the code and write service specific logic without worrying about underlying platform.
+//
+//
+// Example
+//
+// Following examples show how thriftsync syncs handler code with the updated thrift file:
+//
+// **New handler generation**
+//
+//   service TestService {
+//       string testFunction(1: string param)
+//   }
+//
+//   package main
+//
+//   import (
+//   	"go.uber.org/fx"
+//   	"testservice/testservice/testserviceserver"
+//   	"go.uber.org/fx/service"
+//   	"go.uber.org/yarpc/api/transport"
+//   )
+//
+//   type YARPCHandler struct {
+//   	// TODO: modify the TestService handler with your suitable structure
+//   }
+//
+//   // NewYARPCThriftHandler for your service
+//   func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+//   	handler := &YARPCHandler{}
+//   	return testserviceserver.New(handler), nil
+//   }
+//
+//   func (h *YARPCHandler) TestFunction(ctx fx.Context, param *string) (string, error) {
+//   	// TODO: write your code here
+//   	return "", nil
+//   }
+//
+// **New function added to thrift file**
+//
+//   service TestService {
+//       string testFunction(1: string param)
+//
+//       string newtestFunction(1: string param)
+//   }
+//
+//   package main
+//
+//   import (
+//   	"go.uber.org/fx"
+//   	"testservice/testservice/testserviceserver"
+//   	"go.uber.org/fx/service"
+//   	"go.uber.org/yarpc/api/transport"
+//   )
+//
+//   type YARPCHandler struct {
+//   	// TODO: modify the TestService handler with your suitable structure
+//   }
+//
+//   // NewYARPCThriftHandler for your service
+//   func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+//   	handler := &YARPCHandler{}
+//   	return testserviceserver.New(handler), nil
+//   }
+//
+//   func (h *YARPCHandler) testFunction(ctx fx.Context, param string) (string, error) {
+//       Return "", nil
+//   }
+//
+//   func (h *YARPCHandler) newtestFunction(ctx fx.Context, param string) (string, error) {
+//       Return "", nil
+//   }
+//
+// **New parameter added to a function**
+//
+//   service TestService {
+//       string testFunction(1: string param)
+//
+//       string newtestFunction(1: string param, 2: string parameter2)
+//   }
+//
+//   package main
+//
+//   import (
+//   	"go.uber.org/fx"
+//   	"testservice/testservice/testserviceserver"
+//   	"go.uber.org/fx/service"
+//   	"go.uber.org/yarpc/api/transport"
+//   )
+//
+//   type YARPCHandler struct {
+//   	// TODO: modify the TestService handler with your suitable structure
+//   }
+//
+//   // NewYARPCThriftHandler for your service
+//   func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+//   	handler := &YARPCHandler{}
+//   	return testserviceserver.New(handler), nil
+//   }
+//
+//   func (h *YARPCHandler) testFunction(ctx fx.Context, param string) (string, error) {
+//       Return "", nil
+//   }
+//
+//   func (h *YARPCHandler) newtestFunction(ctx fx.Context, param string, parameter2 string) (string, error) {
+//       Return "", nil
+//   }
+//
+// **Updated parameter names and return types**
+//
+//   service TestService {
+//       i64 testFunction(1: string newparameterName)
+//
+//       string newtestFunction(1: string param, 2: string parameter2)
+//   }
+//
+//   package main
+//
+//   import (
+//   	"go.uber.org/fx"
+//   	"testservice/testservice/testserviceserver"
+//   	"go.uber.org/fx/service"
+//   	"go.uber.org/yarpc/api/transport"
+//   )
+//
+//   type YARPCHandler struct {
+//   	// TODO: modify the TestService handler with your suitable structure
+//   }
+//
+//   // NewYARPCThriftHandler for your service
+//   func NewYARPCThriftHandler(service.Host) ([]transport.Procedure, error) {
+//   	handler := &YARPCHandler{}
+//   	return testserviceserver.New(handler), nil
+//   }
+//
+//   func (h *YARPCHandler) testFunction(ctx fx.Context, newparameterName string) (int64, error) {
+//       return nil, nil
+//   }
+//
+//   func (h *YARPCHandler) newtestFunction(ctx fx.Context, param string, parameter2 string) (string, error) {
+//       return "", nil
+//   }
+//
+//
+package main

--- a/modules/rpc/thriftrw-plugin-thriftsync/generate.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/generate.go
@@ -32,8 +32,8 @@ const newHandlerTemplate = `
 // Running thriftsync will only update method signatures, and new methods added to *.thrift
 
 <$pkgname   := .HandlerPackageName>
-
 package <$pkgname>
+
 <$core      := import "go.uber.org/fx">
 <$transport := import "go.uber.org/yarpc/api/transport">
 <$service   := import "go.uber.org/fx/service">

--- a/modules/rpc/thriftrw-plugin-thriftsync/generate.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/generate.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"path/filepath"
+
+	"go.uber.org/thriftrw/plugin"
+)
+
+const newHandlerTemplate = `
+// This is a basic template for a standard Handler for your thrift service defined in the *.thrift input
+// Please modify and write your service specific code/data structures at your descrition.
+// Running thriftsync will only update method signatures, and new methods added to *.thrift
+
+<$pkgname   := .HandlerPackageName>
+
+package <$pkgname>
+<$core      := import "go.uber.org/fx">
+<$transport := import "go.uber.org/yarpc/api/transport">
+<$service   := import "go.uber.org/fx/service">
+
+type YARPCHandler struct{
+  // TODO: modify the <.Service.Name> handler with your suitable structure
+}
+// NewYARPCThriftHandler for your service
+func NewYARPCThriftHandler(<$service>.Host) ([]<$transport>.Procedure, error) {
+  handler := &YARPCHandler{}
+  return <lower .Service.Name>server.New(handler), nil
+}
+
+<$name := lower .Service.Name>
+<range .Service.Functions>
+
+  func (h *YARPCHandler)<.Name>(ctx fx.Context, <range .Arguments> <lower .Name> <formatType .Type>, <end>)<if .ReturnType> (<formatType .ReturnType>, error) <else> error <end> {
+    // TODO: write your code here
+    return nil
+  }
+
+<end>
+`
+
+// HandlerGenerator struct
+type HandlerGenerator struct {
+	opts Options
+}
+
+// NewHandlerGenerator creates a HandlerGenerator for thrift sync
+func NewHandlerGenerator(opts Options) HandlerGenerator {
+	return HandlerGenerator{
+		opts: opts,
+	}
+}
+
+// GenerateHandler generates new handlers
+func (hg *HandlerGenerator) GenerateHandler() ([]byte, error) {
+	handlerFilePath := filepath.Join(hg.opts.baseDir, hg.opts.packageName, "handler.go")
+	return plugin.GoFileFromTemplate(
+		handlerFilePath, newHandlerTemplate, hg.opts.data, hg.opts.templateOptions...)
+}

--- a/modules/rpc/thriftrw-plugin-thriftsync/main.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/main.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/thriftrw/plugin"
+	"go.uber.org/thriftrw/plugin/api"
+)
+
+// Command line flags
+var (
+	_baseDir = flag.String("base-dir",
+		"server",
+		"Path from root where handlers should live")
+	_handlerPackageName = flag.String("handler-package",
+		"main",
+		"Handler package name, defaults to 'main'")
+	_handlerFileName = flag.String("handler-file",
+		"handlers.go",
+		"File name for handlers")
+)
+
+var templateOptions = []plugin.TemplateOption{
+	plugin.TemplateFunc("lower", strings.ToLower),
+}
+
+type generator struct{}
+
+func (generator) Generate(req *api.GenerateServiceRequest) (*api.GenerateServiceResponse, error) {
+	files := make(map[string][]byte)
+	for _, serviceID := range req.RootServices {
+		service := req.Services[serviceID]
+		module := req.Modules[service.ModuleID]
+
+		var (
+			parent       *api.Service
+			parentModule *api.Module
+		)
+		if service.ParentID != nil {
+			parent = req.Services[*service.ParentID]
+			parentModule = req.Modules[parent.ModuleID]
+		}
+
+		templateData := struct {
+			Module             *api.Module
+			Service            *api.Service
+			Parent             *api.Service
+			ParentModule       *api.Module
+			HandlerPackageName string
+		}{
+			Module:             module,
+			Service:            service,
+			Parent:             parent,
+			ParentModule:       parentModule,
+			HandlerPackageName: *_handlerPackageName,
+		}
+
+		gofilePath := filepath.Join(*_baseDir, "handlers.go")
+		opts := NewOptions(*_baseDir, *_handlerPackageName, templateOptions, templateData)
+
+		if _, err := os.Stat(gofilePath); os.IsNotExist(err) {
+			g := NewHandlerGenerator(opts)
+			handlerContents, err := g.GenerateHandler()
+			if err != nil {
+				return nil, err
+			}
+			files[gofilePath] = handlerContents
+		} else {
+			f := NewUpdater(opts)
+			if err := f.UpdateExistingHandlerFile(service, gofilePath, *_baseDir); err != nil {
+				return nil, err
+			} else if err = f.RefreshAll(service, gofilePath); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &api.GenerateServiceResponse{Files: files}, nil
+}
+
+func main() {
+	flag.Parse()
+	plugin.Main(&plugin.Plugin{Name: "thriftsync", ServiceGenerator: generator{}})
+}

--- a/modules/rpc/thriftrw-plugin-thriftsync/options.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/options.go
@@ -20,26 +20,22 @@
 
 package main
 
-// import (
-// 	"go.uber.org/fx"
-// 	"go.uber.org/fx/ulog"
-// 	"go.uber.org/fx/modules/kafka"
-// 	"golang.org/x/net/context"
-// )
+import "go.uber.org/thriftrw/plugin"
 
-// // Create the handler instance for the given topic
-// func CreateMyTopicHandler(topic string, service *fx.Service) kafka.HandlerCreateFunc {
-// 	return func() (kakfa.Handler, error) {
-// 		instance := &MyTopicHandler{}
-// 		return instance.MyTopic, nil
-// 	}
-// }
+// Options for thriftsync
+type Options struct {
+	baseDir         string
+	packageName     string
+	templateOptions []plugin.TemplateOption
+	data            interface{}
+}
 
-// type MyTopicHandler struct {
-// }
-
-// // MyTopic handles messages from topic 'my_topic'
-// func (h *MyTopicHandler) MyTopic(ctx context.Context, message consumer.Message) error {
-// 	ulog.Logger().Info("I got a message", "topic", message.Topic())
-// 	return nil
-// }
+// NewOptions creates options for thriftsync generator and updater
+func NewOptions(baseDir string, packageName string, templateOptions []plugin.TemplateOption, data interface{}) Options {
+	return Options{
+		baseDir:         baseDir,
+		packageName:     packageName,
+		templateOptions: templateOptions,
+		data:            data,
+	}
+}

--- a/modules/rpc/thriftrw-plugin-thriftsync/update.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/update.go
@@ -73,15 +73,15 @@ func (u *Updater) UpdateExistingHandlerFile(
 	goFilePath string,
 	handlerDir string) error {
 
-	newData, err := u.compare(service, goFilePath, handlerDir)
+	newFuncs, err := u.compare(service, goFilePath, handlerDir)
 	if err != nil {
 		return err
 	}
-	data, err := u.generate(goFilePath, newData)
+	appendBytes, err := u.generate(goFilePath, newFuncs)
 	if err != nil {
 		return err
 	}
-	return appendToExisting(goFilePath, bytes.Trim(data, "package discardme"))
+	return appendToExisting(goFilePath, bytes.Trim(appendBytes, "package discardme"))
 }
 
 func (u *Updater) compare(service *api.Service, filepath string, handlerDir string) (*updatedData, error) {
@@ -89,12 +89,11 @@ func (u *Updater) compare(service *api.Service, filepath string, handlerDir stri
 		return nil, err
 	}
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, filepath, nil, 0)
+	file, err := parser.ParseFile(token.NewFileSet(), filepath, nil, 0)
 	if err != nil {
 		return nil, err
 	}
-	newDatas := &updatedData{
+	updated := &updatedData{
 		Service: service,
 	}
 
@@ -110,10 +109,10 @@ func (u *Updater) compare(service *api.Service, filepath string, handlerDir stri
 			return true
 		})
 		if contains == false {
-			newDatas.Functions = append(newDatas.Functions, function)
+			updated.Functions = append(updated.Functions, function)
 		}
 	}
-	return newDatas, err
+	return updated, err
 }
 
 // RefreshAll creates new funcs if they are missing from *.go file, and updates

--- a/modules/rpc/thriftrw-plugin-thriftsync/update.go
+++ b/modules/rpc/thriftrw-plugin-thriftsync/update.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io/ioutil"
+	"os"
+
+	"go.uber.org/thriftrw/plugin"
+	"go.uber.org/thriftrw/plugin/api"
+)
+
+const funcOnlyTemplate = `
+package discardme
+
+<$name := lower .Service.Name>
+
+<range .Functions>
+
+  func (h *YARPCHandler)<.Name>(ctx fx.Context, <range .Arguments> <lower .Name> <formatType .Type>, <end>)<if .ReturnType> (<formatType .ReturnType>, error) <else> error <end> {
+    // TODO: write your code here
+    return nil
+  }
+
+<end>
+`
+
+// Updater struct
+type Updater struct {
+	opts Options
+}
+
+// NewUpdater returns new Updater for thrift sync
+func NewUpdater(opts Options) Updater {
+	return Updater{
+		opts: opts,
+	}
+}
+
+type updatedData struct {
+	Service   *api.Service
+	Functions []*api.Function
+}
+
+// UpdateExistingHandlerFile sync existing handler file with the thrift idl
+// with any missing methods
+func (u *Updater) UpdateExistingHandlerFile(
+	service *api.Service,
+	goFilePath string,
+	handlerDir string) error {
+
+	newData, err := u.compare(service, goFilePath, handlerDir)
+	if err != nil {
+		return err
+	}
+	data, err := u.generate(goFilePath, newData)
+	if err != nil {
+		return err
+	}
+	return appendToExisting(goFilePath, bytes.Trim(data, "package discardme"))
+}
+
+func (u *Updater) compare(service *api.Service, filepath string, handlerDir string) (*updatedData, error) {
+	if _, err := os.Stat(handlerDir); os.IsNotExist(err) {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	newDatas := &updatedData{
+		Service: service,
+	}
+
+	for _, function := range service.Functions {
+		var contains = false
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.FuncDecl:
+				if function.Name == x.Name.Name {
+					contains = true
+				}
+			}
+			return true
+		})
+		if contains == false {
+			newDatas.Functions = append(newDatas.Functions, function)
+		}
+	}
+	return newDatas, err
+}
+
+// RefreshAll creates new funcs if they are missing from *.go file, and updates
+// all the existing functions from the idl.
+func (u *Updater) RefreshAll(service *api.Service, filepath string) error {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath, nil, parser.ParseComments)
+	if err != nil {
+		return err
+	}
+	for _, function := range service.Functions {
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.FuncDecl:
+				if x.Name.Name == function.Name {
+					exp, err := u.createExpr(filepath, service, function)
+					if err != nil {
+						return false
+					}
+
+					ast.Inspect(exp, func(n ast.Node) bool {
+						switch y := n.(type) {
+						case *ast.FuncType:
+							x.Type = &ast.FuncType{
+								Params:  y.Params,
+								Results: y.Results,
+								Func:    y.Func,
+							}
+						}
+						return true
+					})
+				}
+			}
+			return true
+		})
+	}
+	if err := os.Remove(filepath); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0660)
+	if err := printer.Fprint(f, fset, file); err != nil {
+		return err
+	}
+	return err
+}
+
+func (u *Updater) createExpr(filepath string, service *api.Service, f *api.Function) (*ast.File, error) {
+	buff, err := u.generateSingleFunction(filepath, service, f)
+	tmpf, err := ioutil.TempFile("", "tempbuff")
+	if _, err := tmpf.Write(buff); err != nil {
+		return nil, err
+	}
+	exp, err := parser.ParseFile(token.NewFileSet(), tmpf.Name(), nil, parser.ParseComments)
+	if err := os.Remove(tmpf.Name()); err != nil {
+		return nil, err
+	}
+	return exp, err
+}
+
+func (u *Updater) generateSingleFunction(goFilePath string, service *api.Service, f *api.Function) ([]byte, error) {
+	var funcs []*api.Function
+	newData := &updatedData{
+		Service:   service,
+		Functions: append(funcs, f),
+	}
+	return u.generate(goFilePath, newData)
+}
+
+func (u *Updater) generate(goFilePath string, newData *updatedData) ([]byte, error) {
+	funcData := struct {
+		Service   *api.Service
+		Functions []*api.Function
+	}{
+		Service:   newData.Service,
+		Functions: newData.Functions,
+	}
+
+	return plugin.GoFileFromTemplate(
+		goFilePath, funcOnlyTemplate, funcData, u.opts.templateOptions...)
+}
+
+func appendToExisting(filepath string, contents []byte) error {
+
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_APPEND, 0660)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(contents); err != nil {
+		return fmt.Errorf("failed to append to file %q: %v", filepath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
GFM-162
Executing following go generate command creates ``server/handlers.go`` with necessary struct and methods.
``//go:generate thriftrw "--plugin=thriftsync" <thrift_filename>``

thriftsync provides sync between handler code and thrift file for any method signature change. The plugin looks for updating any new methods that are added.