### PR TITLE
Populate struct with non-ptr user defined types

### DIFF
--- a/config/value.go
+++ b/config/value.go
@@ -497,7 +497,7 @@ func (cv Value) valueStruct(key string, target interface{}) (interface{}, error)
 			}
 			if val != nil {
 				// First try to convert primitive type values, if convertValue wasn't able
-				// to convert to primitive,try converting the value asa struct value
+				// to convert to primitive,try converting the value as a struct value
 				if ret, err := convertValue(val, fieldType); ret != nil {
 					if err != nil {
 						return nil, err

--- a/config/value.go
+++ b/config/value.go
@@ -343,8 +343,8 @@ func convertValueFromStruct(value interface{}, targetType reflect.Type, fieldTyp
 	// The fieldType is probably a custom type here. We will try and set the fieldValue by
 	// the custom type
 	// TODO: refactor switch cases into isType functions
-	kind := fieldType.Kind()
-	switch kind {
+	// TODO: refactor this whole method
+	switch fieldType.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		fieldValue.SetInt(int64(value.(int)))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:

--- a/config/value.go
+++ b/config/value.go
@@ -334,12 +334,14 @@ func derefType(t reflect.Type) reflect.Type {
 }
 
 func convertValueFromStruct(value interface{}, targetType reflect.Type, fieldType reflect.Type, fieldValue reflect.Value) (interface{}, error) {
-	if ret, err := convertValue(value, targetType); ret != nil {
+	ret, err := convertValue(value, targetType)
+	if ret != nil {
+		// convertValue was a success
 		return ret, err
 	}
 
-	// The fieldType is probably custom type here. We will try and set the fieldValue by
-	// the type of custom type
+	// The fieldType is probably a custom type here. We will try and set the fieldValue by
+	// the custom type
 	// TODO: refactor switch cases into isType functions
 	kind := fieldType.Kind()
 	switch kind {
@@ -356,7 +358,8 @@ func convertValueFromStruct(value interface{}, targetType reflect.Type, fieldTyp
 	default:
 		return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value).String(), targetType)
 	}
-	return nil, nil
+
+	return ret, nil
 }
 
 // this is a quick-and-dirty conversion method that only handles

--- a/config/value.go
+++ b/config/value.go
@@ -348,6 +348,7 @@ func convertStructValue(value interface{}, targetType reflect.Type, fieldType re
 
 	// The fieldType is probably custom type here. We will try and set the fieldValue by
 	// the type of custom type
+	// TODO: refactor switch cases into isType functions
 	kind := fieldType.Kind()
 	switch kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -361,7 +362,7 @@ func convertStructValue(value interface{}, targetType reflect.Type, fieldType re
 	case reflect.String:
 		fieldValue.SetString(value.(string))
 	default:
-		return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value), targetType)
+		return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value).String(), targetType)
 	}
 	return nil, nil
 }

--- a/config/value.go
+++ b/config/value.go
@@ -336,7 +336,7 @@ func derefType(t reflect.Type) reflect.Type {
 func convertPrimitiveValue(value interface{}, targetType reflect.Type) (interface{}, error) {
 	ret, err := convertVal(value, targetType)
 	if ret == nil {
-		return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value), targetType)
+		return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value).String(), targetType)
 	}
 	return ret, err
 }
@@ -355,9 +355,11 @@ func convertStructValue(value interface{}, targetType reflect.Type, fieldType re
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		fieldValue.SetUint(uint64(value.(int)))
 	case reflect.Float32, reflect.Float64:
-		fieldValue.SetFloat(float64(value.(float64)))
+		fieldValue.SetFloat(value.(float64))
+	case reflect.Bool:
+		fieldValue.SetBool(value.(bool))
 	case reflect.String:
-		fieldValue.SetString(string(value.(string)))
+		fieldValue.SetString(value.(string))
 	default:
 		return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value), targetType)
 	}
@@ -477,9 +479,11 @@ func (cv Value) valueStruct(key string, target interface{}) (interface{}, error)
 						case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 							fieldValue.Elem().SetUint(uint64(val.(int)))
 						case reflect.Float32, reflect.Float64:
