### PR TITLE
Expose deafult DI graph

### DIFF
--- a/dig/default.go
+++ b/dig/default.go
@@ -20,7 +20,7 @@
 
 package dig
 
-// defaultGraph is used for all the top-level inject calls
+// Default graph is used for all the top-level inject calls
 var defaultGraph = newGraph()
 
 // DefaultGraph returns the graph used by top-level inject calls

--- a/dig/default.go
+++ b/dig/default.go
@@ -20,30 +20,30 @@
 
 package dig
 
-// Default graph is used for all the top-level inject calls
-var defaultGraph = newGraph()
+// DefaultGraph is used for all the top-level inject calls
+var DefaultGraph Graph = newGraph()
 
 // Register into the default graph
 func Register(i interface{}) error {
-	return defaultGraph.Register(i)
+	return DefaultGraph.Register(i)
 }
 
 // RegisterAll into the default graph
 func RegisterAll(is ...interface{}) error {
-	return defaultGraph.RegisterAll(is...)
+	return DefaultGraph.RegisterAll(is...)
 }
 
 // Resolve an object through the default graph
 func Resolve(i interface{}) error {
-	return defaultGraph.Resolve(i)
+	return DefaultGraph.Resolve(i)
 }
 
 // ResolveAll the passed in pointers through the dependency graph
 func ResolveAll(is ...interface{}) error {
-	return defaultGraph.ResolveAll(is...)
+	return DefaultGraph.ResolveAll(is...)
 }
 
 // Reset the default graph
 func Reset() {
-	defaultGraph.Reset()
+	DefaultGraph.Reset()
 }

--- a/dig/default.go
+++ b/dig/default.go
@@ -20,30 +20,35 @@
 
 package dig
 
-// DefaultGraph is used for all the top-level inject calls
-var DefaultGraph Graph = newGraph()
+// defaultGraph is used for all the top-level inject calls
+var defaultGraph = newGraph()
+
+// DefaultGraph returns the graph used by top-level inject calls
+func DefaultGraph() Graph {
+	return defaultGraph
+}
 
 // Register into the default graph
 func Register(i interface{}) error {
-	return DefaultGraph.Register(i)
+	return defaultGraph.Register(i)
 }
 
 // RegisterAll into the default graph
 func RegisterAll(is ...interface{}) error {
-	return DefaultGraph.RegisterAll(is...)
+	return defaultGraph.RegisterAll(is...)
 }
 
 // Resolve an object through the default graph
 func Resolve(i interface{}) error {
-	return DefaultGraph.Resolve(i)
+	return defaultGraph.Resolve(i)
 }
 
 // ResolveAll the passed in pointers through the dependency graph
 func ResolveAll(is ...interface{}) error {
-	return DefaultGraph.ResolveAll(is...)
+	return defaultGraph.ResolveAll(is...)
 }
 
 // Reset the default graph
 func Reset() {
-	DefaultGraph.Reset()
+	defaultGraph.Reset()
 }

--- a/dig/default_test.go
+++ b/dig/default_test.go
@@ -57,4 +57,8 @@ func TestDefaultGraph(t *testing.T) {
 	require.NoError(t, ResolveAll(&t2g, &t3g))
 	require.True(t, t2g == t2)
 	require.True(t, t3g == t3)
+
+	var t2g2 *Type2
+	require.NoError(t, DefaultGraph().Resolve(&t2g2))
+	require.Equal(t, t2, t2g2)
 }

--- a/dig/dig.go
+++ b/dig/dig.go
@@ -157,7 +157,7 @@ func (g *graph) Reset() {
 	g.Lock()
 	defer g.Unlock()
 
-	defaultGraph.nodes = make(map[interface{}]object)
+	g.nodes = make(map[interface{}]object)
 }
 
 type object interface {

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -39,6 +39,7 @@ func nonPointerParams(one, two string) *S {
 }
 
 func TestRegister(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		name  string
 		param interface{}
@@ -66,6 +67,7 @@ func TestRegister(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
+	t.Parallel()
 	tts := []struct {
 		name     string
 		register func(g *graph) error
@@ -107,6 +109,7 @@ func TestResolve(t *testing.T) {
 }
 
 func TestObjectRegister(t *testing.T) {
+	t.Parallel()
 	g := New()
 
 	// register a fake struct type into the graph
@@ -139,12 +142,11 @@ func TestBasicRegisterResolve(t *testing.T) {
 	require.NoError(t, err)
 
 	var first *Grandchild1
-	err = g.Resolve(&first)
+	require.NoError(t, g.Resolve(&first), "No error expected during first Resolve")
 
 	var second *Grandchild1
-	err = g.Resolve(&second)
+	require.NoError(t, g.Resolve(&second), "No error expected during second Resolve")
 
-	require.NoError(t, err, "No error expected during Resolve")
 	require.NotNil(t, first, "Child1 must have been registered")
 	require.NotNil(t, second, "Child1 must have been registered")
 	require.True(t, first == second, "Must point to the same object")
@@ -203,6 +205,18 @@ func TestResolveAll(t *testing.T) {
 	require.NoError(t, err, "Did not expect error on resolve all")
 	require.Equal(t, p1.name, "Parent1")
 	require.True(t, p1 == p2 && p2 == p3 && p3 == p4, "All pointers must be equal")
+}
+
+func TestEmptyAfterReset(t *testing.T) {
+	t.Parallel()
+	g := testGraph()
+
+	require.NoError(t, g.Register(NewGrandchild1))
+
+	var first *Grandchild1
+	require.NoError(t, g.Resolve(&first), "No error expected during first Resolve")
+	g.Reset()
+	require.Contains(t, g.Resolve(&first).Error(), "not registered")
 }
 
 func testGraph() *graph {


### PR DESCRIPTION
Exposing the default graph helps us with testing(especially parallel) external packages, it allows us to store the graph reference in the object itself and e.g. override it with options.