### PR TITLE
Add APP_ROOT environment variable to file resolver

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ const (
 	_environment = "_ENVIRONMENT"
 	_datacenter  = "_DATACENTER"
 	_configDir   = "_CONFIG_DIR"
+	_root        = "_ROOT"
 	_configRoot  = "./config"
 	_baseFile    = "base"
 	_secretsFile = "secrets"

--- a/config/config.go
+++ b/config/config.go
@@ -38,10 +38,10 @@ const (
 )
 
 const (
+	_appRoot     = "APP_ROOT"
 	_environment = "_ENVIRONMENT"
 	_datacenter  = "_DATACENTER"
 	_configDir   = "_CONFIG_DIR"
-	_root        = "_ROOT"
 	_configRoot  = "./config"
 	_baseFile    = "base"
 	_secretsFile = "secrets"
@@ -58,6 +58,21 @@ var (
 var (
 	_devEnv = "development"
 )
+
+// AppRoot returns the root directory of your application. UberFx developers
+// can edit this via the APP_ROOT environment variable. If the environment
+// variable is not set then it will fallback to the current working directory.
+// This is often used for resolving relative paths in your service.
+func AppRoot() string {
+	if appRoot := os.Getenv(_appRoot); appRoot != "" {
+		return appRoot
+	}
+	if cwd, err := os.Getwd(); err != nil {
+		panic(fmt.Sprintf("Unable to get the current working directory: %s", err.Error()))
+	} else {
+		return cwd
+	}
+}
 
 func getConfigFiles() []string {
 	env := Environment()

--- a/config/file_resolver.go
+++ b/config/file_resolver.go
@@ -42,13 +42,7 @@ func NewRelativeResolver(paths ...string) FileResolver {
 
 	copy(pathList, paths)
 
-	if appRoot := os.Getenv(EnvironmentPrefix() + _root); appRoot != "" {
-		// add the app root
-		pathList = append(pathList, appRoot)
-	} else if cwd, err := os.Getwd(); err == nil {
-		// add the current cwd
-		pathList = append(pathList, cwd)
-	}
+	pathList = append(pathList, AppRoot())
 
 	// add the exe dir
 	pathList = append(pathList, path.Dir(os.Args[0]))

--- a/config/file_resolver.go
+++ b/config/file_resolver.go
@@ -42,8 +42,11 @@ func NewRelativeResolver(paths ...string) FileResolver {
 
 	copy(pathList, paths)
 
-	// add the current cwd
-	if cwd, err := os.Getwd(); err == nil {
+	if appRoot := os.Getenv(EnvironmentPrefix() + _root); appRoot != "" {
+		// add the app root
+		pathList = append(pathList, appRoot)
+	} else if cwd, err := os.Getwd(); err == nil {
+		// add the current cwd
 		pathList = append(pathList, cwd)
 	}
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -102,7 +102,7 @@ func TestAppRoot(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	defer env.Override(t, "TEST_ROOT", path.Join(cwd, "testdata"))()
+	defer env.Override(t, _appRoot, path.Join(cwd, "testdata"))()
 	provider := NewYAMLProviderFromFiles(false, NewRelativeResolver(), "base.yaml", "dev.yaml", "secrets.yaml")
 
 	baseValue := provider.Get("value").AsString()

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -23,9 +23,13 @@ package config
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
+	"path"
 	"reflect"
 	"testing"
 	"time"
+
+	"go.uber.org/fx/testutils/env"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,6 +87,23 @@ func TestYamlStructChild(t *testing.T) {
 
 func TestExtends(t *testing.T) {
 	provider := NewYAMLProviderFromFiles(false, NewRelativeResolver("./testdata"), "base.yaml", "dev.yaml", "secrets.yaml")
+
+	baseValue := provider.Get("value").AsString()
+	assert.Equal(t, "base_only", baseValue)
+
+	devValue := provider.Get("value_override").AsString()
+	assert.Equal(t, "dev_setting", devValue)
+
+	secretValue := provider.Get("secret").AsString()
+	assert.Equal(t, "my_secret", secretValue)
+}
+
+func TestAppRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	defer env.Override(t, "TEST_ROOT", path.Join(cwd, "testdata"))()
+	provider := NewYAMLProviderFromFiles(false, NewRelativeResolver(), "base.yaml", "dev.yaml", "secrets.yaml")
 
 	baseValue := provider.Get("value").AsString()
 	assert.Equal(t, "base_only", baseValue)


### PR DESCRIPTION
This gives developers the ability to set the root directory of their application. This can be useful for resolving relative directories during service configuration.