### PR TITLE
Remove parallel run for tracing filter

### DIFF
--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -30,6 +30,7 @@ import (
 // New creates an http.Client that includes 2 extra filters: tracing and auth
 // they are going to be applied in following order: tracing, auth, remaining filters
 // and only if all of them passed the request is going to be send.
+// Client is safe to use by multiple go routines, if global tracer is not changed.
 func New(info auth.CreateAuthInfo, filters ...Filter) *http.Client {
 	defaultFilters := []Filter{tracingFilter(), authenticationFilter(info)}
 	defaultFilters = append(defaultFilters, filters...)

--- a/modules/uhttp/client/client_filters.go
+++ b/modules/uhttp/client/client_filters.go
@@ -59,6 +59,8 @@ func tracingFilter() FilterFunc {
 		if s := opentracing.SpanFromContext(ctx); s != nil {
 			parent = s.Context()
 		}
+
+		// TODO(alsam) This makes our client to be not safe to use by multiple go routines.
 		span := opentracing.GlobalTracer().StartSpan(opName, opentracing.ChildOf(parent))
 		ext.SpanKindRPCClient.Set(span)
 		ext.HTTPUrl.Set(span, req.URL.String())

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -55,7 +55,6 @@ func TestExecutionChain(t *testing.T) {
 }
 
 func TestExecutionChainFilters(t *testing.T) {
-	t.Parallel()
 	execChain := newExecutionChain(
 		[]Filter{tracingFilter()}, nopTransport{},
 	)

--- a/modules/uhttp/client/client_filters_test.go
+++ b/modules/uhttp/client/client_filters_test.go
@@ -65,7 +65,6 @@ func TestExecutionChainFilters(t *testing.T) {
 }
 
 func TestExecutionChainFiltersError(t *testing.T) {
-	t.Parallel()
 	execChain := newExecutionChain(
 		[]Filter{tracingFilter()}, errTransport{},
 	)

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -51,7 +51,6 @@ func TestNew_Panic(t *testing.T) {
 }
 
 func TestClientDo(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
 	resp, err := _testClient.Do(req)
@@ -59,7 +58,6 @@ func TestClientDo(t *testing.T) {
 }
 
 func TestClientDoWithoutFilters(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
 	resp, err := _testClient.Do(req)
@@ -67,7 +65,6 @@ func TestClientDoWithoutFilters(t *testing.T) {
 }
 
 func TestClientGet(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	resp, err := _testClient.Get(svr.URL)
 	checkOKResponse(t, resp, err)
@@ -91,41 +88,35 @@ func TestClientGetTwiceExecutesAllFilters(t *testing.T) {
 }
 
 func TestClientGetError(t *testing.T) {
-	t.Parallel()
 	// Causing newRequest to fail, % does not parse as URL
 	resp, err := _testClient.Get("%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientHead(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	resp, err := _testClient.Head(svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientHeadError(t *testing.T) {
-	t.Parallel()
 	// Causing newRequest to fail, % does not parse as URL
 	resp, err := _testClient.Head("%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientPost(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	resp, err := _testClient.Post(svr.URL, "", nil)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientPostError(t *testing.T) {
-	t.Parallel()
 	resp, err := _testClient.Post("%", "", nil)
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientPostForm(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	var urlValues map[string][]string
 	resp, err := _testClient.PostForm(svr.URL, urlValues)

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -74,7 +74,6 @@ func TestClientGet(t *testing.T) {
 }
 
 func TestClientGetTwiceExecutesAllFilters(t *testing.T) {
-	t.Parallel()
 	svr := startServer()
 	count := 0
 	var f FilterFunc = func(r *http.Request, next Executor) (resp *http.Response, err error) {


### PR DESCRIPTION
Test can fail/panic if someone is manipulating with a global tracer in parallel