### PR TITLE
Change service.Option to use the manager struct

### DIFF
--- a/service/options.go
+++ b/service/options.go
@@ -27,44 +27,39 @@ import (
 	"github.com/uber-go/tally"
 )
 
-// A Option configures a service host
-type Option func(Host) error
+// A Option configures a manager
+type Option func(*manager) error
 
-// WithConfiguration adds configuration to a service host
+// WithConfiguration adds configuration to a manager
 func WithConfiguration(config config.Provider) Option {
-	return func(svc Host) error {
-		// TODO(ai) verify type assertion is correct
-		svc2 := svc.(*manager)
-		svc2.configProvider = config
+	return func(m *manager) error {
+		m.configProvider = config
 		return nil
 	}
 }
 
-// WithMetrics configures a service host with metrics and stats reporter
+// WithMetrics configures a manager with metrics and stats reporter
 func WithMetrics(scope tally.Scope, reporter tally.CachedStatsReporter) Option {
-	return func(svc Host) error {
-		svc2 := svc.(*manager)
-		svc2.metrics = scope
-		svc2.statsReporter = reporter
+	return func(m *manager) error {
+		m.metrics = scope
+		m.statsReporter = reporter
 		return nil
 	}
 }
 
-// WithTracer configures a service host with a tracer
+// WithTracer configures a manager with a tracer
 func WithTracer(tracer opentracing.Tracer) Option {
-	return func(svc Host) error {
-		svc2 := svc.(*manager)
-		svc2.tracer = tracer
+	return func(m *manager) error {
+		m.tracer = tracer
 		return nil
 	}
 }
 
-// WithObserver configures a service with an instance lifecycle observer
+// WithObserver configures a manager with an instance lifecycle observer
 func WithObserver(observer Observer) Option {
-	return func(svc Host) error {
-		service := svc.(*manager)
-		service.observer = observer
-		service.serviceCore.observer = observer
+	return func(m *manager) error {
+		m.observer = observer
+		m.serviceCore.observer = observer
 		return nil
 	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -117,7 +117,7 @@ logging:
 }
 
 func TestBadOption_Panics(t *testing.T) {
-	opt := func(_ Host) error {
+	opt := func(_ *manager) error {
 		return errors.New("nope")
 	}
 


### PR DESCRIPTION
This is generally how i've seen options done - the package that exposes them defines them in terms of a private struct. Unless Host is editable, an option on the Host interface doesn't make sense, and there was just casting happening here anyways. I think it would be best to limit Options to be either defined in the service package, or defined in terms of options in the service package.