### PR TITLE
use http.Error to return authFilter error

### DIFF
--- a/modules/uhttp/filters.go
+++ b/modules/uhttp/filters.go
@@ -86,8 +86,7 @@ func (f authorizationFilter) Apply(w http.ResponseWriter, r *http.Request, next 
 	if err := f.authClient.Authorize(r.Context()); err != nil {
 		stats.HTTPAuthFailCounter.Inc(1)
 		fx.Logger(r.Context()).Error(auth.ErrAuthorization, "error", err)
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(w, "Unauthorized access: %+v", err)
+		http.Error(w, fmt.Sprintf("Unauthorized access: %+v", err), http.StatusUnauthorized)
 		return
 	}
 	next.ServeHTTP(w, r)

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -106,7 +106,7 @@ func TestFilterChainFilters_AuthFailure(t *testing.T) {
 			authClient: host.AuthClient(),
 		}).Build(getNopHandler(host))
 	response := testServeHTTP(chain, host)
-	assert.Contains(t, response.Body.String(), "Unauthorized access: Error authorizing the service")
+	assert.Equal(t, response.Body.String(), "Unauthorized access: Error authorizing the service\n")
 	assert.Equal(t, 401, response.Code)
 }
 

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -106,7 +106,7 @@ func TestFilterChainFilters_AuthFailure(t *testing.T) {
 			authClient: host.AuthClient(),
 		}).Build(getNopHandler(host))
 	response := testServeHTTP(chain, host)
-	assert.Contains(t, "Unauthorized access: Error authorizing the service", response.Body.String())
+	assert.Contains(t, response.Body.String(), "Unauthorized access: Error authorizing the service")
 	assert.Equal(t, 401, response.Code)
 }
 


### PR DESCRIPTION
`http.Error` sets some common header by default