-							fieldValue.Elem().SetFloat(float64(val.(float64)))
+							fieldValue.Elem().SetFloat(val.(float64))
+						case reflect.Bool:
+							fieldValue.Elem().SetBool(val.(bool))
 						case reflect.String:
-							fieldValue.Elem().SetString(string(val.(string)))
+							fieldValue.Elem().SetString(val.(string))
 						default:
 							fieldValue.Elem().Set(reflect.ValueOf(val))
 						}

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -255,6 +255,17 @@ func TestTypeOfTypes(t *testing.T) {
 		tts := typeStructStruct{}
 		err := provider.Get(Root).PopulateStruct(&tts)
 		assert.NoError(t, err)
+		assert.Equal(t, userDefinedTypeInt(123), tts.TypeStruct.TestInt)
+		assert.Equal(t, userDefinedTypeUInt(456), tts.TypeStruct.TestUInt)
+		assert.Equal(t, userDefinedTypeFloat(123.456), tts.TypeStruct.TestFloat)
+	})
+}
+
+func TestTypeOfTypesPtr(t *testing.T) {
+	withYamlBytes(t, typeStructYaml, func(provider Provider) {
+		tts := typeStructStructPtr{}
+		err := provider.Get(Root).PopulateStruct(&tts)
+		assert.NoError(t, err)
 		assert.Equal(t, userDefinedTypeInt(123), *tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), *tts.TypeStruct.TestUInt)
 		assert.Equal(t, userDefinedTypeFloat(123.456), *tts.TypeStruct.TestFloat)

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -258,6 +258,11 @@ func TestTypeOfTypes(t *testing.T) {
 		assert.Equal(t, userDefinedTypeInt(123), tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), tts.TypeStruct.TestUInt)
 		assert.Equal(t, userDefinedTypeFloat(123.456), tts.TypeStruct.TestFloat)
+		assert.Equal(t, userDefinedTypeBool(true), tts.TypeStruct.TestBool)
+		assert.Equal(t, userDefinedTypeString("hello"), tts.TypeStruct.TestString)
+		assert.Equal(t, 10*time.Second, tts.TypeStruct.TestDuration.Seconds)
+		assert.Equal(t, 20*time.Minute, tts.TypeStruct.TestDuration.Minutes)
+		assert.Equal(t, 30*time.Hour, tts.TypeStruct.TestDuration.Hours)
 	})
 }
 
@@ -269,6 +274,27 @@ func TestTypeOfTypesPtr(t *testing.T) {
 		assert.Equal(t, userDefinedTypeInt(123), *tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), *tts.TypeStruct.TestUInt)
 		assert.Equal(t, userDefinedTypeFloat(123.456), *tts.TypeStruct.TestFloat)
+		assert.Equal(t, userDefinedTypeBool(true), *tts.TypeStruct.TestBool)
+		assert.Equal(t, userDefinedTypeString("hello"), *tts.TypeStruct.TestString)
+		assert.Equal(t, 10*time.Second, tts.TypeStruct.TestDuration.Seconds)
+		assert.Equal(t, 20*time.Minute, tts.TypeStruct.TestDuration.Minutes)
+		assert.Equal(t, 30*time.Hour, tts.TypeStruct.TestDuration.Hours)
+	})
+}
+
+func TestTypeOfTypesPtrPtr(t *testing.T) {
+	withYamlBytes(t, typeStructYaml, func(provider Provider) {
+		tts := typeStructStructPtrPtr{}
+		err := provider.Get(Root).PopulateStruct(&tts)
+		assert.NoError(t, err)
+		assert.Equal(t, userDefinedTypeInt(123), *tts.TypeStruct.TestInt)
+		assert.Equal(t, userDefinedTypeUInt(456), *tts.TypeStruct.TestUInt)
+		assert.Equal(t, userDefinedTypeFloat(123.456), *tts.TypeStruct.TestFloat)
+		assert.Equal(t, userDefinedTypeBool(true), *tts.TypeStruct.TestBool)
+		assert.Equal(t, userDefinedTypeString("hello"), *tts.TypeStruct.TestString)
+		assert.Equal(t, 10*time.Second, tts.TypeStruct.TestDuration.Seconds)
+		assert.Equal(t, 20*time.Minute, tts.TypeStruct.TestDuration.Minutes)
+		assert.Equal(t, 30*time.Hour, tts.TypeStruct.TestDuration.Hours)
 	})
 }
 

