### PR TITLE
Update Makefile and change default covermode

### DIFF
--- a/.build/flags.mk
+++ b/.build/flags.mk
@@ -3,7 +3,7 @@ PKGS ?= $(shell glide novendor)
 LIST_PKGS ?= $(shell go list ./... | grep -v /vendor/)
 
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go config internal metrics modules service tracing ulog
+PKG_FILES ?= *.go auth config dig internal metrics modules service testutils tracing ulog
 
 # The linting tools evolve with each Go version, so run them only on the latest
 # stable release.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: go
 sudo: false
 go:
   - 1.7
+  - 1.8
   - tip
 
 go_import_path: go.uber.org/fx
 
 env:
   - V=1
+  - COVERMODE=atomic
 
 matrix:
   # Fail the build as soon as the first job fails
@@ -23,6 +25,7 @@ install:
 script:
   - make lint
   - make test
+  - make examples
 
 after_success:
    - '[ "${TRAVIS_GO_VERSION}" != "tip" ] && make coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ go:
 go_import_path: go.uber.org/fx
 
 env:
-  - V=1
-  - COVERMODE=atomic
+  - V=1 COVERMODE=atomic
 
 matrix:
   # Fail the build as soon as the first job fails

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,18 @@ COV_REPORT := overalls.coverprofile
 # all .go files that don't exist in hidden directories
 ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor \
 	-e ".*/\..*" \
-	-e "examples/keyvalue/.*" \
+	-e "examples/.*" \
 	-e ".*/_.*")
 
 TEST_TIMEOUT := "-timeout=10s"
 
 .PHONY: test
-test: examples $(COV_REPORT)
+test: $(COV_REPORT)
 
 TEST_IGNORES = vendor .git
 COVER_IGNORES = $(TEST_IGNORES) examples testutils
+
+COVERMODE ?= set
 
 comma := ,
 null :=
@@ -57,7 +59,7 @@ $(COV_REPORT): $(PKG_FILES) $(ALL_SRC)
 		-project=$(PROJECT_ROOT) \
 		-go-binary=richgo \
 		-ignore "$(OVERALLS_IGNORE)" \
-		-covermode=atomic \
+		-covermode=$(COVERMODE) \
 		$(DEBUG_FLAG) -- \
 		$(TEST_FLAGS) $(RACE) $(TEST_TIMEOUT) $(TEST_VERBOSITY_FLAG) | \
 		grep -v "No Go Test files" | \


### PR DESCRIPTION
This PR does a few things:

- update `PKG_FILES` in .build/flags.mk
- update .travis.yml to use go 1.8
- ignore all examples in `ALL_SRC`
- stop making `make test` depend on `make examples`

But the biggest change is changing the default covermode given to overalls. It was always being run as atomic, which was what made the tests take so long. For travis, I made it so that it still runs as atomic, but as the default for `make test`, changed it to the default value, set. Note the speedup:

```
$ time make clean test
Cleaning old profile
Running tests
| go.uber.org/fx
2017/02/23 13:00:05      | ok    go.uber.org/fx/modules/kafka  0.276s  coverage: 0.0% of statements [no tests to run]
2017/02/23 13:00:07 PASS | go.uber.org/fx/dig 0.099s
2017/02/23 13:00:07 COVER| 86.0% [########__]
2017/02/23 13:00:07 PASS | go.uber.org/fx/metrics 0.084s
2017/02/23 13:00:07 COVER| 90.3% [#########_]
2017/02/23 13:00:08 PASS | go.uber.org/fx/ulog/metrics 0.251s
2017/02/23 13:00:08 COVER| 100.0% [##########]
2017/02/23 13:00:08 PASS | go.uber.org/fx/config 0.228s
2017/02/23 13:00:08 COVER| 92.6% [#########_]
2017/02/23 13:00:08 PASS | go.uber.org/fx/ulog/sentry 0.180s
2017/02/23 13:00:08 COVER| 100.0% [##########]
2017/02/23 13:00:08 PASS | go.uber.org/fx/auth 0.261s
2017/02/23 13:00:08 COVER| 100.0% [##########]
2017/02/23 13:00:09 PASS | go.uber.org/fx/modules/uhttp/client 0.121s
2017/02/23 13:00:09 COVER| 100.0% [##########]
2017/02/23 13:00:09 PASS | go.uber.org/fx/modules 0.187s
2017/02/23 13:00:09 COVER| 100.0% [##########]
2017/02/23 13:00:09 PASS | go.uber.org/fx/tracing 0.140s
2017/02/23 13:00:09 COVER| 85.7% [########__]
2017/02/23 13:00:09 PASS | go.uber.org/fx/modules/task 0.174s
2017/02/23 13:00:09 COVER| 99.3% [#########_]
2017/02/23 13:00:09 PASS | go.uber.org/fx/modules/uhttp 0.222s
2017/02/23 13:00:09 COVER| 94.7% [#########_]
2017/02/23 13:00:09 PASS | go.uber.org/fx/ulog 0.352s
2017/02/23 13:00:09 COVER| 94.4% [#########_]
2017/02/23 13:00:09 PASS | go.uber.org/fx/service 0.336s
2017/02/23 13:00:09 COVER| 88.3% [########__]
2017/02/23 13:00:09 PASS | go.uber.org/fx/modules/rpc 0.183s
2017/02/23 13:00:09 COVER| 94.9% [#########_]
Generating coverage report

real	0m5.437s
user	0m18.839s
sys	0m15.710s
```