### PR TITLE
use sub tests for uhttp/filter_test

### DIFF
--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -49,12 +49,15 @@ func TestDefaultFiltersWithNopHost(t *testing.T) {
 
 	t.Run("run parallel", func(t *testing.T) {
 		t.Run("testFilterChain", func(t *testing.T) {
+			t.Parallel()
 			testFilterChain(t, host)
 		})
 		t.Run("testFilterChainFilters", func(t *testing.T) {
+			t.Parallel()
 			testFilterChainFilters(t, host)
 		})
 		t.Run("testPanicFilter", func(t *testing.T) {
+			t.Parallel()
 			testPanicFilter(t, host)
 		})
 	})
@@ -70,6 +73,7 @@ func TestDefaultFiltersWithNopHostAuthFailure(t *testing.T) {
 
 	t.Run("run parallel", func(t *testing.T) {
 		t.Run("testFilterChainFiltersAuthFailure", func(t *testing.T) {
+			t.Parallel()
 			testFilterChainFiltersAuthFailure(t, host)
 		})
 	})
@@ -82,6 +86,7 @@ func TestDefaultFiltersWithNopHostConfigured(t *testing.T) {
 	// this test's sub tests cannot run parallel
 	// and they need to build host by theirselves
 	t.Run("testTracingFilterWithLogs", func(t *testing.T) {
+		t.Parallel()
 		testTracingFilterWithLogs(t)
 		httpMetricsTeardown()
 	})

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -60,6 +60,10 @@ func TestDefaultFiltersWithNopHost(t *testing.T) {
 			t.Parallel()
 			testPanicFilter(t, host)
 		})
+		t.Run("testMetricsFilter", func(t *testing.T) {
+			t.Parallel()
+			testMetricsFilter(t, host)
+		})
 	})
 
 	// teardown
@@ -171,20 +175,17 @@ func testPanicFilter(t *testing.T, host service.Host) {
 	assert.True(t, counters["panic"].Value() > 0)
 }
 
-func TestMetricsFilter(t *testing.T) {
-	host := service.NopHost()
-	testScope := host.Metrics()
-
+func testMetricsFilter(t *testing.T, host service.Host) {
 	chain := newFilterChainBuilder(host).AddFilters(
 		metricsFilter{},
 	).Build(getNopHandler())
 	response := testServeHTTP(chain)
 	assert.Contains(t, response.Body.String(), "filters ok")
 
+	testScope := host.Metrics()
 	snapshot := testScope.(tally.TestScope).Snapshot()
 	counters := snapshot.Counters()
 	timers := snapshot.Timers()
-
 	assert.True(t, counters["total"].Value() > 0)
 	assert.NotNil(t, timers["GET"].Values())
 }

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -80,6 +80,7 @@ func TestDefaultFiltersWithNopHostAuthFailure(t *testing.T) {
 
 func TestDefaultFiltersWithNopHostConfigured(t *testing.T) {
 	// this test's sub tests cannot run parallel
+	// and they need to build host by theirselves
 	t.Run("testTracingFilterWithLogs", func(t *testing.T) {
 		testTracingFilterWithLogs(t)
 		httpMetricsTeardown()

--- a/modules/uhttp/filters_test.go
+++ b/modules/uhttp/filters_test.go
@@ -69,8 +69,8 @@ func TestDefaultFiltersWithNopHostAuthFailure(t *testing.T) {
 	stats.SetupHTTPMetrics(host.Metrics())
 
 	t.Run("run parallel", func(t *testing.T) {
-		t.Run("testFilterChainFilters_AuthFailure", func(t *testing.T) {
-			testFilterChainFilters_AuthFailure(t, host)
+		t.Run("testFilterChainFiltersAuthFailure", func(t *testing.T) {
+			testFilterChainFiltersAuthFailure(t, host)
 		})
 	})
 
@@ -141,7 +141,7 @@ func testFilterChainFilters(t *testing.T, host service.Host) {
 	assert.Contains(t, response.Body.String(), "filters ok")
 }
 
-func testFilterChainFilters_AuthFailure(t *testing.T, host service.Host) {
+func testFilterChainFiltersAuthFailure(t *testing.T, host service.Host) {
 	chain := newFilterChainBuilder(host).AddFilters(
 		tracingServerFilter{},
 		authorizationFilter{


### PR DESCRIPTION
- run tests which use same host config in parallel
- tear down in filter tests to make sure tests are independent. tests should not depend on one or other to set up global state (here is the http metrics)