### PR TITLE
Allow arbitrary order for Register funcitons

### DIFF
--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -208,9 +208,9 @@ func TestResolveAll(t *testing.T) {
 	g := testGraph()
 
 	err := g.RegisterAll(
-		NewParent1,
-		NewChild1,
 		NewGrandchild1,
+		NewChild1,
+		NewParent1,
 	)
 	require.NoError(t, err)
 

--- a/dig/node.go
+++ b/dig/node.go
@@ -35,6 +35,10 @@ type graphNode interface {
 	dependencies() []interface{}
 
 	// unique identification per node
+	//
+	// TODO(glib): GFM-396
+	// consider using a custom type to identify objects, rather than a string
+	// type id struct { reflect.Type, string name, } or something of the sort
 	id() string
 }
 
@@ -47,6 +51,10 @@ type node struct {
 func (n node) id() string {
 	// in the future, more than just the type of node is going to be required
 	// for instance, when multiple types are allowed with different names
+	//
+	// TODO(glib): GFM-396
+	// Type.String() is not guaranteed to be unique and can return the same value
+	// for structs with the same name in a different package.
 	return n.objType.String()
 }
 

--- a/dig/node.go
+++ b/dig/node.go
@@ -47,7 +47,7 @@ type node struct {
 func (n node) id() string {
 	// in the future, more than just the type of node is going to be required
 	// for instance, when multiple types are allowed with different names
-	return n.objType.Name()
+	return n.objType.String()
 }
 
 type objNode struct {


### PR DESCRIPTION
Fixes a bug where cyclical deps were not correctly identified
due to the fact that all functions returned an empty string
for Name() method. Using String() instead solve the problem
for concrete types.

The modified test covers arbitrary order scenario where
dependencies are registered after the constructor that needs them.