### PR TITLE
Upgrade to new jaeger and use hex for trace and span ids

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: 2b2a3032c1ba22a3650890ee852545a11f4113801497cb33adde98a36f0f9cea
-updated: 2017-02-23T16:04:45.370717001-08:00
+hash: f5c7c493baa0a29039c147f7244c37d573f95eee31ee448577a64024dabd6770
+updated: 2017-02-23T17:37:32.832575-08:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
   subpackages:
   - lib/go/thrift
+- name: github.com/codahale/hdrhistogram
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
@@ -44,16 +46,23 @@ imports:
 - name: github.com/uber-go/tally
   version: 43c1379c0577ac1eb74f9f3869cea07191c9992b
 - name: github.com/uber/jaeger-client-go
-  version: e39d0f1b622558cae3d9db0062a739cc6ffa700f
+  version: a1c7be77e82c1ccd832ace5c4c04b25700d90b1f
   subpackages:
   - config
   - internal/spanlog
+  - log
+  - log/zap
   - thrift-gen/agent
   - thrift-gen/sampling
   - thrift-gen/zipkincore
   - transport
   - transport/udp
   - utils
+- name: github.com/uber/jaeger-lib
+  version: b9556711760c45a30bd79c31c8f041d0d9aba997
+  subpackages:
+  - metrics
+  - metrics/tally
 - name: github.com/uber/tchannel-go
   version: 79387824978f91318be3bfb43ae12e04c38cfe97
   subpackages:
@@ -149,7 +158,7 @@ testImports:
 - name: github.com/mattn/goveralls
   version: 8482d0ebd2a64f95ce02d2b9b7065b0d6fe9151b
 - name: github.com/mvdan/interfacer
-  version: 588bd9940e912b1b2760d41bd836ef28ff97164d
+  version: e2f2db5bb7b0f89a41d2e1d905ff7b78fc09c88d
   subpackages:
   - cmd/interfacer
 - name: github.com/pborman/uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: github.com/gorilla/context
   version: ^1.1.0
 - package: go.uber.org/yarpc
-  version: ^v1.0.0
+  version: ^v1.4.0
 - package: go.uber.org/thriftrw
   version: ^1
 - package: github.com/go-validator/validator
@@ -19,7 +19,7 @@ import:
 - package: github.com/getsentry/raven-go
   version: master
 - package: github.com/uber/jaeger-client-go
-  version: ^1.6.0
+  version: ^2.1.0
 - package: github.com/stretchr/testify
   subpackages:
   - assert

--- a/modules/uhttp/client/client_middleware_benchmark_test.go
+++ b/modules/uhttp/client/client_middleware_benchmark_test.go
@@ -26,10 +26,10 @@ import (
 	"testing"
 
 	"go.uber.org/fx/auth"
-	"go.uber.org/fx/metrics"
 	"go.uber.org/fx/tracing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/uber-go/tally"
 	jconfig "github.com/uber/jaeger-client-go/config"
 	"go.uber.org/zap"
 )
