### PR TITLE
Default rpc name

### DIFF
--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -38,7 +38,7 @@ type CreateThriftServiceFunc func(svc service.Host) ([]transport.Procedure, erro
 // ThriftModule creates a Thrift Module from a service func
 func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) service.ModuleCreateFunc {
 	return func(mi service.ModuleCreateInfo) ([]service.Module, error) {
-		if mi.Name != "" {
+		if mi.Name == "" {
 			mi.Name = "rpc"
 		}
 

--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -38,6 +38,10 @@ type CreateThriftServiceFunc func(svc service.Host) ([]transport.Procedure, erro
 // ThriftModule creates a Thrift Module from a service func
 func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) service.ModuleCreateFunc {
 	return func(mi service.ModuleCreateInfo) ([]service.Module, error) {
+		if mi.Name != "" {
+			mi.Name = "rpc"
+		}
+
 		mod, err := newYARPCThriftModule(mi, hookup, options...)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to instantiate Thrift module")


### PR DESCRIPTION
Right now we'll default to submodule name to yarpc, which is confusing.