### PR TITLE
add test to ensure config does not panic when populate for Array type

### DIFF
--- a/config/value.go
+++ b/config/value.go
@@ -292,6 +292,7 @@ const (
 	bucketArray     = 1
 	bucketObject    = 2
 	bucketMap       = 3
+	bucketSlice     = 4
 )
 
 func getBucket(t reflect.Type) int {
@@ -309,9 +310,9 @@ func getBucket(t reflect.Type) int {
 	case reflect.Map:
 		return bucketMap
 	case reflect.Array:
-		fallthrough
-	case reflect.Slice:
 		return bucketArray
+	case reflect.Slice:
+		return bucketSlice
 	case reflect.Struct:
 		return bucketObject
 	}
@@ -531,6 +532,8 @@ func (cv Value) valueStruct(key string, target interface{}) (interface{}, error)
 				fieldValue.Set(newTarget)
 			}
 		case bucketArray:
+			// TODO(alsam) fix array type.
+		case bucketSlice:
 			destSlice := reflect.MakeSlice(fieldType, 0, 4)
 
 			// start looking for child values.

--- a/config/value.go
+++ b/config/value.go
@@ -532,7 +532,7 @@ func (cv Value) valueStruct(key string, target interface{}) (interface{}, error)
 				fieldValue.Set(newTarget)
 			}
 		case bucketArray:
-			// TODO(alsam) fix array type.
+			// TODO(alsam) fix array type DRI-12.
 		case bucketSlice:
 			destSlice := reflect.MakeSlice(fieldType, 0, 4)
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -362,3 +362,14 @@ func TestYamlProviderFmtPrintOnValueNoPanic(t *testing.T) {
 	}
 	assert.NotPanics(t, f)
 }
+
+func TestArrayTypeNoPanic(t *testing.T) {
+	// This test will panic if we treat array the same as slice.
+	provider := NewYAMLProviderFromBytes(yamlConfig1)
+
+	cs := struct {
+		ID [6]int `yaml:"id"`
+	}{}
+
+	assert.NoError(t, provider.Get(Root).PopulateStruct(&cs))
+}


### PR DESCRIPTION
Array and Slice are different but right now we treat them the same in config package:
```
case bucketArray:
            destSlice := reflect.MakeSlice(fieldType, 0, 4)
```
this will cause panic on Array type like `[6]int`:
```
--- FAIL: TestArrayTypeNoPanic (0.00s)
panic: reflect.MakeSlice of non-slice type [recovered]
    panic: reflect.MakeSlice of non-slice type
```
Add a test to ensure we don’t panic when populate config for Array type
And add TODO for @alsamylkin 