@@ -39,7 +39,9 @@ import (
 // BenchmarkClientMiddleware/auth-8            1000000          1866 ns/op         719 B/op         14 allocs/op
 // BenchmarkClientMiddleware/default-8          300000          5604 ns/op        2477 B/op         41 allocs/op
 func BenchmarkClientMiddleware(b *testing.B) {
-	tracer, closer, err := tracing.InitGlobalTracer(&jconfig.Configuration{}, "Test", zap.NewNop(), metrics.NopCachedStatsReporter)
+	tracer, closer, err := tracing.InitGlobalTracer(
+		&jconfig.Configuration{}, "Test", zap.NewNop(), tally.NoopScope,
+	)
 	if err != nil {
 		b.Error(err)
 	}

--- a/modules/uhttp/middleware_test.go
+++ b/modules/uhttp/middleware_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/fx/metrics"
 	"go.uber.org/fx/service"
 	"go.uber.org/fx/testutils"
 	"go.uber.org/fx/tracing"
@@ -136,7 +135,7 @@ func testTracingInboundWithLogs(t *testing.T) {
 			Reporter: &config.ReporterConfig{LogSpans: true},
 		}
 		tracer, closer, err := tracing.InitGlobalTracer(
-			jConfig, "serviceName", loggerWithZap, metrics.NopCachedStatsReporter,
+			jConfig, "serviceName", loggerWithZap, tally.NoopScope,
 		)
 		assert.NoError(t, err)
 		defer closer.Close()

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -97,7 +97,7 @@ func (svc *serviceCore) setupTracer() error {
 		&svc.tracerConfig,
 		svc.standardConfig.Name,
 		zap.L(),
-		svc.statsReporter,
+		svc.metrics,
 	)
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize global tracer")

--- a/testutils/tracing/tracer.go
+++ b/testutils/tracing/tracer.go
@@ -23,19 +23,17 @@ package tracing
 import (
 	"testing"
 
-	"go.uber.org/fx/metrics"
 	"go.uber.org/fx/tracing"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
 // WithSpan is used for generating a span to be used in testing
 func WithSpan(t *testing.T, log *zap.Logger, f func(opentracing.Span)) {
-	tracer, closer, err := tracing.CreateTracer(
-		nil, "serviceName", log, metrics.NopCachedStatsReporter,
-	)
+	tracer, closer, err := tracing.CreateTracer(nil, "serviceName", log, tally.NoopScope)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, closer.Close())

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -16,9 +16,9 @@ package main
 import (
   "go.uber.org/fx/tracing"
 
-	"github.com/uber-go/tally"
+  "github.com/uber-go/tally"
   "github.com/uber/jaeger-client-go/config"
-	"go.uber.org/zap"
+  "go.uber.org/zap"
 )
 
 func main() {

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -15,19 +15,18 @@ package main
 
 import (
   "go.uber.org/fx/tracing"
-  "go.uber.org/fx/ulog"
 
+	"github.com/uber-go/tally"
   "github.com/uber/jaeger-client-go/config"
+	"go.uber.org/zap"
 )
 
 func main() {
-  logger := ulog.Logger()
-  statsReporter := // initialize stats reporter
   tracer, closer, err := tracing.InitGlobalTracer(
     &config.Configuration{},
     "service-name",
-    logger,
-    statsReporter,
+    zap.L(),
+    tally.NoopScope,
   )
   if err != nil {
     logger.Fatal("Error initializing tracer", "error", err)

--- a/tracing/doc.go
+++ b/tracing/doc.go
@@ -37,9 +37,9 @@
 //   import (
 //     "go.uber.org/fx/tracing"
 //
-//   	"github.com/uber-go/tally"
+//     "github.com/uber-go/tally"
 //     "github.com/uber/jaeger-client-go/config"
-//   	"go.uber.org/zap"
+//     "go.uber.org/zap"
 //   )
 //
 //   func main() {

--- a/tracing/doc.go
+++ b/tracing/doc.go
@@ -36,19 +36,18 @@
 //
 //   import (
 //     "go.uber.org/fx/tracing"
-//     "go.uber.org/fx/ulog"
 //
+//   	"github.com/uber-go/tally"
 //     "github.com/uber/jaeger-client-go/config"
+//   	"go.uber.org/zap"
 //   )
 //
 //   func main() {
-//     logger := ulog.Logger()
-//     statsReporter := // initialize stats reporter
 //     tracer, closer, err := tracing.InitGlobalTracer(
 //       &config.Configuration{},
 //       "service-name",
-//       logger,
-//       statsReporter,
+//       zap.L(),
+//       tally.NoopScope,
 //     )
 //     if err != nil {
 //       logger.Fatal("Error initializing tracer", "error", err)

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -55,9 +55,9 @@ func CreateTracer(
 	if cfg == nil || !cfg.Disabled {
 		cfg = loadAppConfig(cfg)
 	}
-	jMetrics := jtally.Wrap(scope)
-	jLogger := jzap.NewLogger(logger)
-	return cfg.New(serviceName, config.Metrics(jMetrics), config.Logger(jLogger))
+	jaegerMetrics := jtally.Wrap(scope)
+	jaegerLogger := jzap.NewLogger(logger)
+	return cfg.New(serviceName, config.Metrics(jaegerMetrics), config.Logger(jaegerLogger))
 }
 
 func loadAppConfig(cfg *config.Configuration) *config.Configuration {

--- a/ulog/context.go
+++ b/ulog/context.go
@@ -74,8 +74,7 @@ func (t trace) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	if !j.IsValid() {
 		return fmt.Errorf("invalid span: %v", j.SpanID())
 	}
-	enc.AddUint64("span", j.SpanID())
-	enc.AddUint64("trace", j.TraceID())
-	enc.AddUint64("parent", j.ParentID())
+	enc.AddString("span", j.SpanID().String())
+	enc.AddString("trace", j.TraceID().String())
 	return nil
 }

--- a/ulog/context_test.go
+++ b/ulog/context_test.go
@@ -53,7 +53,7 @@ func TestLogger(t *testing.T) {
 			for _, line := range output {
 				assert.Regexp(
 					t,
-					`{"level":"info","msg":"","trace":{"span":\d+,"trace":\d+,"parent":\d+}}`,
+					`{"level":"info","msg":"","trace":{"span":\"[a-zA-Z0-9]+\","trace":\"[a-zA-Z0-9]+\"}}`,
 					line,
 					"Expected output to contain tracing info.",
 				)
@@ -80,7 +80,7 @@ func TestTraceField(t *testing.T) {
 		// but that just copies the production code.
 		assert.Equal(
 			t,
-			map[string]struct{}{"span": {}, "trace": {}, "parent": {}},
+			map[string]struct{}{"span": {}, "trace": {}},
 			keys,
 			"Expected to log span and trace IDs.",
 		)


### PR DESCRIPTION
We log trace and span ids as integers, we want to log them as hex to match the jaeger UI.