### PR TITLE
Allow both .yaml and .yml config file extensions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,7 @@ func getConfigFiles() []string {
 	for _, dir := range dirs {
 		for _, baseFile := range baseFiles {
 			files = append(files, fmt.Sprintf("%s/%s.yaml", dir, baseFile))
+			files = append(files, fmt.Sprintf("%s/%s.yml", dir, baseFile))
 		}
 	}
 


### PR DESCRIPTION
This might be desirable or not - a lot of people use .yml instead of .yaml - .yaml is more "correct", but it would be nice to support both. This just checks for both. As it is now, .yml overrides .yaml, so maybe we want to reverse the order.

Just as another data point, docker-compose accepts both https://docs.docker.com/compose/compose-file