### PR TITLE
Log stacktrace for wrapped errors

### DIFF
--- a/ulog/log.go
+++ b/ulog/log.go
@@ -197,9 +197,9 @@ func (l *baseLogger) fieldsConversion(keyVals ...interface{}) []zap.Field {
 				stack := value.StackTrace()
 				lines := make([]zap.Field, 0, len(stack))
 				for _, frame := range stack {
-					s := fmt.Sprintf("%s", frame)
-					l := fmt.Sprintf("line:%d", frame)
-					lines = append(lines, zap.String(s, l))
+					function := fmt.Sprintf("%n", frame)
+					source := fmt.Sprintf("%v", frame)
+					lines = append(lines, zap.String(function, source))
 				}
 
 				fields = append(fields, zap.Nest("stacktrace", lines...), zap.Error(value))

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -21,7 +21,7 @@
 package ulog
 
 import (
-	err "errors"
+	stdlibErr "errors"
 	"fmt"
 	"time"
 
@@ -162,7 +162,7 @@ type stackTracer interface {
 
 func (l *baseLogger) fieldsConversion(keyVals ...interface{}) []zap.Field {
 	if len(keyVals)%2 != 0 {
-		return []zap.Field{zap.Error(err.New("expected even number of arguments"))}
+		return []zap.Field{zap.Error(stdlibErr.New("expected even number of arguments"))}
 	}
 
 	fields := make([]zap.Field, 0, len(keyVals)/2)

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -197,7 +197,9 @@ func (l *baseLogger) fieldsConversion(keyVals ...interface{}) []zap.Field {
 				stack := value.StackTrace()
 				lines := make([]zap.Field, 0, len(stack))
 				for _, frame := range stack {
-					function := fmt.Sprintf("%n", frame)
+					// Trick go vet to allow use of %n as a formatter
+					format := "%n"
+					function := fmt.Sprintf(format, frame)
 					source := fmt.Sprintf("%v", frame)
 					lines = append(lines, zap.String(function, source))
 				}

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -170,7 +170,7 @@ func TestStackTraceLogger(t *testing.T) {
 		err1 := errors.New("for sure")
 		err2 := errors.Wrap(err1, "it's a trap")
 		log.Error("error message", "error", err2)
-		trace := `{"level":"error","msg":"error message","stacktrace":{"log_test.go":"line:171","in_memory_log.go":"line:60","log_test.go":"line:178"`
+		trace := `{"level":"error","msg":"error message","stacktrace":{"TestStackTraceLogger.func1":"log_test.go:171","WithInMemoryLogger":"in_memory_log.go:60",`
 		line := buf.Lines()[0]
 		assert.Contains(t, line, trace, "No stack trace")
 		assert.Contains(t, line, "it's a trap: for sure")

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -27,10 +27,11 @@ import (
 	"time"
 
 	"go.uber.org/fx/testutils"
+	"go.uber.org/fx/ulog/sentry"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/zap"
-	"go.uber.org/fx/ulog/sentry"
 )
 
 func TestSimpleLogger(t *testing.T) {
@@ -160,4 +161,19 @@ func TestSentryHookDoesNotMutatePrevious(t *testing.T) {
 	assert.NotNil(t, l2.sh)
 	assert.NotNil(t, l2.sh.Fields())
 	assert.Equal(t, map[string]interface{}{"key": "value"}, l2.sh.Fields())
+}
+
+func TestStackTraceLogger(t *testing.T) {
+	t.Parallel()
+	testutils.WithInMemoryLogger(t, nil, func(zapLogger zap.Logger, buf *testutils.TestBuffer) {
+		log := Builder().SetLogger(zapLogger).Build()
+		err1 := errors.New("for sure")
+		err2 := errors.Wrap(err1, "it's a trap")
+		log.Error("error message", "error", err2)
+		trace := `{"level":"error","msg":"error message","stacktrace":{"log_test.go":"line:171","in_memory_log.go":"line:60","log_test.go":"line:178"`
+		line := buf.Lines()[0]
+		assert.Contains(t, line, trace, "No stack trace")
+		assert.Contains(t, line, "it's a trap: for sure")
+		assert.Equal(t, 1, len(buf.Lines()))
+	})
 }


### PR DESCRIPTION
If an error contains StackTrace() we'll wrap using format:
"functionName":"{filename}:line#" with the full error message.