### PR TITLE
Fix number of arguments in error call

### DIFF
--- a/examples/keyvalue/server/main.go
+++ b/examples/keyvalue/server/main.go
@@ -21,11 +21,10 @@
 package main
 
 import (
-	"log"
-
 	"go.uber.org/fx/modules"
 	"go.uber.org/fx/modules/rpc"
 	"go.uber.org/fx/service"
+	"go.uber.org/fx/ulog"
 )
 
 func main() {
@@ -40,7 +39,7 @@ func main() {
 	).Build()
 
 	if err != nil {
-		log.Fatal("Unable to initialize service: ", err)
+		ulog.Logger().Fatal("Unable to initialize service", "error", err)
 	}
 
 	svc.Start()

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -32,7 +32,7 @@ func main() {
 	).Build()
 
 	if err != nil {
-		ulog.Logger().Fatal("Unable to initialize service: ", err)
+		ulog.Logger().Fatal("Unable to initialize service", "error", err)
 	}
 
 	svc.Start()


### PR DESCRIPTION
While creating a new example, I noticed our setup is actually not correct.
We panic at runtime with incorrect number of arguments provided to the log function.