### PR TITLE
Add an observer that will trigger after service starts

### DIFF
--- a/service/observer.go
+++ b/service/observer.go
@@ -28,7 +28,7 @@ type Observer interface {
 
 	// OnStateChange is called whenever the service changes
 	// states
-	OnStateChange(old State, new State)
+	OnStateChange(old State, curr State)
 
 	// OnShutdown is called before the service shuts down
 	OnShutdown(reason Exit)

--- a/service/service.go
+++ b/service/service.go
@@ -152,8 +152,8 @@ type niladicStart func()
 func (n niladicStart) OnInit(service Host) error      { return nil }
 func (n niladicStart) OnShutdown(reason Exit)         {}
 func (n niladicStart) OnCriticalError(err error) bool { return true }
-func (n niladicStart) OnStateChange(old State, new State) {
-	if old == Starting && new == Running {
+func (n niladicStart) OnStateChange(old State, curr State) {
+	if old == Starting && curr == Running {
 		n()
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -146,3 +146,19 @@ func New(options ...Option) (Owner, error) {
 
 	return svc, nil
 }
+
+type niladicStart func()
+
+func (n niladicStart) OnInit(service Host) error      { return nil }
+func (n niladicStart) OnShutdown(reason Exit)         {}
+func (n niladicStart) OnCriticalError(err error) bool { return true }
+func (n niladicStart) OnStateChange(old State, new State) {
+	if old == Starting && new == Running {
+		n()
+	}
+}
+
+// AfterStart will create an observer that will execute f() immediately after service starts.
+func AfterStart(f func()) Observer {
+	return niladicStart(f)
+}

--- a/service/stub_observer.go
+++ b/service/stub_observer.go
@@ -39,8 +39,8 @@ func (s *StubObserver) OnInit(svc Host) error {
 }
 
 // OnStateChange is called during state transitions
-func (s *StubObserver) OnStateChange(old State, newState State) {
-	s.state = newState
+func (s *StubObserver) OnStateChange(old State, curr State) {
+	s.state = curr
 }
 
 // OnShutdown is called for a shutdown


### PR DESCRIPTION
This observer is useful if we want to call some function after service starts, e.g. yarpc client.