### PR TITLE
Prevent dig cycles

### DIFF
--- a/dig/dig.go
+++ b/dig/dig.go
@@ -29,6 +29,7 @@ var (
 	errReturnCount = errors.New("constructor function must return exactly one value")
 	errReturnKind  = errors.New("constructor return type must be a pointer")
 	errArgKind     = errors.New("constructor arguments must be pointers")
+	errCycle       = errors.New("cycle dependencies detected")
 )
 
 // New returns a new Dependency Injection Graph

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -188,15 +188,18 @@ func TestConcurrentAccess(t *testing.T) {
 func TestCycles(t *testing.T) {
 	type Type1 interface{}
 	type Type2 interface{}
+	type Type3 interface{}
 	c1 := func(t2 Type2) Type1 { return nil }
-	c2 := func(t1 Type1) Type2 { return nil }
+	c2 := func(t3 Type3) Type2 { return nil }
+	c3 := func(t1 Type1) Type3 { return nil }
 
 	g := testGraph()
 
 	require.NoError(t, g.Register(c1))
+	require.NoError(t, g.Register(c2))
 
-	err := g.Register(c2)
-	require.Contains(t, err.Error(), "unable to register dig.Type2")
+	err := g.Register(c3)
+	require.Contains(t, err.Error(), "unable to register dig.Type3")
 	require.Contains(t, err.Error(), "cycle")
 }
 

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -194,10 +194,10 @@ func TestCycles(t *testing.T) {
 	g := testGraph()
 
 	require.NoError(t, g.Register(c1))
-	require.NoError(t, g.Register(c2))
 
-	var r Type1
-	require.NoError(t, g.Resolve(&r))
+	err := g.Register(c2)
+	require.Contains(t, err.Error(), "unable to register dig.Type2")
+	require.Contains(t, err.Error(), "cycle")
 }
 
 func TestResolveAll(t *testing.T) {

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -185,6 +185,21 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestCycles(t *testing.T) {
+	type Type1 interface{}
+	type Type2 interface{}
+	c1 := func(t2 Type2) Type1 { return nil }
+	c2 := func(t1 Type1) Type2 { return nil }
+
+	g := testGraph()
+
+	require.NoError(t, g.Register(c1))
+	require.NoError(t, g.Register(c2))
+
+	var r Type1
+	require.NoError(t, g.Resolve(&r))
+}
+
 func TestResolveAll(t *testing.T) {
 	t.Parallel()
 	g := testGraph()

--- a/dig/graph.go
+++ b/dig/graph.go
@@ -211,6 +211,9 @@ func (g *graph) recursiveDetectCycles(n graphNode, visited map[string]bool) erro
 	for _, dep := range n.dependencies() {
 		if node, ok := g.nodes[dep]; ok {
 			if err := g.recursiveDetectCycles(node, visited); err != nil {
+				// TODO(glib): rework the returned error to include the cycle
+				// i.e. Type1 -> Type3 -> Type2 -> Type1
+				// this will likely require `visited` map to be [string]reflect.Type
 				return err
 			}
 		}

--- a/dig/graph.go
+++ b/dig/graph.go
@@ -183,5 +183,38 @@ func (g *graph) registerConstructor(c interface{}) error {
 	}
 
 	g.nodes[objType] = &n
+
+	// object needs to be part of the graph to properly detect cycles
+	if cycleErr := g.detectCycles(&n); cycleErr != nil {
+		// if the cycle was detected delete from the graph
+		delete(g.nodes, objType)
+		return errors.Wrapf(cycleErr, "unable to register %v", objType)
+	}
+
+	return nil
+}
+
+// When a new constructor is being inserted, detect any present cycles
+func (g *graph) detectCycles(n *funcNode) error {
+	visited := make(map[string]bool)
+	return g.recursiveDetectCycles(n, visited)
+}
+
+// DFS and tracking if same node is visited twice
+func (g *graph) recursiveDetectCycles(n graphNode, visited map[string]bool) error {
+	if visited[n.id()] {
+		return errCycle
+	}
+
+	visited[n.id()] = true
+
+	for _, dep := range n.dependencies() {
+		if node, ok := g.nodes[dep]; ok {
+			if err := g.recursiveDetectCycles(node, visited); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/dig/node.go
+++ b/dig/node.go
@@ -33,12 +33,21 @@ type graphNode interface {
 
 	// Other things that need to be present before this object can be created
 	dependencies() []interface{}
+
+	// unique identification per node
+	id() string
 }
 
 type node struct {
 	objType     reflect.Type
 	cached      bool
 	cachedValue reflect.Value
+}
+
+func (n node) id() string {
+	// in the future, more than just the type of node is going to be required
+	// for instance, when multiple types are allowed with different names
+	return n.objType.Name()
 }
 
 type objNode struct {
@@ -49,7 +58,7 @@ type objNode struct {
 }
 
 // Return the earlier provided instance
-func (n objNode) value(g *graph) (reflect.Value, error) {
+func (n *objNode) value(g *graph) (reflect.Value, error) {
 	return reflect.ValueOf(n.obj), nil
 }
 
@@ -121,11 +130,7 @@ func (n funcNode) dependencies() []interface{} {
 
 func (n funcNode) String() string {
 	return fmt.Sprintf(
-		"(function) deps: %v, type: %v, constructor: %v, cached: %v, cachedValue: %v",
-		n.deps,
-		n.objType,
-		n.constructor,
-		n.cached,
-		n.cachedValue,
+		"(function) id: %s, deps: %v, type: %v, constructor: %v, cached: %v, cachedValue: %v",
+		n.id(), n.deps, n.objType, n.constructor, n.cached, n.cachedValue,
 	)
 }


### PR DESCRIPTION
This is a must for beta, because it has the ability to overflow panic the stack if types are not registered correctly.

Fixes #282 