### PR TITLE
Start removing global Logger references

### DIFF
--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -18,7 +18,8 @@ deps: libdeps
 	$(ECHO_V)go install ./vendor/github.com/sectioneight/md-to-godoc
 	@$(call label,Installing interfacer...)
 	$(ECHO_V)go install ./vendor/github.com/mvdan/interfacer/cmd/interfacer
-	$(ECHO_V)echo "--- PASS: TestSomething" | richgo testfilter > /dev/null 2>&1 || ($(call label,Installing richgo) && go get github.com/sectioneight/richgo)
+	@$(call label,Installing richgo...)
+	$(ECHO_V)go install ./vendor/github.com/kyoh86/richgo
 
 GOCOV := gocov
 OVERALLS := overalls

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ $(COV_REPORT): $(PKG_FILES) $(ALL_SRC)
 	$(ECHO_V)rm -f $(COV_REPORT)
 
 	@$(call label,Running tests)
-	$(ECHO_V)$(OVERALLS) -project=$(PROJECT_ROOT) \
+	$(ECHO_V)RICHGO_FORCE_COLOR=1 $(OVERALLS) \
+		-project=$(PROJECT_ROOT) \
 		-go-binary=richgo \
 		-ignore "$(OVERALLS_IGNORE)" \
 		-covermode=atomic \

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: ea195918b27160f0f6f8b5f40f206c58bd457c18ae542484dd5b9a3d1f728184
-updated: 2017-02-07T21:22:55.533973167-08:00
+hash: 939acaa595b674eca722d0e7ce484e860c1813d7a32cca554b62954921e4d66f
+updated: 2017-02-14T04:13:41.636621755-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  version: 0a660ee285e4a4cbac8f702168c40fd4ef5495d1
   subpackages:
   - lib/go/thrift
 - name: github.com/certifi/gocertifi
@@ -37,7 +37,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require
@@ -47,6 +47,8 @@ imports:
   version: 43c1379c0577ac1eb74f9f3869cea07191c9992b
 - name: github.com/uber-go/zap
   version: c064b5c44b285a7e2fd5c9b26e8c38228ce2bccb
+  subpackages:
+  - spy
 - name: github.com/uber/jaeger-client-go
   version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
   subpackages:
@@ -61,9 +63,13 @@ imports:
 - name: github.com/uber/tchannel-go
   version: 79387824978f91318be3bfb43ae12e04c38cfe97
   subpackages:
+  - atomic
   - internal/argreader
   - relay
+  - thrift
+  - thrift/gen-go/meta
   - tnet
+  - trace/thrift/gen-go/tcollector
   - trand
   - typed
 - name: go.uber.org/atomic
@@ -106,6 +112,7 @@ imports:
   - internal/sync
   - peer
   - peer/hostport
+  - transport
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
@@ -113,7 +120,6 @@ imports:
   version: 236b8f043b920452504e263bc21d354427127473
   subpackages:
   - context
-  - context/ctxhttp
 - name: golang.org/x/tools
   version: 19c96be7c450e3dff3797cb1e458414c15010358
   subpackages:
@@ -139,6 +145,8 @@ testImports:
   version: db0ca22445717d1b2c51ac1034440e0a2a2de645
 - name: github.com/kisielk/gotool
   version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
+- name: github.com/kyoh86/richgo
+  version: 35d295f8d8df6dc5159273293c5d294cb6fb6b84
 - name: github.com/mattn/goveralls
   version: 8482d0ebd2a64f95ce02d2b9b7065b0d6fe9151b
 - name: github.com/mvdan/interfacer

--- a/glide.yaml
+++ b/glide.yaml
@@ -57,3 +57,4 @@ testImport:
   version: 2
 - package: github.com/shurcooL/sanitized_anchor_name
 - package: github.com/mvdan/interfacer/cmd/interfacer
+- package: github.com/kyoh86/richgo

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -224,7 +224,7 @@ func newYARPCModule(
 
 	stats.SetupRPCMetrics(mi.Host.Metrics())
 
-	module.log = ulog.Logger().With("moduleName", name)
+	module.log = module.Host().Logger().With("moduleName", name)
 	for _, opt := range options {
 		if err := opt(&mi); err != nil {
 			return module, errs.Wrap(err, "unable to apply option to YARPC module")

--- a/modules/uhttp/doc.go
+++ b/modules/uhttp/doc.go
@@ -27,7 +27,6 @@
 //   package main
 //
 //   import (
-//     "context"
 //     "io"
 //     "net/http"
 //
@@ -49,8 +48,8 @@
 //   }
 //
 //   func registerHTTP(service service.Host) []uhttp.RouteHandler {
-//     handleHome := http.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-//       fx.Logger(ctx).Info("Inside the handler")
+//     handleHome := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//       fx.Logger(r.Context()).Info("Inside the handler")
 //       io.WriteString(w, "Hello, world")
 //     })
 //
@@ -95,10 +94,10 @@
 // Benchmark results:
 //
 //   Current performance benchmark data:
-//   BenchmarkClientFilters/empty-8         	  500000	      3517 ns/op	     256 B/op	       2 allocs/op
-//   BenchmarkClientFilters/tracing-8       	   20000	     64421 ns/op	    1729 B/op	      29 allocs/op
-//   BenchmarkClientFilters/auth-8          	   50000	     36574 ns/op	     728 B/op	      16 allocs/op
-//   BenchmarkClientFilters/default-8       	   10000	    104374 ns/op	    2275 B/op	      43 allocs/op
+//   BenchmarkClientFilters/empty-8         	100000000	        10.8 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkClientFilters/tracing-8       	  500000	      3918 ns/op	    1729 B/op	      27 allocs/op
+//   BenchmarkClientFilters/auth-8          	 1000000	      1866 ns/op	     719 B/op	      14 allocs/op
+//   BenchmarkClientFilters/default-8       	  300000	      5604 ns/op	    2477 B/op	      41 allocs/op
 //
 //
 package uhttp

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -126,11 +126,11 @@ func newModule(
 
 	err := module.Host().Config().Get(getConfigKey(mi.Name)).PopulateStruct(cfg)
 	if err != nil {
-		ulog.Logger().Error("Error loading http module configuration", "error", err)
+		module.Host().Logger().Error("Error loading http module configuration", "error", err)
 	}
 	module.config = *cfg
 
-	module.log = ulog.Logger().With("moduleName", mi.Name)
+	module.log = module.Host().Logger().With("moduleName", mi.Name)
 
 	for _, option := range options {
 		if err := option(&mi); err != nil {


### PR DESCRIPTION
In reality, `ulog.Logger()` just needs to be removed completely.

What we really need, especially given that building of the logger can result in an error, is a SUPER TOP LEVEL thing at the beginning of service initialization that initializes logging, and on failure, does something drastic (like panicking). Then, for internal fx initialization code, in rare cases this global logger is used (like during service initialization). But users of fx should not use `ulog.Logger()`, or we need to redo `ulog.Logger()` to be smarter and take into account configuration.