### PR TITLE
[WIP]Use DIG to create uhttp client

### DIFF
--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -37,7 +37,7 @@ const (
 	_graphKey      = "httpClientGraph"
 )
 
-// WithOutbound lets you add custom middleware to the client
+// WithOutbound lets you add to custom middleware to the client
 func WithOutbound(middleware ...OutboundMiddleware) modules.Option {
 	return func(info *service.ModuleCreateInfo) error {
 		items := info.Items
@@ -50,7 +50,7 @@ func WithOutbound(middleware ...OutboundMiddleware) modules.Option {
 	}
 }
 
-// WithGraph allows you to a custom dependency injection graph to resolve Tracer and AuthInfo
+// WithGraph allows you to use a custom dependency injection graph to resolve Tracer and AuthInfo
 func WithGraph(graph dig.Graph) modules.Option {
 	return func(info *service.ModuleCreateInfo) error {
 		info.Items[_graphKey] = graph

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -37,7 +37,7 @@ const (
 	_graphKey      = "httpClientGraph"
 )
 
-// WithOutbound lets you add to custom middleware to the client
+// WithOutbound lets you to add a custom middleware to the client
 func WithOutbound(middleware ...OutboundMiddleware) modules.Option {
 	return func(info *service.ModuleCreateInfo) error {
 		items := info.Items

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -74,7 +74,7 @@ func New(options ...modules.Option) (*http.Client, error) {
 		}
 	}
 
-	// Resolve auth and _tracer.
+	// Resolve auth and tracer.
 	graph := dig.DefaultGraph()
 	if g, ok := info.Items[_graphKey]; ok {
 		graph = g.(dig.Graph)

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -90,7 +90,7 @@ func New(options ...modules.Option) (*http.Client, error) {
 		return nil, err
 	}
 
-	// Construct filters.
+	// Make middleware.
 	middleware := make([]OutboundMiddleware, 0, len(options)+2)
 	middleware = append(middleware, tracingOutbound(*tracer), authenticationOutbound(*auth))
 

--- a/modules/uhttp/client/client.go
+++ b/modules/uhttp/client/client.go
@@ -74,7 +74,7 @@ func New(options ...modules.Option) (*http.Client, error) {
 		}
 	}
 
-	// Resolve auth and tracer.
+	// Resolve auth and _tracer.
 	graph := dig.DefaultGraph()
 	if g, ok := info.Items[_graphKey]; ok {
 		graph = g.(dig.Graph)

--- a/modules/uhttp/client/client_middleware.go
+++ b/modules/uhttp/client/client_middleware.go
@@ -51,7 +51,7 @@ func (f OutboundMiddlewareFunc) Handle(r *http.Request, next Executor) (resp *ht
 	return f(r, next)
 }
 
-func tracingOutbound() OutboundMiddlewareFunc {
+func tracingOutbound(tracer opentracing.Tracer) OutboundMiddlewareFunc {
 	return func(req *http.Request, next Executor) (resp *http.Response, err error) {
 		ctx := req.Context()
 		opName := req.Method
@@ -61,7 +61,7 @@ func tracingOutbound() OutboundMiddlewareFunc {
 		}
 
 		// TODO(alsam) This makes our client to be not safe to use by multiple go routines.
-		span := opentracing.GlobalTracer().StartSpan(opName, opentracing.ChildOf(parent))
+		span := tracer.StartSpan(opName, opentracing.ChildOf(parent))
 		ext.SpanKindRPCClient.Set(span)
 		ext.HTTPUrl.Set(span, req.URL.String())
 		defer span.Finish()

--- a/modules/uhttp/client/client_middleware_benchmark_test.go
+++ b/modules/uhttp/client/client_middleware_benchmark_test.go
@@ -47,9 +47,9 @@ func BenchmarkClientMiddleware(b *testing.B) {
 	defer closer.Close()
 	bm := map[string][]OutboundMiddleware{
 		"empty":   {},
-		"tracing": {tracingOutbound()},
+		"tracing": {tracingOutbound(tracer)},
 		"auth":    {authenticationOutbound(fakeAuthInfo{_testYaml})},
-		"default": {tracingOutbound(), authenticationOutbound(fakeAuthInfo{_testYaml})},
+		"default": {tracingOutbound(tracer), authenticationOutbound(fakeAuthInfo{_testYaml})},
 	}
 
 	for name, middleware := range bm {

--- a/modules/uhttp/client/client_middleware_test.go
+++ b/modules/uhttp/client/client_middleware_test.go
@@ -119,7 +119,7 @@ func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 	tr := &shadowTracer{
 		opentracing.NoopTracer{},
 		func(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
-			return errors.New("Very bad tracer")
+			return errors.New("Very bad _tracer")
 		},
 		nil,
 	}
@@ -132,7 +132,7 @@ func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 		op := func(t *testing.T) {
 			execChain := newExecutionChain(
 				[]OutboundMiddleware{middleware}, nopTransport{})
-			span := tracer.StartSpan("test_method")
+			span := _tracer.StartSpan("test_method")
 			span.SetBaggageItem(auth.ServiceAuth, "testService")
 			sp := &shadowSpan{span, tr}
 			tr.span = sp
@@ -140,7 +140,7 @@ func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 			ctx := opentracing.ContextWithSpan(context.Background(), sp)
 
 			_, err := execChain.RoundTrip(_req().WithContext(ctx))
-			assert.EqualError(t, err, "Very bad tracer")
+			assert.EqualError(t, err, "Very bad _tracer")
 		}
 
 		t.Run(name, op)

--- a/modules/uhttp/client/client_middleware_test.go
+++ b/modules/uhttp/client/client_middleware_test.go
@@ -125,11 +125,11 @@ func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 	}
 	testCases := map[string]OutboundMiddleware{
 		"auth":    authenticationOutbound(fakeAuthInfo{_testYaml}),
-		"tracing": tracingOutbound(opentracing.NoopTracer{}),
+		"tracing": tracingOutbound(tr),
 	}
 
 	for name, middleware := range testCases {
-		op := func(tracer opentracing.Tracer) {
+		op := func(t *testing.T) {
 			execChain := newExecutionChain(
 				[]OutboundMiddleware{middleware}, nopTransport{})
 			span := tracer.StartSpan("test_method")
@@ -143,7 +143,7 @@ func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 			assert.EqualError(t, err, "Very bad tracer")
 		}
 
-		t.Run(name, func(t *testing.T) { withOpentracingSetup(t, nil, op) })
+		t.Run(name, op)
 	}
 }
 

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -25,6 +25,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go.uber.org/fx/auth"
+	"go.uber.org/fx/dig"
+	"go.uber.org/fx/modules"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,12 +38,27 @@ var (
 	_testYaml = []byte(`
 name: test
 `)
-	_testClient = New(opentracing.NoopTracer{}, fakeAuthInfo{yaml: _testYaml})
+	tracer   = opentracing.NoopTracer{}
+	authInfo = fakeAuthInfo{yaml: _testYaml}
 )
+
+func withTestGraph(t *testing.T, tracer opentracing.Tracer, info auth.CreateAuthInfo) modules.Option{
+	g := dig.New()
+	require.NoError(t, g.Register(&tracer))
+	require.NoError(t, g.Register(&info))
+	return WithGraph(g)
+}
+
+func testClient(t *testing.T) *http.Client {
+	cl, err := New(withTestGraph(t, tracer, authInfo))
+	require.NoError(t, err)
+	return cl
+}
 
 func TestNew(t *testing.T) {
 	t.Parallel()
-	chain, ok := _testClient.Transport.(executionChain)
+
+	chain, ok := testClient(t).Transport.(executionChain)
 	require.True(t, ok)
 	assert.Equal(t, 2, len(chain.middleware))
 }
@@ -47,7 +66,7 @@ func TestNew(t *testing.T) {
 func TestNew_Panic(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() {
-		New(opentracing.NoopTracer{}, fakeAuthInfo{yaml: []byte(``)})
+		New(withTestGraph(t, tracer, &fakeAuthInfo{yaml: []byte(``)}))
 	})
 }
 
@@ -55,7 +74,7 @@ func TestClientDo(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
-	resp, err := _testClient.Do(req)
+	resp, err := testClient(t).Do(req)
 	checkOKResponse(t, resp, err)
 }
 
@@ -63,14 +82,14 @@ func TestClientDoWithoutMiddleware(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
 	req := createHTTPClientRequest(svr.URL)
-	resp, err := _testClient.Do(req)
+	resp, err := testClient(t).Do(req)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
-	resp, err := _testClient.Get(svr.URL)
+	resp, err := testClient(t).Get(svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
@@ -83,46 +102,47 @@ func TestClientGetTwiceExecutesAllMiddleware(t *testing.T) {
 		return next.Execute(r)
 	}
 
-	cl := New(opentracing.NoopTracer{}, fakeAuthInfo{yaml: _testYaml}, f)
+	cl, err := New(withTestGraph(t, tracer, authInfo), WithOutbound(f), WithOutbound(f))
+	require.NoError(t, err)
 	resp, err := cl.Get(svr.URL)
 	checkOKResponse(t, resp, err)
-	require.Equal(t, 1, count)
+	require.Equal(t, 2, count)
 	resp, err = cl.Get(svr.URL)
 	checkOKResponse(t, resp, err)
-	require.Equal(t, 2, count)
+	require.Equal(t, 4, count)
 }
 
 func TestClientGetError(t *testing.T) {
 	t.Parallel()
 	// Causing newRequest to fail, % does not parse as URL
-	resp, err := _testClient.Get("%")
+	resp, err := testClient(t).Get("%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientHead(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
-	resp, err := _testClient.Head(svr.URL)
+	resp, err := testClient(t).Head(svr.URL)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientHeadError(t *testing.T) {
 	t.Parallel()
 	// Causing newRequest to fail, % does not parse as URL
-	resp, err := _testClient.Head("%")
+	resp, err := testClient(t).Head("%")
 	checkErrResponse(t, resp, err)
 }
 
 func TestClientPost(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
-	resp, err := _testClient.Post(svr.URL, "", nil)
+	resp, err := testClient(t).Post(svr.URL, "", nil)
 	checkOKResponse(t, resp, err)
 }
 
 func TestClientPostError(t *testing.T) {
 	t.Parallel()
-	resp, err := _testClient.Post("%", "", nil)
+	resp, err := testClient(t).Post("%", "", nil)
 	checkErrResponse(t, resp, err)
 }
 
@@ -130,8 +150,20 @@ func TestClientPostForm(t *testing.T) {
 	t.Parallel()
 	svr := startServer()
 	var urlValues map[string][]string
-	resp, err := _testClient.PostForm(svr.URL, urlValues)
+	resp, err := testClient(t).PostForm(svr.URL, urlValues)
 	checkOKResponse(t, resp, err)
+}
+
+func TestClientConstructionErrors(t *testing.T) {
+	t.Parallel()
+	g := dig.New()
+	_, err := New(WithGraph(g))
+	var tracer *opentracing.Tracer
+	require.Equal(t, err, g.Resolve(&tracer))
+	require.NoError(t, g.Register(tracer))
+	var info *auth.CreateAuthInfo
+	_, err = New(WithGraph(g))
+	require.Equal(t, err, g.Resolve(&info))
 }
 
 func checkErrResponse(t *testing.T, resp *http.Response, err error) {

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -38,8 +38,8 @@ var (
 	_testYaml = []byte(`
 name: test
 `)
-	tracer   = opentracing.NoopTracer{}
-	authInfo = fakeAuthInfo{yaml: _testYaml}
+	_tracer   = opentracing.NoopTracer{}
+	_authInfo = fakeAuthInfo{yaml: _testYaml}
 )
 
 func withTestGraph(t *testing.T, tracer opentracing.Tracer, info auth.CreateAuthInfo) modules.Option {
@@ -50,7 +50,7 @@ func withTestGraph(t *testing.T, tracer opentracing.Tracer, info auth.CreateAuth
 }
 
 func testClient(t *testing.T) *http.Client {
-	cl, err := New(withTestGraph(t, tracer, authInfo))
+	cl, err := New(withTestGraph(t, _tracer, _authInfo))
 	require.NoError(t, err)
 	return cl
 }
@@ -66,7 +66,7 @@ func TestNew(t *testing.T) {
 func TestNew_Panic(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() {
-		New(withTestGraph(t, tracer, &fakeAuthInfo{yaml: []byte(``)}))
+		New(withTestGraph(t, _tracer, &fakeAuthInfo{yaml: []byte(``)}))
 	})
 }
 
@@ -102,7 +102,7 @@ func TestClientGetTwiceExecutesAllMiddleware(t *testing.T) {
 		return next.Execute(r)
 	}
 
-	cl, err := New(withTestGraph(t, tracer, authInfo), WithOutbound(f), WithOutbound(f))
+	cl, err := New(withTestGraph(t, _tracer, _authInfo), WithOutbound(f), WithOutbound(f))
 	require.NoError(t, err)
 	resp, err := cl.Get(svr.URL)
 	checkOKResponse(t, resp, err)

--- a/modules/uhttp/client/client_test.go
+++ b/modules/uhttp/client/client_test.go
@@ -42,7 +42,7 @@ name: test
 	authInfo = fakeAuthInfo{yaml: _testYaml}
 )
 
-func withTestGraph(t *testing.T, tracer opentracing.Tracer, info auth.CreateAuthInfo) modules.Option{
+func withTestGraph(t *testing.T, tracer opentracing.Tracer, info auth.CreateAuthInfo) modules.Option {
 	g := dig.New()
 	require.NoError(t, g.Register(&tracer))
 	require.NoError(t, g.Register(&info))

--- a/service/host.go
+++ b/service/host.go
@@ -164,6 +164,7 @@ func (s *manager) shutdown(err error, reason string, exitCode *int) (bool, error
 	}
 
 	// Flush tracing buffers
+	// GFM-378 uhttp.Client is not safe to send requests anymore
 	if s.tracerCloser != nil {
 		ulog.Logger(_simpleCtx).Debug("Closing tracer")
 		if err = s.tracerCloser.Close(); err != nil {


### PR DESCRIPTION
Simplify client construction and use a DI graph to resolve auth and tracing.
If they are not present, an error is returned.

Constructor now accepts 2 options: di graph and middleware,
which can be used to override auth/tracing and add extra middleware.

TODO: Put tracer and auth in the default graph.
