### PR TITLE
remove []Filter in uhttp.New param and add uhttp.WithFilters func

### DIFF
--- a/modules/uhttp/http_options.go
+++ b/modules/uhttp/http_options.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uhttp
+
+import (
+	"go.uber.org/fx/modules"
+	"go.uber.org/fx/service"
+)
+
+const _filterKey = "uhttpFilter"
+
+// WithFilter adds Filter to uhttp Module that will be applied to all incoming http requests.
+func WithFilter(fs ...Filter) modules.Option {
+	return func(mci *service.ModuleCreateInfo) error {
+		filters := filtersFromCreateInfo(*mci)
+		filters = append(filters, fs...)
+		if mci.Items == nil {
+			mci.Items = make(map[string]interface{})
+		}
+		mci.Items[_filterKey] = filters
+
+		return nil
+	}
+}
+
+func filtersFromCreateInfo(mci service.ModuleCreateInfo) []Filter {
+	items, ok := mci.Items[_filterKey]
+	if !ok {
+		return nil
+	}
+
+	// Intentionally panic if programmer adds non-filter slice to the data
+	return items.([]Filter)
+}

--- a/modules/uhttp/http_options.go
+++ b/modules/uhttp/http_options.go
@@ -27,8 +27,8 @@ import (
 
 const _filterKey = "uhttpFilter"
 
-// WithFilter adds Filter to uhttp Module that will be applied to all incoming http requests.
-func WithFilter(fs ...Filter) modules.Option {
+// WithFilters adds Filters to uhttp Module that will be applied to all incoming http requests.
+func WithFilters(fs ...Filter) modules.Option {
 	return func(mci *service.ModuleCreateInfo) error {
 		filters := filtersFromCreateInfo(*mci)
 		filters = append(filters, fs...)

--- a/modules/uhttp/http_options_test.go
+++ b/modules/uhttp/http_options_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uhttp
+
+import (
+	"testing"
+
+	"go.uber.org/fx/service"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithFilter(t *testing.T) {
+	fakeFilter1 := fakeFilter()
+	fakeFilter2 := fakeFilter()
+	tests := []struct {
+		desc   string
+		mi     service.ModuleCreateInfo
+		input  []Filter
+		expect []Filter
+	}{
+		{
+			desc:   "TestWithOneFilter",
+			mi:     service.ModuleCreateInfo{},
+			input:  []Filter{fakeFilter1},
+			expect: []Filter{fakeFilter1},
+		},
+		{
+			desc:   "TestWithTwoFilters",
+			mi:     service.ModuleCreateInfo{},
+			input:  []Filter{fakeFilter1, fakeFilter2},
+			expect: []Filter{fakeFilter1, fakeFilter2},
+		},
+		{
+			desc: "TestHasOneWithOneFilter",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					_filterKey: []Filter{fakeFilter1},
+				},
+			},
+			input:  []Filter{fakeFilter2},
+			expect: []Filter{fakeFilter1, fakeFilter2},
+		},
+		{
+			desc: "TestHasOneWithNilFilter",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					_filterKey: []Filter{fakeFilter1},
+				},
+			},
+			input:  nil,
+			expect: []Filter{fakeFilter1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			opt := WithFilter(tt.input...)
+			assert.NoError(t, opt(&tt.mi))
+			assert.Equal(t, len(tt.expect), len(filtersFromCreateInfo(tt.mi)))
+		})
+	}
+}
+
+func TestFiltersFromCreateInfo(t *testing.T) {
+	fakeFilter1 := fakeFilter()
+	fakeFilter2 := fakeFilter()
+	tests := []struct {
+		desc    string
+		mi      service.ModuleCreateInfo
+		filters []Filter
+	}{
+		{
+			desc:    "TestEmptyItems",
+			mi:      service.ModuleCreateInfo{},
+			filters: nil,
+		},
+		{
+			desc: "TestSometingElseInItems",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					"somethingElse": []Filter{fakeFilter1},
+				},
+			},
+			filters: nil,
+		},
+		{
+			desc: "TestOneFilterInItems",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					_filterKey: []Filter{fakeFilter1},
+				},
+			},
+			filters: []Filter{fakeFilter1},
+		},
+		{
+			desc: "TestTwoFiltersInItems",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					_filterKey: []Filter{fakeFilter1, fakeFilter2},
+				},
+			},
+			filters: []Filter{fakeFilter1, fakeFilter2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			fs := filtersFromCreateInfo(tt.mi)
+			assert.Equal(t, len(tt.filters), len(fs))
+		})
+	}
+}

--- a/modules/uhttp/http_options_test.go
+++ b/modules/uhttp/http_options_test.go
@@ -73,6 +73,7 @@ func TestWithFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
 			opt := WithFilter(tt.input...)
 			assert.NoError(t, opt(&tt.mi))
 			assert.Equal(t, len(tt.expect), len(filtersFromCreateInfo(tt.mi)))
