### PR TITLE
Move service handler creation after FX creates dispatcher

### DIFF
--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -28,21 +28,20 @@ import (
 	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
 	"go.uber.org/fx/service"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
 )
 
-type YarpcHandler struct {
+type YARPCHandler struct {
 	sync.RWMutex
 
 	items map[string]string
 }
 
-func NewYarpcThriftHandler(_ service.Host, dispatcher *yarpc.Dispatcher) error {
-	handler := &YarpcHandler{items: map[string]string{}}
-	dispatcher.Register(kvs.New(handler))
-	return nil
+func NewYARPCThriftHandler(_ service.Host, _ *yarpc.Dispatcher) ([]transport.Procedure, error) {
+	return kvs.New(&YARPCHandler{items: map[string]string{}}), nil
 }
 
-func (h *YarpcHandler) GetValue(ctx context.Context, key *string) (string, error) {
+func (h *YARPCHandler) GetValue(ctx context.Context, key *string) (string, error) {
 	h.RLock()
 	defer h.RUnlock()
 
@@ -52,7 +51,7 @@ func (h *YarpcHandler) GetValue(ctx context.Context, key *string) (string, error
 	return "", &kv.ResourceDoesNotExist{Key: *key}
 }
 
-func (h *YarpcHandler) SetValue(ctx context.Context, key *string, value *string) error {
+func (h *YARPCHandler) SetValue(ctx context.Context, key *string, value *string) error {
 	h.Lock()
 
 	h.items[*key] = *value

--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/fx/examples/keyvalue/kv"
 	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
 	"go.uber.org/fx/service"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 )
 
@@ -37,7 +36,7 @@ type YARPCHandler struct {
 	items map[string]string
 }
 
-func NewYARPCThriftHandler(_ service.Host, _ *yarpc.Dispatcher) ([]transport.Procedure, error) {
+func NewYARPCThriftHandler(_ service.Host) ([]transport.Procedure, error) {
 	return kvs.New(&YARPCHandler{items: map[string]string{}}), nil
 }
 

--- a/examples/keyvalue/server/handlers.go
+++ b/examples/keyvalue/server/handlers.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/fx/examples/keyvalue/kv"
 	kvs "go.uber.org/fx/examples/keyvalue/kv/keyvalueserver"
 	"go.uber.org/fx/service"
-	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc"
 )
 
 type YarpcHandler struct {
@@ -36,9 +36,10 @@ type YarpcHandler struct {
 	items map[string]string
 }
 
-func NewYarpcThriftHandler(service.Host) ([]transport.Procedure, error) {
+func NewYarpcThriftHandler(_ service.Host, dispatcher *yarpc.Dispatcher) error {
 	handler := &YarpcHandler{items: map[string]string{}}
-	return kvs.New(handler), nil
+	dispatcher.Register(kvs.New(handler))
+	return nil
 }
 
 func (h *YarpcHandler) GetValue(ctx context.Context, key *string) (string, error) {

--- a/examples/keyvalue/server/main.go
+++ b/examples/keyvalue/server/main.go
@@ -32,7 +32,7 @@ func main() {
 	svc, err := service.WithModules(
 		// Create a YARPC module that exposes endpoints
 		rpc.ThriftModule(
-			rpc.CreateThriftServiceFunc(NewYarpcThriftHandler),
+			rpc.CreateThriftServiceFunc(NewYARPCThriftHandler),
 			modules.WithRoles("service"),
 		),
 	).WithOptions(

--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -25,12 +25,11 @@ import (
 	"go.uber.org/fx/service"
 
 	"github.com/pkg/errors"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 )
 
 // CreateThriftServiceFunc creates a Thrift service from a service host
-type CreateThriftServiceFunc func(svc service.Host, dispatcher *yarpc.Dispatcher) ([]transport.Procedure, error)
+type CreateThriftServiceFunc func(svc service.Host) ([]transport.Procedure, error)
 
 // ThriftModule creates a Thrift Module from a service func
 func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) service.ModuleCreateFunc {

--- a/modules/rpc/thrift.go
+++ b/modules/rpc/thrift.go
@@ -26,10 +26,11 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
 )
 
 // CreateThriftServiceFunc creates a Thrift service from a service host
-type CreateThriftServiceFunc func(svc service.Host, dispatcher *yarpc.Dispatcher) error
+type CreateThriftServiceFunc func(svc service.Host, dispatcher *yarpc.Dispatcher) ([]transport.Procedure, error)
 
 // ThriftModule creates a Thrift Module from a service func
 func ThriftModule(hookup CreateThriftServiceFunc, options ...modules.Option) service.ModuleCreateFunc {

--- a/modules/rpc/thrift_test.go
+++ b/modules/rpc/thrift_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift"
 )
 
@@ -50,10 +51,10 @@ func TestThriftModule_OK(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	testInbounds := func(_ service.Host, dispatcher *yarpc.Dispatcher) error {
+	testInbounds := func(_ service.Host, dispatcher *yarpc.Dispatcher) ([]transport.Procedure, error) {
 		require.Equal(t, 2, len(dispatcher.Inbounds()))
 		wg.Done()
-		return nil
+		return nil, nil
 	}
 
 	chip := ThriftModule(testInbounds, modules.WithRoles("rescue"))
@@ -133,15 +134,12 @@ func errorOption(_ *service.ModuleCreateInfo) error {
 	return errors.New("bad option")
 }
 
-func okCreate(_ service.Host, dispatcher *yarpc.Dispatcher) error {
-	reg := thrift.BuildProcedures(thrift.Service{
+func okCreate(_ service.Host, dispatcher *yarpc.Dispatcher) ([]transport.Procedure, error) {
+	return thrift.BuildProcedures(thrift.Service{
 		Name: "foo",
-	})
-
-	dispatcher.Register(reg)
-	return nil
+	}), nil
 }
 
-func badCreateService(service.Host, *yarpc.Dispatcher) error {
-	return errors.New("can't create service")
+func badCreateService(service.Host, *yarpc.Dispatcher) ([]transport.Procedure, error) {
+	return nil, errors.New("can't create service")
 }

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -115,8 +115,8 @@ type Address struct {
 
 type handlerWithDispatcher func(dispatcher *yarpc.Dispatcher) error
 
-// Stores a collection of all modules configs with a shared dispatcher and user handles to
-// append procedures to the dispatcher
+// Stores a collection of all module configs with a shared dispatcher
+// and user handles to work with the dispatcher.
 type dispatcherController struct {
 	// sync configs
 	sync.RWMutex
@@ -178,7 +178,7 @@ func (c *dispatcherController) addDefaultMiddleware(host service.Host, statsClie
 }
 
 // Starts the dispatcher:
-// 1. Merge all existing configs
+// 1. Add default middleware and merge all existing configs
 // 2. Create a dispatcher
 // 3. Call user handles to e.g. register transport.Procedures on the dispatcher
 // 4. Start the dispatcher
@@ -284,7 +284,7 @@ func newYARPCModule(
 		return nil, errs.Wrap(err, "can't read inbounds")
 	}
 
-	// iterate over inbounds
+	// Iterate over inbounds.
 	transportsIn, err := prepareInbounds(module.config.Inbounds, mi.Host.Name())
 	if err != nil {
 		return nil, errs.Wrap(err, "can't process inbounds")

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -308,7 +308,13 @@ func newYARPCModule(
 
 	module.controller.addConfig(module.config)
 	module.controller.appendHandler(func(dispatcher *yarpc.Dispatcher) error {
-		return reg(mi.Host, dispatcher)
+		t, err := reg(mi.Host, dispatcher)
+		if err != nil {
+			return err
+		}
+
+		dispatcher.Register(t)
+		return nil
 	})
 
 	module.log.Info("Module successfuly created", "inbounds", module.config.Inbounds)

--- a/modules/rpc/yarpc.go
+++ b/modules/rpc/yarpc.go
@@ -48,7 +48,6 @@ import (
 // register it in a dig.Graph provided with options/default graph.
 type YARPCModule struct {
 	modules.ModuleBase
-	register    registerServiceFunc
 	config      yarpcConfig
 	log         ulog.Log
 	statsClient *statsClient
@@ -184,7 +183,7 @@ func (c *dispatcherController) addDefaultMiddleware(host service.Host, statsClie
 // 4. Start the dispatcher
 //
 // Once started the controller will not start the dispatcher again.
-func (c *dispatcherController) Start(host service.Host) error {
+func (c *dispatcherController) Start(host service.Host, statsClient *statsClient) error {
 	c.start.Do(func() {
 		c.addDefaultMiddleware(host, statsClient)
 


### PR DESCRIPTION
Because we create service before the yarpc.Dispatcher it is hard for clients to get it in the constructor, they have to get it during request serving to e.g. create client.

With this change services will be able to resolve Dispatcher at construction time.