### PR TITLE
Add config.ResolvePath helper for resolving relative paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -62,7 +64,6 @@ var (
 // AppRoot returns the root directory of your application. UberFx developers
 // can edit this via the APP_ROOT environment variable. If the environment
 // variable is not set then it will fallback to the current working directory.
-// This is often used for resolving relative paths in your service.
 func AppRoot() string {
 	if appRoot := os.Getenv(_appRoot); appRoot != "" {
 		return appRoot
@@ -72,6 +73,19 @@ func AppRoot() string {
 	} else {
 		return cwd
 	}
+}
+
+// ResolvePath returns an absolute path derived from AppRoot and the relative path.
+// If the input parameter is is already an absolute path it will be returned immediately.
+func ResolvePath(relative string) (string, error) {
+	if filepath.IsAbs(relative) {
+		return relative, nil
+	}
+	abs := path.Join(AppRoot(), relative)
+	if _, err := os.Stat(abs); err != nil {
+		return "", err
+	}
+	return abs, nil
 }
 
 func getConfigFiles() []string {

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ func AppRoot() string {
 }
 
 // ResolvePath returns an absolute path derived from AppRoot and the relative path.
-// If the input parameter is is already an absolute path it will be returned immediately.
+// If the input parameter is already an absolute path it will be returned immediately.
 func ResolvePath(relative string) (string, error) {
 	if filepath.IsAbs(relative) {
 		return relative, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"testing"
 
 	"go.uber.org/fx/testutils/env"
@@ -369,4 +371,29 @@ func TestGetConfigFiles(t *testing.T) {
 	assert.Contains(t, files, "./config/development.yaml")
 	assert.Contains(t, files, "./config/secrets.yaml")
 	assert.Contains(t, files, "./config/development-dc.yaml")
+}
+
+func expectedResolvePath(t *testing.T) string {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	return path.Join(cwd, "testdata")
+}
+
+func TestResolvePath(t *testing.T) {
+	res, err := ResolvePath("testdata")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResolvePath(t), res)
+}
+
+func TestResolvePathInvalid(t *testing.T) {
+	res, err := ResolvePath("invalid")
+	assert.Error(t, err)
+	assert.Equal(t, "", res)
+}
+
+func TestResolvePathAbs(t *testing.T) {
+	abs := expectedResolvePath(t)
+	res, err := ResolvePath(abs)
+	assert.NoError(t, err)
+	assert.Equal(t, abs, res)
 }


### PR DESCRIPTION
ResolvePath returns an absolute path derived from AppRoot and the relative path. If the input parameter is is already an absolute path it will be returned immediately.