### PR TITLE
Refactor config providers

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/fx/testutils/env"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var envValues = map[string]string{
@@ -400,5 +401,9 @@ func TestResolvePathAbs(t *testing.T) {
 
 func TestEnvProviderWithEmptyPrefix(t *testing.T) {
 	p := NewEnvProvider("", mapEnvironmentProvider{map[string]string{"key": "value"}})
-	assert.Equal(t, "value", p.Get("key").AsString())
+	require.Equal(t, "value", p.Get("key").AsString())
+	emptyScope := p.Scope("")
+	require.Equal(t, "value", emptyScope.Get("key").AsString())
+	scope := emptyScope.Scope("key")
+	require.Equal(t, "value", scope.Get("").AsString())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -397,3 +397,8 @@ func TestResolvePathAbs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, abs, res)
 }
+
+func TestEnvProviderWithEmptyPrefix(t *testing.T) {
+	p := NewEnvProvider("", mapEnvironmentProvider{map[string]string{"key": "value"}})
+	assert.Equal(t, "value", p.Get("key").AsString())
+}

--- a/config/env.go
+++ b/config/env.go
@@ -42,7 +42,12 @@ var _ Provider = &envConfigProvider{}
 
 // foo.bar -> [prefix]__foo__bar
 func toEnvString(prefix string, key string) string {
-	return fmt.Sprintf("%s__%s", prefix, strings.Replace(key, ".", "__", -1))
+	newKey := strings.Replace(key, ".", "__", -1)
+	if prefix == "" {
+		return newKey
+	}
+
+	return fmt.Sprintf("%s__%s", prefix, newKey)
 }
 
 // NewEnvProvider creates a configuration provider backed by an environment
@@ -75,7 +80,7 @@ func (p envConfigProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, p)
 }
 
