### PR TITLE
add String() func on config.Value to solve fmt print panic

### DIFF
--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -77,7 +77,7 @@ func TestStaticProviderFmtPrintOnValueNoPanic(t *testing.T) {
 	val := p.Get("something")
 
 	f := func() {
-		fmt.Sprintf("%v", val)
+		assert.Contains(t, fmt.Sprintf("%v", val), "")
 	}
 	assert.NotPanics(t, f)
 }

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -21,6 +21,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,4 +70,14 @@ func TestStaticProvider_Callbacks(t *testing.T) {
 	p := NewStaticProvider(nil)
 	assert.NoError(t, p.RegisterChangeCallback("test", nil))
 	assert.NoError(t, p.UnregisterChangeCallback("token"))
+}
+
+func TestStaticProviderFmtPrintOnValueNoPanic(t *testing.T) {
+	p := NewStaticProvider(nil)
+	val := p.Get("something")
+
+	f := func() {
+		fmt.Sprintf("%v", val)
+	}
+	assert.NotPanics(t, f)
 }

--- a/config/value.go
+++ b/config/value.go
@@ -162,6 +162,11 @@ func (cv Value) ChildKeys() []string {
 	return nil
 }
 
+// String prints out underline value in Value with fmt.Srpintf.
+func (cv Value) String() string {
+	return fmt.Sprintf("%v", cv.value)
+}
+
 // TryAsString attempts to return the configuration value as a string
 func (cv Value) TryAsString() (string, bool) {
 	v := cv.Value()

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -358,7 +358,7 @@ func TestYamlProviderFmtPrintOnValueNoPanic(t *testing.T) {
 	c := provider.Get("modules.rpc.bind")
 
 	f := func() {
-		fmt.Sprintf("%v", c)
+		assert.Contains(t, fmt.Sprintf("%v", c), "")
 	}
 	assert.NotPanics(t, f)
 }

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -350,4 +351,14 @@ func TestMerge(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestYamlProviderFmtPrintOnValueNoPanic(t *testing.T) {
+	provider := NewYAMLProviderFromBytes(yamlConfig1)
+	c := provider.Get("modules.rpc.bind")
+
+	f := func() {
+		fmt.Sprintf("%v", c)
+	}
+	assert.NotPanics(t, f)
 }


### PR DESCRIPTION
Fixes #278 

I think the cause of this issue is: `Value` has a `Provider` and `yamlConfigProvider` has a `map[string]Value`. This cause finding a `String()` function recursing indefinitely.
Add `String()` function to `Value` can solve this issue.

However, we don't want user use this function, so this solution may not be ideal. Open to discuss.