### PR TITLE
remove unused uhttp.Response struct

### DIFF
--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -59,15 +59,6 @@ const (
 
 var _ service.Module = &Module{}
 
-// Response is an envelope for returning the results of an HTTP call
-type Response struct {
-	Status      int
-	ContentType string
-	Body        interface{}
-	Headers     map[string]string
-	Error       error
-}
-
 // A Module is a module to handle HTTP requests
 type Module struct {
 	modules.ModuleBase


### PR DESCRIPTION
Hi @sectioneight, I saw this struct was introduced in [Rewrite HTTP to be based on handlers, not annotations](https://github.com/uber-go/fx/commit/ef12a4a3d0f97a48c1cc4fbcce7100ac7fdd2ffd). But I don't see it is being used anywhere, are we plan to use it in future?