-func (p envConfigProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (p envConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Environments don't receive callback events
 	return nil
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -20,8 +20,8 @@
 
 package config
 
-// ConfigurationChangeCallback is called for updates of configuration data
-type ConfigurationChangeCallback func(key string, provider string, configdata interface{})
+// ChangeCallback is called for updates of configuration data
+type ChangeCallback func(key string, provider string, data interface{})
 
 // Root marks the root node in a Provider
 const Root = ""
@@ -37,54 +37,54 @@ type Provider interface {
 
 	// A RegisterChangeCallback provides callback registration for config providers.
 	// These callbacks are nop if a dynamic provider is not configured for the service.
-	RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error
+	RegisterChangeCallback(key string, callback ChangeCallback) error
 	UnregisterChangeCallback(token string) error
 }
 
-// ScopedProvider defines recursive interface of providers based on the prefix
-type ScopedProvider struct {
+// scopedProvider defines recursive interface of providers based on the prefix
+type scopedProvider struct {
 	Provider
 
 	prefix string
 }
 
 // NewScopedProvider creates a child provider given a prefix
-func NewScopedProvider(prefix string, provider Provider) *ScopedProvider {
-	return &ScopedProvider{provider, prefix}
+func NewScopedProvider(prefix string, provider Provider) Provider {
+	if prefix == "" {
+		return provider
+	}
+
+	return &scopedProvider{provider, prefix}
 }
 
-func addPrefix(prefix, key string) string {
-	if prefix == "" {
-		return key
-	}
-
+func (sp scopedProvider) addPrefix(key string) string {
 	if key == "" {
-		return prefix
+		return sp.prefix
 	}
 
-	return prefix + "." + key
+	return sp.prefix + "." + key
 }
 
 // Get returns configuration value
-func (sp ScopedProvider) Get(key string) Value {
-	return sp.Provider.Get(addPrefix(sp.prefix, key))
+func (sp scopedProvider) Get(key string) Value {
+	return sp.Provider.Get(sp.addPrefix(key))
 }
 
 // Scope returns new scoped provider, given a prefix
-func (sp ScopedProvider) Scope(prefix string) Provider {
+func (sp scopedProvider) Scope(prefix string) Provider {
 	if prefix == "" {
 		return sp
 	}
 
-	return NewScopedProvider(addPrefix(sp.prefix, prefix), sp.Provider)
+	return NewScopedProvider(sp.addPrefix(prefix), sp.Provider)
 }
 
 // RegisterChangeCallback registers the callback in the underlying provider
-func (sp ScopedProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
-	return sp.Provider.RegisterChangeCallback(addPrefix(sp.prefix, key), callback)
+func (sp scopedProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
+	return sp.Provider.RegisterChangeCallback(sp.addPrefix(key), callback)
 }
 
 // UnregisterChangeCallback un registers a callback in the underlying provider
-func (sp ScopedProvider) UnregisterChangeCallback(key string) error {
-	return sp.Provider.UnregisterChangeCallback(addPrefix(sp.prefix, key))
+func (sp scopedProvider) UnregisterChangeCallback(key string) error {
+	return sp.Provider.UnregisterChangeCallback(sp.addPrefix(key))
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -54,7 +54,10 @@ func NewScopedProvider(prefix string, provider Provider) Provider {
 		return provider
 	}
 
-	return &scopedProvider{provider, prefix}
+	return &scopedProvider{
+		Provider: provider,
+		prefix:   prefix,
+	}
 }
 
 func (sp scopedProvider) addPrefix(key string) string {

--- a/config/provider_group.go
+++ b/config/provider_group.go
@@ -65,7 +65,7 @@ func (p providerGroup) Name() string {
 	return p.name
 }
 
-func (p providerGroup) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (p providerGroup) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	for _, provider := range p.providers {
 		if err := provider.RegisterChangeCallback(key, callback); err != nil {
 			return err

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -121,7 +121,7 @@ func TestScope_WithScopedProvider(t *testing.T) {
 
 type mockDynamicProvider struct {
 	data      map[string]interface{}
-	callBacks map[string]ConfigurationChangeCallback
+	callBacks map[string]ChangeCallback
 }
 
 // StaticProvider should only be used in tests to isolate config from your environment
@@ -155,9 +155,9 @@ func (s *mockDynamicProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, s)
 }
 
-func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	if s.callBacks == nil {
-		s.callBacks = make(map[string]ConfigurationChangeCallback)
+		s.callBacks = make(map[string]ChangeCallback)
 	}
 
 	if _, ok := s.callBacks[key]; ok {
@@ -170,7 +170,7 @@ func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback Config
 
 func (s *mockDynamicProvider) UnregisterChangeCallback(token string) error {
 	if s.callBacks == nil {
-		s.callBacks = make(map[string]ConfigurationChangeCallback)
+		s.callBacks = make(map[string]ChangeCallback)
 	}
 
 	if _, ok := s.callBacks[token]; !ok {

--- a/config/static_provider.go
+++ b/config/static_provider.go
@@ -24,13 +24,8 @@ type staticProvider struct {
 	data map[string]interface{}
 }
 
-type scopedStaticProvider struct {
-	Provider
-
-	prefix string
-}
-
 // NewStaticProvider should only be used in tests to isolate config from your environment
+// It is not race free, because underlying map can be accessed with Value().
 func NewStaticProvider(data map[string]interface{}) Provider {
 	return &staticProvider{
 		data: data,

--- a/config/static_provider.go
+++ b/config/static_provider.go
@@ -20,13 +20,7 @@
 
 package config
 
-import (
-	"fmt"
-	"sync"
-)
-
 type staticProvider struct {
-	sync.RWMutex
 	data map[string]interface{}
 }
 
@@ -55,23 +49,19 @@ func (*staticProvider) Name() string {
 }
 
 func (s *staticProvider) Get(key string) Value {
-	s.RLock()
-	defer s.RUnlock()
-
 	if key == "" {
-		// NOTE: This returns access to the underlying map, which does not guarantee
-		// thread-safety. This is only used in the test suite.
 		return NewValue(s, key, s.data, true, GetType(s.data), nil)
 	}
+
 	val, found := s.data[key]
 	return NewValue(s, key, val, found, GetType(val), nil)
 }
 
 func (s *staticProvider) Scope(prefix string) Provider {
-	return newScopedStaticProvider(s, prefix)
+	return NewScopedProvider(prefix, s)
 }
 
-func (s *staticProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (s *staticProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Static provider don't receive callback events
 	return nil
 }
@@ -81,19 +71,4 @@ func (s *staticProvider) UnregisterChangeCallback(token string) error {
 	return nil
 }
 
-func newScopedStaticProvider(s *staticProvider, prefix string) Provider {
-	return &scopedStaticProvider{
-		Provider: s,
-		prefix:   prefix,
-	}
-}
-
-func (s *scopedStaticProvider) Get(key string) Value {
-	if s.prefix != "" {
-		key = fmt.Sprintf("%s.%s", s.prefix, key)
-	}
-	return s.Provider.Get(key)
-}
-
 var _ Provider = &staticProvider{}
-var _ Provider = &scopedStaticProvider{}

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -43,7 +43,7 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 	var root interface{} = make(map[interface{}]interface{})
 	for _, v := range files {
 		curr := make(map[interface{}]interface{})
-		if err := unmarshalYamlValue(v, &curr); err != nil {
+		if err := unmarshalYAMLValue(v, &curr); err != nil {
 			panic(err)
 		}
 
@@ -114,9 +114,9 @@ func NewYAMLProviderFromFiles(mustExist bool, resolver FileResolver, files ...st
 	return newYAMLProviderCore(readers...)
 }
 
-// NewYamlProviderFromReader creates a configuration provider from a list of `io.ReadClosers`.
+// NewYAMLProviderFromReader creates a configuration provider from a list of `io.ReadClosers`.
 // As above, all the objects are going to be merged and arrays/values overridden in the order of the files.
-func NewYamlProviderFromReader(readers ...io.ReadCloser) Provider {
+func NewYAMLProviderFromReader(readers ...io.ReadCloser) Provider {
 	return newYAMLProviderCore(readers...)
 }
 
@@ -168,7 +168,7 @@ func (y yamlConfigProvider) Scope(prefix string) Provider {
 	return NewScopedProvider(prefix, y)
 }
 
-func (y yamlConfigProvider) RegisterChangeCallback(key string, callback ConfigurationChangeCallback) error {
+func (y yamlConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Yaml configuration don't receive callback events
 	return nil
 }
@@ -274,7 +274,7 @@ func (n *yamlNode) Children() []*yamlNode {
 	return nodes
 }
 
-func unmarshalYamlValue(reader io.ReadCloser, value interface{}) error {
+func unmarshalYAMLValue(reader io.ReadCloser, value interface{}) error {
 	if data, err := ioutil.ReadAll(reader); err != nil {
 		return err
 	} else if err = yaml.Unmarshal(data, value); err != nil {

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -115,9 +115,9 @@ func TestAppRoot(t *testing.T) {
 	assert.Equal(t, "my_secret", secretValue)
 }
 
-func TestNewYamlProviderFromReader(t *testing.T) {
+func TestNewYAMLProviderFromReader(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(yamlConfig1))
-	provider := NewYamlProviderFromReader(ioutil.NopCloser(buff))
+	provider := NewYAMLProviderFromReader(ioutil.NopCloser(buff))
 	cs := &configStruct{}
 	assert.NoError(t, provider.Get(Root).PopulateStruct(cs))
 	assert.Equal(t, "yaml", provider.Scope(Root).Name())
@@ -125,10 +125,10 @@ func TestNewYamlProviderFromReader(t *testing.T) {
 	assert.Equal(t, "owner@service.com", cs.Owner)
 }
 
-func TestYamlNode(t *testing.T) {
+func TestYAMLNode(t *testing.T) {
 	buff := bytes.NewBuffer([]byte("a: b"))
 	node := &yamlNode{value: make(map[interface{}]interface{})}
-	err := unmarshalYamlValue(ioutil.NopCloser(buff), &node.value)
+	err := unmarshalYAMLValue(ioutil.NopCloser(buff), &node.value)
 	require.NoError(t, err)
 	assert.Equal(t, "map[a:b]", node.String())
 	assert.Equal(t, "map[interface {}]interface {}", node.Type().String())
@@ -138,7 +138,7 @@ func TestYamlNodeWithNil(t *testing.T) {
 	provider := NewYAMLProviderFromFiles(false, nil)
 	assert.NotNil(t, provider)
 	assert.Panics(t, func() {
-		_ = unmarshalYamlValue(nil, nil)
+		_ = unmarshalYAMLValue(nil, nil)
 	}, "Expected panic with nil inpout.")
 }
 


### PR DESCRIPTION
Mostly renaming: 
unstutter ConfigurationChangeCallback -> ChangeCallback
Yaml ->YAML

Remove lock from staticProvider: it is read only, no reason to do any locks.
Fix Env provider in case of empty prefix.
Make scopeProvider private: all other providers are private. This also removes a need a prefix check for every lookup.