### PR TITLE
use http.Request context

### DIFF
--- a/examples/simple/handlers.go
+++ b/examples/simple/handlers.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,7 +31,7 @@ import (
 
 type exampleHandler struct{}
 
-func (exampleHandler) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (exampleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, fmt.Sprintf("Headers: %+v", r.Header))
 }
 
@@ -48,10 +47,9 @@ func registerHTTPers(service service.Host) []uhttp.RouteHandler {
 	}
 }
 
-type simpleFilter struct {
-}
+type simpleFilter struct{}
 
-func (simpleFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next uhttp.Handler) {
+func (simpleFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	io.WriteString(w, "Going through simpleFilter")
-	next.ServeHTTP(ctx, w, r)
+	next.ServeHTTP(w, r)
 }

--- a/modules/uhttp/README.md
+++ b/modules/uhttp/README.md
@@ -7,7 +7,6 @@ but the details of that are abstracted away through `uhttp.RouteHandler`.
 package main
 
 import (
-  "context"
   "io"
   "net/http"
 
@@ -29,8 +28,8 @@ func main() {
 }
 
 func registerHTTP(service service.Host) []uhttp.RouteHandler {
-  handleHome := http.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-    fx.Logger(ctx).Info("Inside the handler")
+  handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    fx.Logger(r.Context()).Info("Inside the handler")
     io.WriteString(w, "Hello, world")
   })
 
@@ -76,8 +75,8 @@ func main() {
 ### Benchmark results:
 ```
 Current performance benchmark data:
-BenchmarkClientFilters/empty-8         	  500000	      3517 ns/op	     256 B/op	       2 allocs/op
-BenchmarkClientFilters/tracing-8       	   20000	     64421 ns/op	    1729 B/op	      29 allocs/op
-BenchmarkClientFilters/auth-8          	   50000	     36574 ns/op	     728 B/op	      16 allocs/op
-BenchmarkClientFilters/default-8       	   10000	    104374 ns/op	    2275 B/op	      43 allocs/op
+BenchmarkClientFilters/empty-8         	100000000	        10.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkClientFilters/tracing-8       	  500000	      3918 ns/op	    1729 B/op	      27 allocs/op
+BenchmarkClientFilters/auth-8          	 1000000	      1866 ns/op	     719 B/op	      14 allocs/op
+BenchmarkClientFilters/default-8       	  300000	      5604 ns/op	    2477 B/op	      41 allocs/op
 ```

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -21,7 +21,6 @@
 package client
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -58,18 +57,18 @@ func newExecutionChain(
 	}
 }
 
-func (ec executionChain) Execute(ctx context.Context, r *http.Request) (resp *http.Response, err error) {
+func (ec executionChain) Execute(r *http.Request) (resp *http.Response, err error) {
 	if ec.currentFilter < len(ec.filters) {
 		filter := ec.filters[ec.currentFilter]
 		ec.currentFilter++
 
-		return filter.Apply(ctx, r, ec)
+		return filter.Apply(r, ec)
 	}
 
-	return ec.finalTransport.RoundTrip(r.WithContext(ctx))
+	return ec.finalTransport.RoundTrip(r)
 }
 
 // Implement http.RoundTripper interface to use as a Transport in http.Client
 func (ec executionChain) RoundTrip(r *http.Request) (resp *http.Response, err error) {
-	return ec.Execute(r.Context(), r)
+	return ec.Execute(r)
 }

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -52,8 +52,7 @@ func (f FilterFunc) Apply(r *http.Request, next Executor) (resp *http.Response, 
 }
 
 func tracingFilter() FilterFunc {
-	return func(req *http.Request, next Executor,
-	) (resp *http.Response, err error) {
+	return func(req *http.Request, next Executor) (resp *http.Response, err error) {
 		ctx := req.Context()
 		opName := req.Method
 		var parent opentracing.SpanContext
@@ -87,8 +86,7 @@ func tracingFilter() FilterFunc {
 func authenticationFilter(info auth.CreateAuthInfo) FilterFunc {
 	authClient := auth.Load(info)
 	serviceName := info.Config().Get(config.ServiceNameKey).AsString()
-	return func(req *http.Request, next Executor,
-	) (resp *http.Response, err error) {
+	return func(req *http.Request, next Executor) (resp *http.Response, err error) {
 		ctx := req.Context()
 		// Client needs to know what service it is to authenticate
 		authCtx := authClient.SetAttribute(ctx, auth.ServiceAuth, serviceName)

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -21,7 +21,6 @@
 package client
 
 import (
-	"context"
 	"net/http"
 
 	"go.uber.org/fx"
@@ -34,31 +33,28 @@ import (
 
 // Executor executes the http request. Execute must be safe to use by multiple go routines
 type Executor interface {
-	Execute(ctx context.Context, r *http.Request) (resp *http.Response, err error)
+	Execute(r *http.Request) (resp *http.Response, err error)
 }
 
-// Filter applies filters on client requests and request's context such as
-// adding tracing to the context. Filters must call next.Execute() at most once, calling it twice and more
+// Filter applies filters on client requests and such as adding tracing to request's context.
+// Filters must call next.Execute() at most once, calling it twice and more
 // will lead to an undefined behavior
 type Filter interface {
-	Apply(ctx context.Context, r *http.Request, next Executor) (resp *http.Response, err error)
+	Apply(r *http.Request, next Executor) (resp *http.Response, err error)
 }
 
 // FilterFunc is an adaptor to call normal functions to apply filters
-type FilterFunc func(
-	ctx context.Context, r *http.Request, next Executor,
-) (resp *http.Response, err error)
+type FilterFunc func(r *http.Request, next Executor) (resp *http.Response, err error)
 
 // Apply implements Apply from the Filter interface and simply delegates to the function
-func (f FilterFunc) Apply(
-	ctx context.Context, r *http.Request, next Executor,
-) (resp *http.Response, err error) {
-	return f(ctx, r, next)
+func (f FilterFunc) Apply(r *http.Request, next Executor) (resp *http.Response, err error) {
+	return f(r, next)
 }
 
 func tracingFilter() FilterFunc {
-	return func(ctx context.Context, req *http.Request, next Executor,
+	return func(req *http.Request, next Executor,
 	) (resp *http.Response, err error) {
+		ctx := req.Context()
 		opName := req.Method
 		var parent opentracing.SpanContext
 		if s := opentracing.SpanFromContext(ctx); s != nil {
@@ -75,7 +71,7 @@ func tracingFilter() FilterFunc {
 			return nil, err
 		}
 
-		resp, err = next.Execute(ctx, req)
+		resp, err = next.Execute(req.WithContext(ctx))
 		if resp != nil {
 			span.SetTag("http.status_code", resp.StatusCode)
 		}
@@ -91,8 +87,9 @@ func tracingFilter() FilterFunc {
 func authenticationFilter(info auth.CreateAuthInfo) FilterFunc {
 	authClient := auth.Load(info)
 	serviceName := info.Config().Get(config.ServiceNameKey).AsString()
-	return func(ctx context.Context, req *http.Request, next Executor,
+	return func(req *http.Request, next Executor,
 	) (resp *http.Response, err error) {
+		ctx := req.Context()
 		// Client needs to know what service it is to authenticate
 		authCtx := authClient.SetAttribute(ctx, auth.ServiceAuth, serviceName)
 
@@ -108,7 +105,7 @@ func authenticationFilter(info auth.CreateAuthInfo) FilterFunc {
 			return nil, err
 		}
 
-		return next.Execute(authCtx, req)
+		return next.Execute(req.WithContext(authCtx))
 	}
 }
 

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -59,8 +59,7 @@ func TestExecutionChainFilters(t *testing.T) {
 	execChain := newExecutionChain(
 		[]Filter{tracingFilter()}, nopTransport{},
 	)
-	ctx := context.Background()
-	resp, err := execChain.RoundTrip(_req().WithContext(ctx))
+	resp, err := execChain.RoundTrip(_req())
 	assert.NoError(t, err)
 	assert.Equal(t, _respOK, resp)
 }

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -21,7 +21,6 @@
 package client
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,11 +77,9 @@ func TestClientGetTwiceExecutesAllFilters(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
 	count := 0
-	var f FilterFunc = func(
-		ctx context.Context, r *http.Request, next Executor,
-	) (resp *http.Response, err error) {
+	var f FilterFunc = func(r *http.Request, next Executor) (resp *http.Response, err error) {
 		count++
-		return next.Execute(ctx, r)
+		return next.Execute(r)
 	}
 
 	cl := New(fakeAuthInfo{yaml: _testYaml}, f)

--- a/modules/uhttp/filterchain_builder.go
+++ b/modules/uhttp/filterchain_builder.go
@@ -21,7 +21,6 @@
 package uhttp
 
 import (
-	"context"
 	"net/http"
 
 	"go.uber.org/fx/service"
@@ -29,24 +28,24 @@ import (
 
 type filterChain struct {
 	currentFilter int
-	finalHandler  Handler
+	finalHandler  http.Handler
 	filters       []Filter
 }
 
-func (fc filterChain) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (fc filterChain) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if fc.currentFilter == len(fc.filters) {
-		fc.finalHandler.ServeHTTP(ctx, w, r)
+		fc.finalHandler.ServeHTTP(w, r)
 	} else {
 		filter := fc.filters[fc.currentFilter]
 		fc.currentFilter++
-		filter.Apply(ctx, w, r, fc)
+		filter.Apply(w, r, fc)
 	}
 }
 
 type filterChainBuilder struct {
 	service.Host
 
-	finalHandler Handler
+	finalHandler http.Handler
 	filters      []Filter
 }
 
@@ -76,7 +75,7 @@ func (f filterChainBuilder) AddFilters(filters ...Filter) filterChainBuilder {
 	return f
 }
 
-func (f filterChainBuilder) Build(finalHandler Handler) filterChain {
+func (f filterChainBuilder) Build(finalHandler http.Handler) filterChain {
 	return filterChain{
 		filters:      f.filters,
 		finalHandler: finalHandler,

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -52,14 +52,11 @@ type contextFilter struct {
 }
 
 func (f contextFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
-	ctx := r.Context()
-	ctx = fx.NewContext(ctx, f.host)
-	r = r.WithContext(ctx)
-	next.ServeHTTP(w, r)
+	ctx := fx.NewContext(r.Context(), f.host)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-type tracingServerFilter struct {
-}
+type tracingServerFilter struct{}
 
 func (f tracingServerFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	ctx := r.Context()
@@ -77,8 +74,7 @@ func (f tracingServerFilter) Apply(w http.ResponseWriter, r *http.Request, next 
 
 	ctx = fx.WithContextAwareLogger(ctx, span)
 
-	r = r.WithContext(ctx)
-	next.ServeHTTP(w, r)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // authorizationFilter authorizes services based on configuration

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -21,7 +21,6 @@
 package uhttp
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -34,33 +33,36 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// Filter applies filters on requests, request contexts or responses such as
+// Filter applies filters on requests or responses such as
 // adding tracing to the context
 type Filter interface {
-	Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler)
+	Apply(w http.ResponseWriter, r *http.Request, next http.Handler)
 }
 
 // FilterFunc is an adaptor to call normal functions to apply filters
-type FilterFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler)
+type FilterFunc func(w http.ResponseWriter, r *http.Request, next http.Handler)
 
 // Apply implements Apply from the Filter interface and simply delegates to the function
-func (f FilterFunc) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
-	f(ctx, w, r, next)
+func (f FilterFunc) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	f(w, r, next)
 }
 
 type contextFilter struct {
 	host service.Host
 }
 
-func (f contextFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+func (f contextFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	ctx := r.Context()
 	ctx = fx.NewContext(ctx, f.host)
-	next.ServeHTTP(ctx, w, r)
+	r = r.WithContext(ctx)
+	next.ServeHTTP(w, r)
 }
 
 type tracingServerFilter struct {
 }
 
-func (f tracingServerFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+func (f tracingServerFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	ctx := r.Context()
 	operationName := r.Method
 	carrier := opentracing.HTTPHeadersCarrier(r.Header)
 	spanCtx, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, carrier)
@@ -76,7 +78,7 @@ func (f tracingServerFilter) Apply(ctx context.Context, w http.ResponseWriter, r
 	ctx = fx.WithContextAwareLogger(ctx, span)
 
 	r = r.WithContext(ctx)
-	next.ServeHTTP(ctx, w, r)
+	next.ServeHTTP(w, r)
 }
 
 // authorizationFilter authorizes services based on configuration
@@ -84,22 +86,23 @@ type authorizationFilter struct {
 	authClient auth.Client
 }
 
-func (f authorizationFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
-	if err := f.authClient.Authorize(ctx); err != nil {
+func (f authorizationFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	if err := f.authClient.Authorize(r.Context()); err != nil {
 		stats.HTTPAuthFailCounter.Inc(1)
-		fx.Logger(ctx).Error(auth.ErrAuthorization, "error", err)
+		fx.Logger(r.Context()).Error(auth.ErrAuthorization, "error", err)
 		w.WriteHeader(http.StatusUnauthorized)
 		fmt.Fprintf(w, "Unauthorized access: %+v", err)
 		return
 	}
-	next.ServeHTTP(ctx, w, r)
+	next.ServeHTTP(w, r)
 }
 
 // panicFilter handles any panics and return an error
 // panic filter should be added at the end of filter chain to catch panics
 type panicFilter struct{}
 
-func (f panicFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+func (f panicFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	ctx := r.Context()
 	defer func() {
 		if err := recover(); err != nil {
 			fx.Logger(ctx).Error("Panic recovered serving request", "error", err, "url", r.URL)
@@ -109,14 +112,13 @@ func (f panicFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.R
 			fmt.Fprintf(w, "Server error: %+v", err)
 		}
 	}()
-	next.ServeHTTP(ctx, w, r)
+	next.ServeHTTP(w, r)
 }
 
 // metricsFilter adds any default metrics related to HTTP
-type metricsFilter struct {
-}
+type metricsFilter struct{}
 
-func (f metricsFilter) Apply(ctx context.Context, w http.ResponseWriter, r *http.Request, next Handler) {
+func (f metricsFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	defer stats.HTTPStatusCountScope.Tagged(map[string]string{stats.TagStatus: w.Header().Get("Status")}).Counter("total").Inc(1)
-	next.ServeHTTP(ctx, w, r)
+	next.ServeHTTP(w, r)
 }

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -21,7 +21,6 @@
 package uhttp
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -114,14 +113,13 @@ func TestFilterChainFilters_AuthFailure(t *testing.T) {
 func testServeHTTP(chain filterChain, host service.Host) *httptest.ResponseRecorder {
 	request := httptest.NewRequest("", "http://filters", nil)
 	response := httptest.NewRecorder()
-	ctx := context.Background()
-	chain.ServeHTTP(ctx, response, request)
+	chain.ServeHTTP(response, request)
 	return response
 }
 
-func getNopHandler(host service.Host) HandlerFunc {
-	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		fx.Logger(ctx).Info("Inside Noop Handler")
+func getNopHandler(host service.Host) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fx.Logger(r.Context()).Info("Inside Noop Handler")
 		io.WriteString(w, "filters ok")
 	}
 }

--- a/modules/uhttp/handler.go
+++ b/modules/uhttp/handler.go
@@ -47,6 +47,5 @@ func (h *handlerWithHost) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	stopwatch := stats.HTTPMethodTimer.Timer(r.Method).Start()
 	defer stopwatch.Stop()
 
-	r = r.WithContext(ctx)
-	h.handler.ServeHTTP(w, r)
+	h.handler.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/modules/uhttp/health.go
+++ b/modules/uhttp/health.go
@@ -21,14 +21,13 @@
 package uhttp
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 )
 
 type healthHandler struct{}
 
-func (h healthHandler) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO(ai) import more sophisticated health mechanism from internal libraries
 	fmt.Fprintf(w, "OK\n")
 }

--- a/modules/uhttp/router.go
+++ b/modules/uhttp/router.go
@@ -21,13 +21,15 @@
 package uhttp
 
 import (
+	"net/http"
+
 	"github.com/gorilla/mux"
 
 	"go.uber.org/fx/service"
 )
 
 type route struct {
-	handler Handler
+	handler http.Handler
 }
 
 // Router is wrapper around gorila mux
@@ -45,6 +47,6 @@ func NewRouter(host service.Host) *Router {
 }
 
 // Handle wraps and calls the http.Handler underneath
-func (h *Router) Handle(path string, handler Handler) {
-	h.Router.Handle(path, Wrap(h.host, handler))
+func (h *Router) Handle(path string, handler http.Handler) {
+	h.Router.Handle(path, WithHost(h.host, handler))
 }

--- a/modules/uhttp/router_test.go
+++ b/modules/uhttp/router_test.go
@@ -21,7 +21,6 @@
 package uhttp
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -46,11 +45,11 @@ func withRouter(t *testing.T, f func(r *Router, l net.Listener)) {
 	l := serve(t, r)
 	defer l.Close()
 	r.Handle("/foo/baz/quokka",
-		HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Write([]byte("hello"))
 		}))
 	r.Handle("/foo/bar/quokka",
-		HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Write([]byte("world"))
 		}))
 	f(r, l)

--- a/modules/uhttp/routes.go
+++ b/modules/uhttp/routes.go
@@ -20,7 +20,11 @@
 
 package uhttp
 
-import "github.com/gorilla/mux"
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
 
 // FromGorilla turns a gorilla mux route into an UberFx route
 func FromGorilla(r *mux.Route) Route {
@@ -32,11 +36,11 @@ func FromGorilla(r *mux.Route) Route {
 // A RouteHandler is an HTTP handler for a single route
 type RouteHandler struct {
 	Path    string
-	Handler Handler
+	Handler http.Handler
 }
 
 // NewRouteHandler creates a route handler
-func NewRouteHandler(path string, handler Handler) RouteHandler {
+func NewRouteHandler(path string, handler http.Handler) RouteHandler {
 	return RouteHandler{
 		Path:    path,
 		Handler: handler,

--- a/modules/uhttp/routes_test.go
+++ b/modules/uhttp/routes_test.go
@@ -21,7 +21,6 @@
 package uhttp
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -38,7 +37,7 @@ func TestFromGorilla_OK(t *testing.T) {
 }
 
 func TestNewRouteHandler(t *testing.T) {
-	rh := NewRouteHandler("/", HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	rh := NewRouteHandler("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "Hi\n")
 	}))
 


### PR DESCRIPTION
refer #237 

use http.Request instead of explicitly passing context, so we can follow std API instead of define our own.