### PR TITLE
service: remove `NewBuilder` and `Owner.AddModules` and `New`

### DIFF
--- a/examples/keyvalue/server/main.go
+++ b/examples/keyvalue/server/main.go
@@ -29,14 +29,14 @@ import (
 )
 
 func main() {
-	svc, err := service.NewBuilder(
-		service.WithObserver(&Observer{}),
-	).WithModules(
+	svc, err := service.WithModules(
 		// Create a YARPC module that exposes endpoints
 		rpc.ThriftModule(
 			rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
 			modules.WithRoles("service"),
 		),
+	).WithOptions(
+		service.WithObserver(&Observer{}),
 	).Build()
 
 	if err != nil {

--- a/service/README.md
+++ b/service/README.md
@@ -81,23 +81,9 @@ Or via the service parameters, we would activate in the following ways:
 * `./myservice --roles "worker"`: Runs only the **Kakfa** module
 * Etc...
 
-## Instantiation
-
-Generally, you create a service in one of two ways:
-
-* The builder pattern, that is `service.WithModules(...).Build()`
-* Calling `service.New()` directly.
-
-The former is generally easier. We use the builder pattern in all examples, but
-`New()` is exported in case you'd like extra control over how your service is
-instantiated.
-
-If you **choose to** call `service.New()`, you need to call
-`AddModules(...)` to configure which modules you'd like to serve.
-
 ## Options
 
-Both the builder pattern and the `New()` function take a variadic `Options`
+The service builder takes a variadic `Options`
 pattern, allowing you to pick and choose which components you'd like to
 override. As a common theme of UberFx, specifying zero options should give
 you a fully working application.

--- a/service/builder.go
+++ b/service/builder.go
@@ -22,16 +22,16 @@ package service
 
 import "github.com/pkg/errors"
 
+// WithModules is a helper to create a service without any options
+func WithModules(modules ...ModuleCreateFunc) *Builder {
+	b := &Builder{}
+	return b.WithModules(modules...)
+}
+
 // A Builder is a helper to create a service
 type Builder struct {
 	options []Option
 	modules []ModuleCreateFunc
-}
-
-// NewBuilder returns a new Builder for instantiating services
-func NewBuilder(options ...Option) *Builder {
-	b := &Builder{}
-	return b.WithOptions(options...)
 }
 
 // WithModules adds the given modules to the service
@@ -39,12 +39,6 @@ func (b *Builder) WithModules(modules ...ModuleCreateFunc) *Builder {
 	b.modules = append(b.modules, modules...)
 
 	return b
-}
-
-// WithModules is a helper to create a service without any options
-func WithModules(modules ...ModuleCreateFunc) *Builder {
-	b := NewBuilder()
-	return b.WithModules(modules...)
 }
 
 // WithOptions adds service Options to the builder
@@ -55,14 +49,9 @@ func (b *Builder) WithOptions(options ...Option) *Builder {
 
 // Build returns the service, or any errors encountered during build phase.
 func (b *Builder) Build() (Owner, error) {
-	svc, err := New(b.options...)
+	svc, err := NewOwner(b.modules, b.options...)
 	if err != nil {
-		return nil, errors.Wrap(err, "service instantiation failed due to options")
+		return nil, errors.Wrap(err, "service instantiation failed")
 	}
-
-	if err := svc.AddModules(b.modules...); err != nil {
-		return nil, errors.Wrap(err, "service modules failed to initialize")
-	}
-
 	return svc, nil
 }

--- a/service/builder.go
+++ b/service/builder.go
@@ -49,7 +49,7 @@ func (b *Builder) WithOptions(options ...Option) *Builder {
 
 // Build returns the service, or any errors encountered during build phase.
 func (b *Builder) Build() (Owner, error) {
-	svc, err := NewOwner(b.modules, b.options...)
+	svc, err := newOwner(b.modules, b.options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "service instantiation failed")
 	}

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -27,51 +27,28 @@ import (
 	. "go.uber.org/fx/testutils"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestNewBuilder_NoConfig(t *testing.T) {
-	_, err := NewBuilder().Build()
-	assert.Error(t, err)
-}
-
-func TestNewBuilder_WithConfig(t *testing.T) {
-	b := NewBuilder(
-		WithConfiguration(StaticAppData(nil)),
-	)
-
-	svc, err := b.Build()
-	require.NoError(t, err)
-	assert.NotEmpty(t, svc.Name())
-}
-
-func TestBuilder_WithModules(t *testing.T) {
-	_, err := NewBuilder(
-		WithConfiguration(StaticAppData(nil)),
-	).WithModules(nopModule).Build()
-	assert.NoError(t, err)
-}
-
-func TestBuilder_WithErrModule(t *testing.T) {
-	_, err := NewBuilder(
-		WithConfiguration(StaticAppData(nil)),
-	).WithModules(errModule).Build()
-	assert.Error(t, err)
-}
-
-func TestBuilder_SkipsModulesBadInit(t *testing.T) {
-	empty := ""
-	_, err := NewBuilder(
-		WithConfiguration(StaticAppData(&empty)),
-	).WithModules(nopModule).Build()
-	assert.Error(t, err, "Expected service name to be provided")
-}
 
 func TestWithModules_OK(t *testing.T) {
 	_, err := WithModules(nopModule).WithOptions(
 		WithConfiguration(StaticAppData(nil)),
 	).Build()
 	assert.NoError(t, err)
+}
+
+func TestWithModules_Err(t *testing.T) {
+	_, err := WithModules(errModule).WithOptions(
+		WithConfiguration(StaticAppData(nil)),
+	).Build()
+	assert.Error(t, err)
+}
+
+func TestWithModules_SkipsModulesBadInit(t *testing.T) {
+	empty := ""
+	_, err := WithModules(nopModule).WithOptions(
+		WithConfiguration(StaticAppData(&empty)),
+	).Build()
+	assert.Error(t, err, "Expected service name to be provided")
 }
 
 func nopModule(_ ModuleCreateInfo) ([]Module, error) {

--- a/service/doc.go
+++ b/service/doc.go
@@ -104,25 +104,9 @@
 //
 // • Etc...
 //
-// Instantiation
-//
-// Generally, you create a service in one of two ways:
-//
-// • The builder pattern, that is service.WithModules(...).Build()
-//
-// • Calling service.New() directly.
-//
-// The former is generally easier. We use the builder pattern in all examples, but
-// New() is exported in case you'd like extra control over how your service is
-// instantiated.
-//
-//
-// If you **choose to** call service.New(), you need to call
-// AddModules(...) to configure which modules you'd like to serve.
-//
 // Options
 //
-// Both the builder pattern and the New() function take a variadic Optionspattern, allowing you to pick and choose which components you'd like to
+// The service builder takes a variadic Optionspattern, allowing you to pick and choose which components you'd like to
 // override. As a common theme of UberFx, specifying zero options should give
 // you a fully working application.
 //

--- a/service/host.go
+++ b/service/host.go
@@ -183,8 +183,8 @@ func (s *host) shutdown(err error, reason string, exitCode *int) (bool, error) {
 	return true, err
 }
 
-// AddModules adds the given modules to a service host
-func (s *host) AddModules(modules ...ModuleCreateFunc) error {
+// addModules adds the given modules to a service host
+func (s *host) addModules(modules ...ModuleCreateFunc) error {
 	for _, mcf := range modules {
 		mi := ModuleCreateInfo{
 			Host:  s,

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -32,27 +32,26 @@ import (
 	"github.com/uber-go/tally"
 )
 
-func TestAddModules_OK(t *testing.T) {
-	sh := &host{}
-	require.NoError(t, sh.AddModules(successModuleCreate))
-	assert.Empty(t, sh.Modules())
+func TestNewOwner_ModulesOK(t *testing.T) {
+	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig))
+	require.NoError(t, err)
 }
 
-func TestAddModules_Errors(t *testing.T) {
-	sh := &host{}
-	assert.Error(t, sh.AddModules(errorModuleCreate))
+func TestNewOwner_ModulesErr(t *testing.T) {
+	_, err := NewOwner([]ModuleCreateFunc{errorModuleCreate}, withConfig(validServiceConfig))
+	assert.Error(t, err)
 }
 
-func TestWithMetrics_OK(t *testing.T) {
+func TestNewOwner_WithMetricsOK(t *testing.T) {
 	assert.NotPanics(t, func() {
-		New(WithMetrics(tally.NoopScope, metrics.NopCachedStatsReporter))
+		NewOwner([]ModuleCreateFunc{successModuleCreate}, WithMetrics(tally.NoopScope, metrics.NopCachedStatsReporter))
 	})
 }
 
-func TestWithTracing_OK(t *testing.T) {
+func TestNewOwner_WithTracingOK(t *testing.T) {
 	tracer := &opentracing.NoopTracer{}
 	assert.NotPanics(t, func() {
-		New(WithTracer(tracer))
+		NewOwner([]ModuleCreateFunc{successModuleCreate}, WithTracer(tracer))
 	})
 }
 

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -33,25 +33,25 @@ import (
 )
 
 func TestNewOwner_ModulesOK(t *testing.T) {
-	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig))
+	_, err := newOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig))
 	require.NoError(t, err)
 }
 
 func TestNewOwner_ModulesErr(t *testing.T) {
-	_, err := NewOwner([]ModuleCreateFunc{errorModuleCreate}, withConfig(validServiceConfig))
+	_, err := newOwner([]ModuleCreateFunc{errorModuleCreate}, withConfig(validServiceConfig))
 	assert.Error(t, err)
 }
 
 func TestNewOwner_WithMetricsOK(t *testing.T) {
 	assert.NotPanics(t, func() {
-		NewOwner([]ModuleCreateFunc{successModuleCreate}, WithMetrics(tally.NoopScope, metrics.NopCachedStatsReporter))
+		newOwner([]ModuleCreateFunc{successModuleCreate}, WithMetrics(tally.NoopScope, metrics.NopCachedStatsReporter))
 	})
 }
 
 func TestNewOwner_WithTracingOK(t *testing.T) {
 	tracer := &opentracing.NoopTracer{}
 	assert.NotPanics(t, func() {
-		NewOwner([]ModuleCreateFunc{successModuleCreate}, WithTracer(tracer))
+		newOwner([]ModuleCreateFunc{successModuleCreate}, WithTracer(tracer))
 	})
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -81,8 +81,8 @@ type serviceConfig struct {
 	Roles       []string `yaml:"roles"`
 }
 
-// NewOwner creates a service owner from a set of module creation functions and options.
-func NewOwner(modules []ModuleCreateFunc, options ...Option) (Owner, error) {
+// newOwner creates a service owner from a set of module creation functions and options.
+func newOwner(modules []ModuleCreateFunc, options ...Option) (Owner, error) {
 	svc := &host{
 		// TODO: get these out of config struct instead
 		modules: []Module{},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -40,7 +40,7 @@ func TestServiceCreation(t *testing.T) {
 	r.CountersWG.Add(1)
 	scope, closer := tally.NewRootScope("", nil, r, 50*time.Millisecond, tally.DefaultSeparator)
 	defer closer.Close()
-	svc, err := NewOwner(
+	svc, err := newOwner(
 		[]ModuleCreateFunc{successModuleCreate},
 		withConfig(validServiceConfig),
 		WithMetrics(scope, nil),
@@ -53,7 +53,7 @@ func TestServiceCreation(t *testing.T) {
 }
 
 func TestWithObserver_Nil(t *testing.T) {
-	svc, err := NewOwner(
+	svc, err := newOwner(
 		[]ModuleCreateFunc{successModuleCreate},
 		withConfig(validServiceConfig),
 		WithObserver(nil),
@@ -64,7 +64,7 @@ func TestWithObserver_Nil(t *testing.T) {
 }
 
 func TestServiceCreation_MissingRequiredParams(t *testing.T) {
-	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(nil))
+	_, err := newOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(nil))
 	assert.Error(t, err, "should fail with missing service name")
 	assert.Contains(t, err.Error(), "zero value")
 }
@@ -77,7 +77,7 @@ func TestServiceWithRoles(t *testing.T) {
 	}
 	cfgOpt := withConfig(data)
 
-	svc, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
+	svc, err := newOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
 	require.NoError(t, err)
 
 	assert.Contains(t, svc.Roles(), "foo")
@@ -93,7 +93,7 @@ metrics:
 `)
 	cfgOpt := WithConfiguration(config.NewYAMLProviderFromBytes(data))
 
-	svc, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
+	svc, err := newOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
 	require.NoError(t, err)
 
 	assert.Nil(t, svc.RuntimeMetricsCollector())
@@ -109,7 +109,7 @@ logging:
 `)
 	cfgOpt := WithConfiguration(config.NewYAMLProviderFromBytes(data))
 
-	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
+	_, err := newOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
 	require.NoError(t, err)
 	// Note: Sentry is not accessible so we cannot directly test it here. Just invoking the code
 	// path to make sure there is no panic
@@ -121,13 +121,13 @@ func TestBadOption_Panics(t *testing.T) {
 		return errors.New("nope")
 	}
 
-	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig), opt)
+	_, err := newOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig), opt)
 	assert.Error(t, err, "should fail with invalid option")
 }
 
 func TestNew_WithObserver(t *testing.T) {
 	o := observerStub()
-	svc, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig), WithObserver(o))
+	svc, err := newOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig), WithObserver(o))
 	require.NoError(t, err)
 	assert.Equal(t, o, svc.Observer())
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -40,7 +40,8 @@ func TestServiceCreation(t *testing.T) {
 	r.CountersWG.Add(1)
 	scope, closer := tally.NewRootScope("", nil, r, 50*time.Millisecond, tally.DefaultSeparator)
 	defer closer.Close()
-	svc, err := New(
+	svc, err := NewOwner(
+		[]ModuleCreateFunc{successModuleCreate},
 		withConfig(validServiceConfig),
 		WithMetrics(scope, nil),
 	)
@@ -52,7 +53,8 @@ func TestServiceCreation(t *testing.T) {
 }
 
 func TestWithObserver_Nil(t *testing.T) {
-	svc, err := New(
+	svc, err := NewOwner(
+		[]ModuleCreateFunc{successModuleCreate},
 		withConfig(validServiceConfig),
 		WithObserver(nil),
 	)
@@ -62,7 +64,7 @@ func TestWithObserver_Nil(t *testing.T) {
 }
 
 func TestServiceCreation_MissingRequiredParams(t *testing.T) {
-	_, err := New(withConfig(nil))
+	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(nil))
 	assert.Error(t, err, "should fail with missing service name")
 	assert.Contains(t, err.Error(), "zero value")
 }
@@ -75,7 +77,7 @@ func TestServiceWithRoles(t *testing.T) {
 	}
 	cfgOpt := withConfig(data)
 
-	svc, err := New(cfgOpt)
+	svc, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
 	require.NoError(t, err)
 
 	assert.Contains(t, svc.Roles(), "foo")
@@ -91,7 +93,7 @@ metrics:
 `)
 	cfgOpt := WithConfiguration(config.NewYAMLProviderFromBytes(data))
 
-	svc, err := New(cfgOpt)
+	svc, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
 	require.NoError(t, err)
 
 	assert.Nil(t, svc.RuntimeMetricsCollector())
@@ -107,7 +109,7 @@ logging:
 `)
 	cfgOpt := WithConfiguration(config.NewYAMLProviderFromBytes(data))
 
-	_, err := New(cfgOpt)
+	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, cfgOpt)
 	require.NoError(t, err)
 	// Note: Sentry is not accessible so we cannot directly test it here. Just invoking the code
 	// path to make sure there is no panic
@@ -119,13 +121,13 @@ func TestBadOption_Panics(t *testing.T) {
 		return errors.New("nope")
 	}
 
-	_, err := New(withConfig(validServiceConfig), opt)
+	_, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig), opt)
 	assert.Error(t, err, "should fail with invalid option")
 }
 
 func TestNew_WithObserver(t *testing.T) {
 	o := observerStub()
-	svc, err := New(withConfig(validServiceConfig), WithObserver(o))
+	svc, err := NewOwner([]ModuleCreateFunc{successModuleCreate}, withConfig(validServiceConfig), WithObserver(o))
 	require.NoError(t, err)
 	assert.Equal(t, o, svc.Observer())
 }

--- a/service/testutils/service.go
+++ b/service/testutils/service.go
@@ -28,14 +28,10 @@ func WithService(module service.ModuleCreateFunc, observer service.Observer, opt
 		observer = service.ObserverStub()
 	}
 
-	svc, err := service.New(append(options, service.WithObserver(observer))...)
+	svc, err := service.NewOwner([]service.ModuleCreateFunc{module}, append(options, service.WithObserver(observer))...)
 	if err != nil {
 		panic(err)
 	}
-	err = svc.AddModules(module)
 
-	if err != nil {
-		panic(err)
-	}
 	fn(svc)
 }

--- a/service/testutils/service.go
+++ b/service/testutils/service.go
@@ -28,7 +28,7 @@ func WithService(module service.ModuleCreateFunc, observer service.Observer, opt
 		observer = service.ObserverStub()
 	}
 
-	svc, err := service.NewOwner([]service.ModuleCreateFunc{module}, append(options, service.WithObserver(observer))...)
+	svc, err := service.WithModules(module).WithOptions(append(options, service.WithObserver(observer))...).Build()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
To create builder, it is more clear to use `WithModules`
and `WithOptions`.

For `Owner.AddModules`, the modules should be added at the
build stage. There is no need to add modules after Owner
is created.

`New` is removed, and it is encouraged to always use builder.

for https://jira.uberinternal.com/browse/DRI-11