@@ -124,6 +125,7 @@ func TestFiltersFromCreateInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
 			fs := filtersFromCreateInfo(tt.mi)
 			assert.Equal(t, len(tt.filters), len(fs))
 		})

--- a/modules/uhttp/http_options_test.go
+++ b/modules/uhttp/http_options_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWithFilter(t *testing.T) {
+func TestWithFilters(t *testing.T) {
 	fakeFilter1 := fakeFilter()
 	fakeFilter2 := fakeFilter()
 	tests := []struct {
@@ -72,9 +72,10 @@ func TestWithFilter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
-			opt := WithFilter(tt.input...)
+			opt := WithFilters(tt.input...)
 			assert.NoError(t, opt(&tt.mi))
 			assert.Equal(t, len(tt.expect), len(filtersFromCreateInfo(tt.mi)))
 		})
@@ -124,6 +125,7 @@ func TestFiltersFromCreateInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			fs := filtersFromCreateInfo(tt.mi)

--- a/modules/uhttp/http_options_test.go
+++ b/modules/uhttp/http_options_test.go
@@ -82,6 +82,64 @@ func TestWithFilters(t *testing.T) {
 	}
 }
 
+func TestWithFiltersTwice(t *testing.T) {
+	fakeFilter1 := fakeFilter()
+	fakeFilter2 := fakeFilter()
+	tests := []struct {
+		desc   string
+		mi     service.ModuleCreateInfo
+		input  []Filter
+		expect []Filter
+	}{
+		{
+			desc:   "TestWithOneFilterTwice",
+			mi:     service.ModuleCreateInfo{},
+			input:  []Filter{fakeFilter1},
+			expect: []Filter{fakeFilter1, fakeFilter1},
+		},
+		{
+			desc:   "TestWithTwoFiltersTwice",
+			mi:     service.ModuleCreateInfo{},
+			input:  []Filter{fakeFilter1, fakeFilter2},
+			expect: []Filter{fakeFilter1, fakeFilter2, fakeFilter1, fakeFilter2},
+		},
+		{
+			desc: "TestHasOneWithOneFilterTwice",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					_filterKey: []Filter{fakeFilter1},
+				},
+			},
+			input:  []Filter{fakeFilter2},
+			expect: []Filter{fakeFilter1, fakeFilter2, fakeFilter2},
+		},
+		{
+			desc: "TestHasOneWithNilFilterTwice",
+			mi: service.ModuleCreateInfo{
+				Items: map[string]interface{}{
+					_filterKey: []Filter{fakeFilter1},
+				},
+			},
+			input:  nil,
+			expect: []Filter{fakeFilter1},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			opt := WithFilters(tt.input...)
+			assert.NoError(t, opt(&tt.mi))
+
+			opt = WithFilters(tt.input...)
+			assert.NoError(t, opt(&tt.mi))
+
+			assert.Equal(t, len(tt.expect), len(filtersFromCreateInfo(tt.mi)))
+		})
+	}
+}
+
 func TestFiltersFromCreateInfo(t *testing.T) {
 	fakeFilter1 := fakeFilter()
 	fakeFilter2 := fakeFilter()

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -61,8 +61,8 @@ func TestNew_WithOptions(t *testing.T) {
 	})
 }
 
-func TestHTTPModule_WithFilter(t *testing.T) {
-	withModule(t, registerPanic, []modules.Option{WithFilter(fakeFilter())}, false, func(m *Module) {
+func TestHTTPModule_WithFilters(t *testing.T) {
+	withModule(t, registerPanic, []modules.Option{WithFilters(fakeFilter())}, false, func(m *Module) {
 		assert.NotNil(t, m)
 		makeRequest(m, "GET", "/", nil, func(r *http.Response) {
 			body, err := ioutil.ReadAll(r.Body)
@@ -74,7 +74,7 @@ func TestHTTPModule_WithFilter(t *testing.T) {
 }
 
 func TestHTTPModule_WithUserPanicFilter(t *testing.T) {
-	withModule(t, registerTracerCheckHandler, []modules.Option{WithFilter(userPanicFilter())}, false, func(m *Module) {
+	withModule(t, registerTracerCheckHandler, []modules.Option{WithFilters(userPanicFilter())}, false, func(m *Module) {
 		assert.NotNil(t, m)
 		makeRequest(m, "GET", "/", nil, func(r *http.Response) {
 			assert.Equal(t, http.StatusInternalServerError, r.StatusCode, "Expected 500 with panic wrapper")


### PR DESCRIPTION
follow `rpc` packge, make `WithFilters` returns `modules.Option`, so we don't need to pass `[]Filter` as an additional param in `uhttp.New`.
No more `uhttp.New(hander, nil)` :D 