### PR TITLE
Add testing logger and sink

### DIFF
--- a/ulog/log.go
+++ b/ulog/log.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
+	"github.com/uber-go/zap/spy"
 )
 
 type baseLogger struct {
@@ -86,6 +87,16 @@ func defaultLogger() Log {
 	return &baseLogger{
 		log: zap.New(zap.NewJSONEncoder()),
 	}
+}
+
+// TestingLogger returns basic logger and underlying sink for testing the messages
+// WithInMemoryLogger testing helper can also be used to test actual outputted
+// JSON bytes
+func TestingLogger() (Log, *spy.Sink) {
+	log, sink := spy.New()
+	return &baseLogger{
+		log: log,
+	}, sink
 }
 
 // Logger returns the package-level logger configured for the service

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -34,6 +34,16 @@ import (
 	"github.com/uber-go/zap"
 )
 
+func TestZapSink(t *testing.T) {
+	l, s := TestingLogger()
+	l.Info("This is my message", "And this is", "My field")
+	assert.Equal(t, 1, len(s.Logs()))
+
+	e := s.Logs()[0]
+	assert.Equal(t, "This is my message", e.Msg)
+	assert.Contains(t, e.Fields, zap.String("And this is", "My field"))
+}
+
 func TestSimpleLogger(t *testing.T) {
 	testutils.WithInMemoryLogger(t, nil, func(zapLogger zap.Logger, buf *testutils.TestBuffer) {
 		log := Builder().SetLogger(zapLogger).Build()
@@ -170,9 +180,9 @@ func TestStackTraceLogger(t *testing.T) {
 		err1 := errors.New("for sure")
 		err2 := errors.Wrap(err1, "it's a trap")
 		log.Error("error message", "error", err2)
-		trace := `{"level":"error","msg":"error message","stacktrace":{"TestStackTraceLogger.func1":"log_test.go:171","WithInMemoryLogger":"in_memory_log.go:60",`
 		line := buf.Lines()[0]
-		assert.Contains(t, line, trace, "No stack trace")
+		assert.Contains(t, line, "WithInMemoryLogger", "Missing trace for memory logger function")
+		assert.Contains(t, line, "TestStackTraceLogger", "Missing trace for test function")
 		assert.Contains(t, line, "it's a trap: for sure")
 		assert.Equal(t, 1, len(buf.Lines()))
 	})


### PR DESCRIPTION
GFM-47

`WithInMemoryLogger` gives access to the logged bytes. This sink adds access to the underlying zap tuples and logged message, in the same way that zap itself is tested.

Very useful for testing that traceID was included with a particular value, for instance, without having to construct part of that JSON to validate against the logged bytes.