### PR TITLE
Generic module package

### DIFF
--- a/modules/generic/README.md
+++ b/modules/generic/README.md
@@ -20,6 +20,7 @@ type fooModule struct {
 func (m *fooModule) Initialize(contoller Controller, config interface{}) error {
   m.Controller = controller
   m.config = config.(*fooConfig)
+  return nil
 }
 
 func (m *fooModule) Start() error {

--- a/modules/generic/README.md
+++ b/modules/generic/README.md
@@ -17,7 +17,10 @@ type fooModule struct {
   config *fooConfig
 }
 
-func (m *fooModule) Initialize(contoller Controller, config interface{}) error {
+func (m *fooModule) Initialize(
+  contoller generic.Controller,
+  config interface{},
+) error {
   m.Controller = controller
   m.config = config.(*fooConfig)
   return nil

--- a/modules/generic/README.md
+++ b/modules/generic/README.md
@@ -1,0 +1,32 @@
+# Generic Module
+
+This provides functionality to implement new modules more easily.
+
+```go
+func NewFooModule(options ...module.Option) service.ModuleCreateFunc {
+  return generic.NewModule("foo", &fooModule{}, &fooConfig{}, options...)
+}
+
+type fooConfig struct {
+  modules.ModuleConfig
+  Foo string
+}
+
+type fooModule struct {
+  generic.Controller
+  config *fooConfig
+}
+
+func (m *fooModule) Initialize(contoller Controller, config interface{}) error {
+  m.Controller = controller
+  m.config = config.(*fooConfig)
+}
+
+func (m *fooModule) Start() error {
+  return nil
+}
+
+func (m *fooModule) Stop() error {
+  return nil
+}
+```

--- a/modules/generic/README.md
+++ b/modules/generic/README.md
@@ -4,7 +4,7 @@ This provides functionality to implement new modules more easily.
 
 ```go
 func NewFooModule(options ...module.Option) service.ModuleCreateFunc {
-  return generic.NewModule("foo", &fooModule{}, &fooConfig{}, options...)
+  return generic.NewModule("foo", &fooModule{}, options...)
 }
 
 type fooConfig struct {
@@ -14,16 +14,12 @@ type fooConfig struct {
 
 type fooModule struct {
   generic.Controller
-  config *fooConfig
+  config fooConfig
 }
 
-func (m *fooModule) Initialize(
-  contoller generic.Controller,
-  config interface{},
-) error {
+func (m *fooModule) Initialize(contoller generic.Controller) error {
   m.Controller = controller
-  m.config = config.(*fooConfig)
-  return nil
+  return generic.PopulateStruct(controller, &m.config)
 }
 
 func (m *fooModule) Start() error {

--- a/modules/generic/doc.go
+++ b/modules/generic/doc.go
@@ -36,7 +36,10 @@
 //     config *fooConfig
 //   }
 //
-//   func (m *fooModule) Initialize(contoller Controller, config interface{}) error {
+//   func (m *fooModule) Initialize(
+//     contoller generic.Controller,
+//     config interface{},
+//   ) error {
 //     m.Controller = controller
 //     m.config = config.(*fooConfig)
 //     return nil

--- a/modules/generic/doc.go
+++ b/modules/generic/doc.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package generic is the Generic Module.
+//
+// This provides functionality to implement new modules more easily.
+//
+//   func NewFooModule(options ...module.Option) service.ModuleCreateFunc {
+//     return generic.NewModule("foo", &fooModule{}, &fooConfig{}, options...)
+//   }
+//
+//   type fooConfig struct {
+//     modules.ModuleConfig
+//     Foo string
+//   }
+//
+//   type fooModule struct {
+//     generic.Controller
+//     config *fooConfig
+//   }
+//
+//   func (m *fooModule) Initialize(contoller Controller, config interface{}) error {
+//     m.Controller = controller
+//     m.config = config.(*fooConfig)
+//   }
+//
+//   func (m *fooModule) Start() error {
+//     return nil
+//   }
+//
+//   func (m *fooModule) Stop() error {
+//     return nil
+//   }
+//
+//
+package generic

--- a/modules/generic/doc.go
+++ b/modules/generic/doc.go
@@ -23,7 +23,7 @@
 // This provides functionality to implement new modules more easily.
 //
 //   func NewFooModule(options ...module.Option) service.ModuleCreateFunc {
-//     return generic.NewModule("foo", &fooModule{}, &fooConfig{}, options...)
+//     return generic.NewModule("foo", &fooModule{}, options...)
 //   }
 //
 //   type fooConfig struct {
@@ -33,16 +33,12 @@
 //
 //   type fooModule struct {
 //     generic.Controller
-//     config *fooConfig
+//     config fooConfig
 //   }
 //
-//   func (m *fooModule) Initialize(
-//     contoller generic.Controller,
-//     config interface{},
-//   ) error {
+//   func (m *fooModule) Initialize(contoller generic.Controller) error {
 //     m.Controller = controller
-//     m.config = config.(*fooConfig)
-//     return nil
+//     return generic.PopulateStruct(controller, &m.config)
 //   }
 //
 //   func (m *fooModule) Start() error {

--- a/modules/generic/doc.go
+++ b/modules/generic/doc.go
@@ -39,6 +39,7 @@
 //   func (m *fooModule) Initialize(contoller Controller, config interface{}) error {
 //     m.Controller = controller
 //     m.config = config.(*fooConfig)
+//     return nil
 //   }
 //
 //   func (m *fooModule) Start() error {

--- a/modules/generic/generic.go
+++ b/modules/generic/generic.go
@@ -63,7 +63,7 @@ type Module interface {
 	Stop() error
 }
 
-// NewModule returns a ModuleCreateFunc for the given GenericModule.
+// NewModule returns a ModuleCreateFunc for the given Module.
 func NewModule(
 	moduleName string,
 	module Module,

--- a/modules/generic/generic.go
+++ b/modules/generic/generic.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package generic
+
+import (
+	"sync"
+
+	"go.uber.org/fx/modules"
+	"go.uber.org/fx/service"
+	"go.uber.org/fx/ulog"
+)
+
+// Module is a simpliciation of the Module interface
+// that can be wrapped with a Module for easier implemenation.
+type Module interface {
+	// This will be called after ModuleBase, log, and config are populated.
+	// If the module wishes, these can be stored for use in the module.
+	// Start and stop should not be called before this is called.
+	Initialize(moduleBase modules.ModuleBase, log ulog.Log, config interface{}) error
+	// Start the module, on return the module is expected to be started
+	// If there is an error, the module is not expected to be started.
+	Start() error
+	// Stop the module, on return the module is expected to be stopped
+	// If there is an error, the module is still expected to be stopped.
+	Stop() error
+}
+
+// NewModule returns a ModuleCreateFunc for the given GenericModule.
+//
+// config should be a struct pointer to a configuration struct.
+//
+//   type FooConfig struct {
+//       modules.ModuleConfig
+//       Foo string
+//   }
+//
+//   NewModule("foo", module, &FooConfig{})
+func NewModule(
+	moduleName string,
+	module Module,
+	config interface{},
+	options ...modules.Option,
+) service.ModuleCreateFunc {
+	return func(moduleCreateInfo service.ModuleCreateInfo) ([]service.Module, error) {
+		module, err := newWrapperModule(moduleCreateInfo, moduleName, module, config, options...)
+		if err != nil {
+			return nil, err
+		}
+		return []service.Module{module}, nil
+	}
+}
+
+type wrapperModule struct {
+	moduleName string
+	module     Module
+	lock       sync.RWMutex
+	running    bool
+}
+
+func newWrapperModule(
+	moduleCreateInfo service.ModuleCreateInfo,
+	moduleName string,
+	module Module,
+	config interface{},
+	options ...modules.Option,
+) (service.Module, error) {
+	for _, option := range options {
+		if err := option(&moduleCreateInfo); err != nil {
+			return nil, err
+		}
+	}
+	if moduleCreateInfo.Name != "" {
+		moduleName = moduleCreateInfo.Name
+	}
+	moduleBase := *modules.NewModuleBase(
+		moduleName,
+		moduleCreateInfo.Host,
+		moduleCreateInfo.Roles,
+	)
+	if err := moduleBase.Host().Config().Scope("modules").Get(moduleName).PopulateStruct(config); err != nil {
+		return nil, err
+	}
+	if err := module.Initialize(
+		moduleBase,
+		ulog.Logger().With("moduleName", moduleName),
+		config,
+	); err != nil {
+		return nil, err
+	}
+	return &wrapperModule{moduleName: moduleName, module: module}, nil
+}
+
+func (m *wrapperModule) Name() string {
+	return m.moduleName
+}
+
+func (m *wrapperModule) Start(readyC chan<- struct{}) <-chan error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	errC := make(chan error, 1)
+	if err := m.module.Start(); err != nil {
+		errC <- err
+		return errC
+	}
+	errC <- nil
+	m.running = true
+	readyC <- struct{}{}
+	return errC
+}
+
+func (m *wrapperModule) Stop() error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.running = false
+	return m.module.Stop()
+}
+
+func (m *wrapperModule) IsRunning() bool {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.running
+}

--- a/modules/generic/generic_test.go
+++ b/modules/generic/generic_test.go
@@ -103,7 +103,7 @@ func newModule(
 }
 
 func newModuleFunc(moduleName string, testModule *testModule, options ...modules.Option) service.ModuleCreateFunc {
-	return NewModule(moduleName, testModule, &testConfig{}, options...)
+	return NewModule(moduleName, testModule, options...)
 }
 
 func newConfigProvider(moduleName string, testConfig *testConfig) config.Provider {
@@ -127,7 +127,7 @@ type testConfig struct {
 
 type testModule struct {
 	Controller
-	config     *testConfig
+	config     testConfig
 	startCount int
 	stopCount  int
 	err        error
@@ -137,10 +137,9 @@ func newTestModule() *testModule {
 	return &testModule{}
 }
 
-func (m *testModule) Initialize(controller Controller, config interface{}) error {
+func (m *testModule) Initialize(controller Controller) error {
 	m.Controller = controller
-	m.config = config.(*testConfig)
-	return nil
+	return PopulateStruct(controller, &m.config)
 }
 
 func (m *testModule) Start() error {

--- a/modules/generic/generic_test.go
+++ b/modules/generic/generic_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package generic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/fx/config"
+	"go.uber.org/fx/modules"
+	"go.uber.org/fx/service"
+)
+
+func TestConfig(t *testing.T) {
+	testConfig := &testConfig{Test: "foo"}
+	testModule, _ := setup(t, testConfig, "test")
+	assert.Equal(t, testConfig.Test, testModule.config.Test)
+}
+
+func setup(
+	t *testing.T,
+	testConfig *testConfig,
+	moduleName string,
+) (*testModule, service.Module) {
+	testModule := newTestModule()
+	module, err := newModule(testModule, testConfig, moduleName)
+	require.NoError(t, err)
+	return testModule, module
+}
+
+func newModule(
+	testModule *testModule,
+	testConfig *testConfig,
+	moduleName string,
+) (service.Module, error) {
+	modules, err := newModuleFunc(moduleName, testModule)(
+		service.ModuleCreateInfo{
+			Name: moduleName,
+			Host: service.NopHostWithConfig(
+				newConfigProvider(
+					moduleName,
+					testConfig,
+				),
+			),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return modules[0], nil
+}
+
+func newModuleFunc(moduleName string, testModule *testModule, options ...modules.Option) service.ModuleCreateFunc {
+	return NewModule(moduleName, testModule, &testConfig{}, options...)
+}
+
+func newConfigProvider(moduleName string, testConfig *testConfig) config.Provider {
+	if testConfig == nil {
+		return nil
+	}
+	return config.NewYAMLProviderFromBytes(newYAMLConfigBytes(moduleName, testConfig))
+}
+
+func newYAMLConfigBytes(moduleName string, testConfig *testConfig) []byte {
+	return []byte(fmt.Sprintf(`
+modules:
+  %s:
+    test: %s
+`, moduleName, testConfig.Test))
+}
+
+type testConfig struct {
+	Test string `yaml:"test"`
+}
+
+type testModule struct {
+	Controller
+	config *testConfig
+}
+
+func newTestModule() *testModule {
+	return &testModule{}
+}
+
+func (m *testModule) Initialize(controller Controller, config interface{}) error {
+	m.Controller = controller
+	m.config = config.(*testConfig)
+	return nil
+}
+
+func (m *testModule) Start() error {
+	return nil
+}
+
+func (m *testModule) Stop() error {
+	return nil
+}

--- a/service/host_mock.go
+++ b/service/host_mock.go
@@ -32,7 +32,12 @@ import (
 
 // NopHost is to be used in tests
 func NopHost() Host {
-	return NopHostConfigured(auth.NopClient, ulog.NopLogger, opentracing.NoopTracer{})
+	return NopHostWithConfig(nil)
+}
+
+// NopHostWithConfig is to be used in tests and allows setting of config.
+func NopHostWithConfig(configProvider config.Provider) Host {
+	return nopHostConfigured(auth.NopClient, ulog.NopLogger, opentracing.NoopTracer{}, configProvider)
 }
 
 // NopHostAuthFailure is nop host with failure auth client
@@ -45,9 +50,16 @@ func NopHostAuthFailure() Host {
 
 // NopHostConfigured is a nop host with set logger and tracer for tests
 func NopHostConfigured(client auth.Client, logger ulog.Log, tracer opentracing.Tracer) Host {
+	return nopHostConfigured(client, logger, tracer, nil)
+}
+
+func nopHostConfigured(client auth.Client, logger ulog.Log, tracer opentracing.Tracer, configProvider config.Provider) Host {
+	if configProvider == nil {
+		configProvider = config.NewStaticProvider(nil)
+	}
 	return &serviceCore{
 		authClient:     client,
-		configProvider: config.NewStaticProvider(nil),
+		configProvider: configProvider,
 		standardConfig: serviceConfig{
 			Name:        "dummy",
 			Owner:       "root@example.com",


### PR DESCRIPTION
I was working on writing a new Module, and I realized that there's a lot of duplicated code between the existing Module implementations in FX, and that most implementations of Module just need a couple things:

- Access to the service/config data
- Start
- Stop

It would be nice if there was a simplification of this. This is what I have come up with for now. I'm not crazy about the Controller interface, and the call to Initialize, but this should make writing Modules a lot easier. I may have missed something or done something incorrectly or not per FX idioms, so let me know. I'll add more testing if this is something you'd want, but didn't want to go further until I got some feedback.