### PR TITLE
Integrate richgo for better test output

### DIFF
--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -18,6 +18,7 @@ deps: libdeps
 	$(ECHO_V)go install ./vendor/github.com/sectioneight/md-to-godoc
 	@$(call label,Installing interfacer...)
 	$(ECHO_V)go install ./vendor/github.com/mvdan/interfacer/cmd/interfacer
+	$(ECHO_V)richgo testfilter 2>/dev/null || ($(call label,Installing richgo) && go get github.com/sectioneight/richgo)
 
 GOCOV := gocov
 OVERALLS := overalls

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.out
 *.html
 *.coverprofile
+coverage.txt
 *.pprof
 node_modules
 /.bin

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cef0b0139c5289591e3eb35c47578f35f82b5b6b9bab694d81a55bc5dab7b852
-updated: 2017-02-02T05:45:45.584806318-08:00
+hash: 379df26cbe8a7715f2b1926325de0a111ca5f2ea87e8a053457f99ba7025a108
+updated: 2017-02-02T07:28:04.397672278-08:00
 imports:
 - name: github.com/apache/thrift
   version: de9c330b24c9190078eefb68c864d2a41a4dee07
@@ -144,8 +144,10 @@ testImports:
 - name: github.com/pborman/uuid
   version: 1b00554d822231195d1babd97ff4a781231955c9
 - name: github.com/russross/blackfriday
-  version: a4dd8ad4a6fda03e68be3eacb71efbf51565415e
+  version: ad7f7c56d58a2c7f75a14cdcaa8b8acd5dc4f141
 - name: github.com/sectioneight/md-to-godoc
   version: f274e5a4257c85a9eaf60ac820ee813b78cac6ab
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
+- name: github.com/yookoala/realpath
+  version: c416d99ab5ed256fa30c1f3bab73152deb59bb69

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 7bb20f339469516288de7af1c3679bf6f448ec48552a1457f2ec2651609a3577
-updated: 2017-01-27T10:40:56.247602225-08:00
+hash: cef0b0139c5289591e3eb35c47578f35f82b5b6b9bab694d81a55bc5dab7b852
+updated: 2017-02-02T05:45:45.584806318-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 96be8c8d9408548966b3fb2895a8b84ac1045a37
+  version: de9c330b24c9190078eefb68c864d2a41a4dee07
   subpackages:
   - lib/go/thrift
 - name: github.com/certifi/gocertifi
@@ -37,7 +37,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
   - assert
   - require
@@ -59,7 +59,7 @@ imports:
   - transport/udp
   - utils
 - name: github.com/uber/tchannel-go
-  version: aeda4836756434b4077ca7ef4b6a8c0d6b382101
+  version: 79387824978f91318be3bfb43ae12e04c38cfe97
   subpackages:
   - internal/argreader
   - relay
@@ -72,10 +72,17 @@ imports:
   version: c98a13058faa5dd41584a77221a268d2c72d832d
   subpackages:
   - envelope
+  - internal/envelope
   - internal/envelope/exception
+  - internal/frame
+  - internal/goast
+  - internal/multiplex
   - internal/semver
+  - plugin
+  - plugin/api
   - protocol
   - protocol/binary
+  - ptr
   - version
   - wire
 - name: go.uber.org/yarpc
@@ -99,10 +106,14 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 007e530097ad7f954752df63046b4036f98ba6a6
   subpackages:
   - context
   - context/ctxhttp
+- name: golang.org/x/tools
+  version: 1529f889eb4b594d1f047f2fb8d5b3cc85c8f006
+  subpackages:
+  - go/ast/astutil
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
@@ -113,7 +124,7 @@ testImports:
   subpackages:
   - gocov
 - name: github.com/go-playground/overalls
-  version: dab02cad1edafb5aa1d38729ba4bfd5618b836ce
+  version: b52dfefba43cf6f75bb177ba45697ed12e0d10a2
 - name: github.com/golang/lint
   version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
   subpackages:
@@ -138,7 +149,3 @@ testImports:
   version: f274e5a4257c85a9eaf60ac820ee813b78cac6ab
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
-- name: golang.org/x/tools
-  version: 1529f889eb4b594d1f047f2fb8d5b3cc85c8f006
-  subpackages:
-  - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -47,6 +47,9 @@ testImport:
   # Force glide to get the latest version. Newer than this should be fine,
   # but older than this doesn't support -go-binary flag I added
   version: b52dfefba43cf6f75bb177ba45697ed12e0
+  # dependency of overalls that isn't imported in code. we REALLY need a
+  # separate manifest for build tools. that's a problem for future-aiden though
+- package: github.com/yookoala/realpath
 - package: github.com/sectioneight/md-to-godoc
   version: master
 # specified manually since we don't import md-to-godoc

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,6 +44,9 @@ testImport:
   - gocov
 - package: github.com/axw/gocov
 - package: github.com/go-playground/overalls
+  # Force glide to get the latest version. Newer than this should be fine,
+  # but older than this doesn't support -go-binary flag I added
+  version: b52dfefba43cf6f75bb177ba45697ed12e0
 - package: github.com/sectioneight/md-to-godoc
   version: master
 # specified manually since we don't import md-to-godoc


### PR DESCRIPTION
A few things are going on here:

First, we're upgrading overalls for a PR I merged this morning (https://github.com/go-playground/overalls/pull/18) that adds
suppor for richgo (https://github.com/kyoh86/richgo). We're currently
pointing at my fork of richgo until my PRs get merged.

Mostly we need this: https://github.com/kyoh86/richgo/pull/6

But I also fixed some stuff about TTY handling that I have an open issue
with the author for.

The second thing I changed is that the coverage data is now dumped to
coverage.txt by default. It grew large enough that it didn't fit on a
single page, or even three pages. The output of richgo actually gives
you package-level coverage and visualization so I think this is a good
tradeoff. A few new ways to run the tests, but the default is my
favorite:

```
make test TEST_FLAGS=-v
```

This shows off richgo's really neat features, but is more verbose

```
make test COVER=1
```

This returns the old behavior of showing the gigantic coverage breakdown
on stdout after each test run.