### PR TITLE
remove unused uhttp route struct

### DIFF
--- a/modules/uhttp/router.go
+++ b/modules/uhttp/router.go
@@ -28,10 +28,6 @@ import (
 	"go.uber.org/fx/service"
 )
 
-type route struct {
-	handler http.Handler
-}
-
 // Router is wrapper around gorila mux
 type Router struct {
 	mux.Router


### PR DESCRIPTION
Hi @anuptalwalkar, this struct was introduced in #77, but it is not being used. Can we remove it? Or we plan to use it later?