### PR TITLE
Tidy up make test output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ space := $(null) #
 OVERALLS_IGNORE = $(subst $(space),$(comma),$(strip $(COVER_IGNORES)))
 
 ifeq ($(V),0)
-_FILTER_OVERALLS = cat
+_FILTER_OVERALLS = grep -v "^Test args"
 else
 _FILTER_OVERALLS = grep -v "^Processing:"
 endif


### PR DESCRIPTION
The output is no longer littered with test args used in coveralls.
Noise can be resumed with V=1 param, if necessary

```
$ make clean test
Installing thriftrw...
Installing thriftrw-plugin-yarpc...
Installing thriftrw-plugin-thriftsync...
Cleaning old profile
Running tests
| go.uber.org/fx
2017/02/07 15:42:25 PASS | go.uber.org/fx/modules/kafka 0.013s
2017/02/07 15:42:25 COVER| 0.0% [__________]
2017/02/07 15:42:28 PASS | go.uber.org/fx/metrics 0.879s
2017/02/07 15:42:28 COVER| 90.3% [#########_]
2017/02/07 15:42:28 PASS | go.uber.org/fx/ulog/metrics 0.779s
2017/02/07 15:42:28 COVER| 100.0% [##########]
2017/02/07 15:42:28 PASS | go.uber.org/fx/auth 0.640s
2017/02/07 15:42:28 COVER| 100.0% [##########]
2017/02/07 15:42:28 PASS | go.uber.org/fx/config 0.725s
2017/02/07 15:42:28 COVER| 92.6% [#########_]
2017/02/07 15:42:29 PASS | go.uber.org/fx/ulog/sentry 0.665s
2017/02/07 15:42:29 COVER| 100.0% [##########]
2017/02/07 15:42:29 PASS | go.uber.org/fx/internal/fxcontext 0.256s
2017/02/07 15:42:29 COVER| 100.0% [##########]
2017/02/07 15:42:29 PASS | go.uber.org/fx/modules/uhttp/client 0.231s
2017/02/07 15:42:29 COVER| 100.0% [##########]
2017/02/07 15:42:29 PASS | go.uber.org/fx/modules 0.274s
2017/02/07 15:42:29 COVER| 100.0% [##########]
2017/02/07 15:42:29 PASS | go.uber.org/fx/tracing 0.378s
2017/02/07 15:42:29 COVER| 85.0% [########__]
2017/02/07 15:42:29 PASS | go.uber.org/fx/modules/task 0.417s
2017/02/07 15:42:29 COVER| 99.2% [#########_]
2017/02/07 15:42:29 PASS | go.uber.org/fx/ulog 0.471s
2017/02/07 15:42:29 COVER| 97.2% [#########_]
2017/02/07 15:42:29 PASS | go.uber.org/fx/modules/uhttp 0.306s
2017/02/07 15:42:29 COVER| 94.4% [#########_]
2017/02/07 15:42:30 PASS | go.uber.org/fx/service 0.397s
2017/02/07 15:42:30 COVER| 88.5% [########__]
2017/02/07 15:42:30 PASS | go.uber.org/fx/modules/rpc 0.380s
2017/02/07 15:42:30 COVER| 95.3% [#########_]
Generating coverage report
```