### PR TITLE
Use string to log stacktrace

### DIFF
--- a/ulog/log.go
+++ b/ulog/log.go
@@ -205,17 +205,9 @@ func (l *baseLogger) fieldsConversion(keyVals ...interface{}) []zap.Field {
 			case fmt.Stringer:
 				fields = append(fields, zap.Stringer(key, value))
 			case stackTracer:
-				stack := value.StackTrace()
-				lines := make([]zap.Field, 0, len(stack))
-				for _, frame := range stack {
-					// Trick go vet to allow use of %n as a formatter
-					format := "%n"
-					function := fmt.Sprintf(format, frame)
-					source := fmt.Sprintf("%v", frame)
-					lines = append(lines, zap.String(function, source))
-				}
-
-				fields = append(fields, zap.Nest("stacktrace", lines...), zap.Error(value))
+				fields = append(fields,
+					zap.String("stacktrace", fmt.Sprintf("%+v", value.StackTrace())),
+					zap.Error(value))
 			case error:
 				fields = append(fields, zap.Error(value))
 			default:

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -23,6 +23,7 @@ package ulog
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -183,9 +184,9 @@ func TestStackTraceLogger(t *testing.T) {
 		log.Error("error message", "error", err2)
 		line := buf.Lines()[0]
 		assert.Contains(t, line, "TestStackTraceLogger.func1", "Missing first function")
-		assert.Contains(t, line, "log_test.go:172", "Missing source")
+		assert.Contains(t, line, filepath.Join("ulog", "log_test.go:"), "Missing source")
 		assert.Contains(t, line, "testutils.WithInMemoryLogger", "Missing second function")
-		assert.Contains(t, line, "in_memory_log.go:60", "Missing source")
+		assert.Contains(t, line, filepath.Join("testutils", "in_memory_log.go:"), "Missing source")
 		assert.True(t, strings.Index(line, "log_test.go") < strings.Index(line, "in_memory_log.go"))
 
 		assert.Contains(t, line, "it's a trap: for sure")

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -181,8 +181,11 @@ func TestStackTraceLogger(t *testing.T) {
 		err2 := errors.Wrap(err1, "it's a trap")
 		log.Error("error message", "error", err2)
 		line := buf.Lines()[0]
-		assert.Contains(t, line, "WithInMemoryLogger", "Missing trace for memory logger function")
-		assert.Contains(t, line, "TestStackTraceLogger", "Missing trace for test function")
+		assert.Contains(t, line, "TestStackTraceLogger.func1", "Missing first function")
+		assert.Contains(t, line, "log_test.go:171", "Missing source")
+		assert.Contains(t, line, "testutils.WithInMemoryLogger", "Missing second function")
+		assert.Contains(t, line, "in_memory_log.go:60", "Missing source")
+
 		assert.Contains(t, line, "it's a trap: for sure")
 		assert.Equal(t, 1, len(buf.Lines()))
 	})

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -23,6 +23,7 @@ package ulog
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -182,9 +183,10 @@ func TestStackTraceLogger(t *testing.T) {
 		log.Error("error message", "error", err2)
 		line := buf.Lines()[0]
 		assert.Contains(t, line, "TestStackTraceLogger.func1", "Missing first function")
-		assert.Contains(t, line, "log_test.go:171", "Missing source")
+		assert.Contains(t, line, "log_test.go:172", "Missing source")
 		assert.Contains(t, line, "testutils.WithInMemoryLogger", "Missing second function")
 		assert.Contains(t, line, "in_memory_log.go:60", "Missing source")
+		assert.True(t, strings.Index(line, "log_test.go") < strings.Index(line, "in_memory_log.go"))
 
 		assert.Contains(t, line, "it's a trap: for sure")
 		assert.Equal(t, 1, len(buf.Lines()))

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -184,9 +184,11 @@ func TestStackTraceLogger(t *testing.T) {
 		log.Error("error message", "error", err2)
 		line := buf.Lines()[0]
 		assert.Contains(t, line, "TestStackTraceLogger.func1", "Missing first function")
-		assert.Contains(t, line, filepath.Join("ulog", "log_test.go:"), "Missing source")
+		assert.Contains(t, line, filepath.Join("ulog", "log_test.go"), "Missing source")
+		assert.Regexp(t, `log_test.go:\d+`, line, "Missing line numbers")
+
 		assert.Contains(t, line, "testutils.WithInMemoryLogger", "Missing second function")
-		assert.Contains(t, line, filepath.Join("testutils", "in_memory_log.go:"), "Missing source")
+		assert.Contains(t, line, filepath.Join("testutils", "in_memory_log.go"), "Missing source")
 		assert.True(t, strings.Index(line, "log_test.go") < strings.Index(line, "in_memory_log.go"))
 
 		assert.Contains(t, line, "it's a trap: for sure")


### PR DESCRIPTION
Log stacktrace zap-way:
https://github.com/uber-go/zap/blob/master/field.go#L146

Unfortunately errors package doesn't provide a granular format control for the entire stack, so I opted out for simplicity to log the full trace with full path, line numbers and function names.