--- a/config/yaml_test_data.go
+++ b/config/yaml_test_data.go
@@ -138,10 +138,22 @@ type nestedTypeUInt uint32
 type userDefinedTypeFloat nestedTypeFloat
 type nestedTypeFloat float32
 
-type nestedTypeStruct struct {
+type nestedTypeStructPtr struct {
 	TestInt   *userDefinedTypeInt   `yaml:"testInt"`
 	TestUInt  *userDefinedTypeUInt  `yaml:"testUInt"`
 	TestFloat *userDefinedTypeFloat `yaml:"testFloat"`
+}
+
+type typeStructPtr nestedTypeStructPtr
+
+type typeStructStructPtr struct {
+	TypeStruct typeStructPtr `yaml:"typeStruct"`
+}
+
+type nestedTypeStruct struct {
+	TestInt   userDefinedTypeInt   `yaml:"testInt"`
+	TestUInt  userDefinedTypeUInt  `yaml:"testUInt"`
+	TestFloat userDefinedTypeFloat `yaml:"testFloat"`
 }
 
 type typeStruct nestedTypeStruct

--- a/config/yaml_test_data.go
+++ b/config/yaml_test_data.go
@@ -138,10 +138,21 @@ type nestedTypeUInt uint32
 type userDefinedTypeFloat nestedTypeFloat
 type nestedTypeFloat float32
 
+type userDefinedTypeBool nestedTypeBool
+type nestedTypeBool bool
+
+type userDefinedTypeString nestedTypeString
+type nestedTypeString string
+
+type userDefinedTypeDuration durationStruct
+
 type nestedTypeStructPtr struct {
-	TestInt   *userDefinedTypeInt   `yaml:"testInt"`
-	TestUInt  *userDefinedTypeUInt  `yaml:"testUInt"`
-	TestFloat *userDefinedTypeFloat `yaml:"testFloat"`
+	TestInt      *userDefinedTypeInt      `yaml:"testInt"`
+	TestUInt     *userDefinedTypeUInt     `yaml:"testUInt"`
+	TestFloat    *userDefinedTypeFloat    `yaml:"testFloat"`
+	TestBool     *userDefinedTypeBool     `yaml:"testBool"`
+	TestString   *userDefinedTypeString   `yaml:"testString"`
+	TestDuration *userDefinedTypeDuration `yaml:"testDuration"`
 }
 
 type typeStructPtr nestedTypeStructPtr
@@ -150,10 +161,17 @@ type typeStructStructPtr struct {
 	TypeStruct typeStructPtr `yaml:"typeStruct"`
 }
 
+type typeStructStructPtrPtr struct {
+	TypeStruct *typeStructPtr `yaml:"typeStruct"`
+}
+
 type nestedTypeStruct struct {
-	TestInt   userDefinedTypeInt   `yaml:"testInt"`
-	TestUInt  userDefinedTypeUInt  `yaml:"testUInt"`
-	TestFloat userDefinedTypeFloat `yaml:"testFloat"`
+	TestInt      userDefinedTypeInt      `yaml:"testInt"`
+	TestUInt     userDefinedTypeUInt     `yaml:"testUInt"`
+	TestFloat    userDefinedTypeFloat    `yaml:"testFloat"`
+	TestBool     userDefinedTypeBool     `yaml:"testBool"`
+	TestString   userDefinedTypeString   `yaml:"testString"`
+	TestDuration userDefinedTypeDuration `yaml:"testDuration"`
 }
 
 type typeStruct nestedTypeStruct
@@ -167,6 +185,12 @@ typeStruct:
   testInt: 123
   testUInt: 456
   testFloat: 123.456
+  testBool: true
+  testString: hello
+  testDuration:
+    seconds: 10s
+    minutes: 20m
+    hours: 30h
 `)
 
 var happyTextUnmarshallerYaml = []byte(`


### PR DESCRIPTION
1. populateStruct when variables are non pointers, and user defined types
2. Refactored convertValue to work with both primitive type Get() and PopulateStruct()