### PR TITLE
Remove unused config.IsDevelopmentEnv func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## v1.0.0-beta2 (unreleased)
 
-* [Breaking] Remove `ulog` and expose `*zap.Logger` directly.
+* [Breaking] Remove `ulog.Logger` interface and expose `*zap.Logger` directly.
 * [Breaking] Upgrade `zap` to `v1.0.0-rc.2` (now go.uber.org/zap, was
     github.com/uber-go/zap)
+* Remove now-unused `config.IsDevelopmentEnv()` helper to encourage better
+  testing practices. Not a breaking change as nobody is using this func
+  themselves according to our code search tool.
 
 ## v1.0.0-beta1 (20 Feb 2017)
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 )
 
@@ -138,12 +137,6 @@ func Environment() string {
 		env = _devEnv
 	}
 	return env
-}
-
-// IsDevelopmentEnv returns true if the current environment is set to development
-// TODO(glib): Remove usage of this function
-func IsDevelopmentEnv() bool {
-	return strings.Contains(Environment(), _devEnv)
 }
 
 // Path returns path to the yaml configurations


### PR DESCRIPTION
We recognized early on that this was an anti-pattern, and with Akshay's
log refactor we no longer have any references to it.

This is not a breaking change because nobody is using this according to
our internal code search tool.