### PR TITLE
uhttp stop return panic detail to client

### DIFF
--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -33,6 +33,8 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+const panicRespnose = "Server Error"
+
 // Filter applies filters on requests or responses such as
 // adding tracing to the context
 type Filter interface {
@@ -102,9 +104,7 @@ func (f panicFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Han
 		if err := recover(); err != nil {
 			ulog.Logger(ctx).Error("Panic recovered serving request", "error", err, "url", r.URL)
 			stats.HTTPPanicCounter.Inc(1)
-			w.Header().Add(ContentType, ContentTypeText)
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "Server error: %+v", err)
+			http.Error(w, panicRespnose, http.StatusInternalServerError)
 		}
 	}()
 	next.ServeHTTP(w, r)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -104,7 +104,7 @@ func (f panicFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Han
 		if err := recover(); err != nil {
 			ulog.Logger(ctx).Error("Panic recovered serving request", "error", err, "url", r.URL)
 			stats.HTTPPanicCounter.Inc(1)
-			http.Error(w, panicRespnose, http.StatusInternalServerError)
+			http.Error(w, panicResponse, http.StatusInternalServerError)
 		}
 	}()
 	next.ServeHTTP(w, r)

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -33,7 +33,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-const panicRespnose = "Server Error"
+const panicResponse = "Server Error"
 
 // Filter applies filters on requests or responses such as
 // adding tracing to the context

--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -31,9 +31,10 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/pkg/errors"
 )
 
-const panicResponse = "Server Error"
+const _panicResponse = "Server Error"
 
 // Filter applies filters on requests or responses such as
 // adding tracing to the context
@@ -102,9 +103,9 @@ func (f panicFilter) Apply(w http.ResponseWriter, r *http.Request, next http.Han
 	ctx := r.Context()
 	defer func() {
 		if err := recover(); err != nil {
-			ulog.Logger(ctx).Error("Panic recovered serving request", "error", err, "url", r.URL)
+			ulog.Logger(ctx).Error("Panic recovered serving request", "error", errors.Errorf("panic in handler: %+v", err), "url", r.URL)
 			stats.HTTPPanicCounter.Inc(1)
-			http.Error(w, panicResponse, http.StatusInternalServerError)
+			http.Error(w, _panicResponse, http.StatusInternalServerError)
 		}
 	}()
 	next.ServeHTTP(w, r)

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -115,7 +115,7 @@ func TestPanicFilter(t *testing.T) {
 		panicFilter{},
 	).Build(getPanicHandler())
 	response := testServeHTTP(chain)
-	assert.Contains(t, response.Body.String(), _panicResponse)
+	assert.Equal(t, response.Body.String(), _panicResponse+"\n")
 	assert.Equal(t, http.StatusInternalServerError, response.Code)
 }
 


### PR DESCRIPTION
I opened a similar issue to yarpc [hide panic detail to caller](https://github.com/yarpc/yarpc-go/issues/734)

I think we should hide server panic detail from client to avoid some information leaking. the panic detail can be found in server's log and maybe sentry.