### PR TITLE
[Do not merge]Consume latest tally

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -10,7 +10,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -35,7 +35,7 @@ imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
@@ -46,7 +46,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 43c1379c0577ac1eb74f9f3869cea07191c9992b
+  version: 34be4a565ce6286a0ba91a54a81be3f6181ca2e2
 - name: github.com/uber/jaeger-client-go
   version: a1c7be77e82c1ccd832ace5c4c04b25700d90b1f
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/zap
   version: v1.0.0-rc.2
 - package: github.com/uber-go/tally
-  version: ^1.1.0
+  version: ^2.1.0
 - package: github.com/gorilla/mux
   version: ^1.1.0
 - package: github.com/gorilla/context

--- a/metrics/nop_reporter.go
+++ b/metrics/nop_reporter.go
@@ -46,13 +46,13 @@ func (c *capabilities) Tagging() bool {
 	return c.tagging
 }
 
-// NopCachedStatsReporter is an implementatin of tally.CachedStatsReporter than simply does nothing.
+// NopCachedStatsReporter is an implementation of tally.CachedStatsReporter that simply does nothing
+// and should be used for testing purposes only.
 // TODO:(anup) This should exist in tally. https://github.com/uber-go/tally/issues/23
-// Remove and replace metrics.NopCachedStatsReporter with tally.NopCachedStatsRepor once issue is resolved
+// Remove and replace metrics.NopCachedStatsReporter with tally.NopCachedStatsReporter once issue is resolved
 var NopCachedStatsReporter tally.CachedStatsReporter = nopCachedStatsReporter{}
 
-type nopCachedStatsReporter struct {
-}
+type nopCachedStatsReporter struct{}
 
 func (nopCachedStatsReporter) AllocateCounter(name string, tags map[string]string) tally.CachedCount {
 	return NopCachedCount
@@ -74,10 +74,10 @@ func (r nopCachedStatsReporter) Capabilities() tally.Capabilities {
 	return capabilitiesReportingNoTagging
 }
 
-func (r nopCachedStatsReporter) Flush() {
-}
+func (r nopCachedStatsReporter) Flush() {}
 
-// NopCachedCount is an implementation of tally.CachedCount
+// NopCachedCount is an implementation of tally.CachedCount and same as other Nop types don't do anything and
+// should be used for testing purposes only.
 var NopCachedCount tally.CachedCount = nopCachedCount{}
 
 type nopCachedCount struct {
@@ -86,47 +86,45 @@ type nopCachedCount struct {
 func (nopCachedCount) ReportCount(value int64) {
 }
 
-// NopCachedGauge is an implementation of tally.CachedGauge
+// NopCachedGauge is an implementation of tally.CachedGauge and same as other Nop types don't do anything and
+// should be used for testing purposes only.
 var NopCachedGauge tally.CachedGauge = nopCachedGauge{}
 
-type nopCachedGauge struct {
-}
+type nopCachedGauge struct{}
 
-func (nopCachedGauge) ReportGauge(value float64) {
-}
+func (nopCachedGauge) ReportGauge(value float64) {}
 
 // NopCachedTimer is an implementation of tally.CachedTimer
 var NopCachedTimer tally.CachedTimer = nopCachedTimer{}
 
-type nopCachedTimer struct {
-}
+type nopCachedTimer struct{}
 
-func (nopCachedTimer) ReportTimer(interval time.Duration) {
-}
+func (nopCachedTimer) ReportTimer(interval time.Duration) {}
 
-// NopCachedHistogram is an implementation of tally.CachedHistogram
+// NopCachedHistogram is an implementation of tally.CachedHistogram and same as other Nop types don't do anything and
+// should be used for testing purposes only.
 var NopCachedHistogram tally.CachedHistogram = nopCachedHistogram{}
 
-type nopCachedHistogram struct {
-}
+type nopCachedHistogram struct{}
 
 func (nopCachedHistogram) ValueBucket(
-	bucketLowerBound, bucketUpperBound float64,
+	bucketLowerBound float64,
+	bucketUpperBound float64,
 ) tally.CachedHistogramBucket {
 	return nopCachedHistogramBucket{}
 }
 
 func (nopCachedHistogram) DurationBucket(
-	bucketLowerBound, bucketUpperBound time.Duration,
+	bucketLowerBound time.Duration,
+	bucketUpperBound time.Duration,
 ) tally.CachedHistogramBucket {
 	return nopCachedHistogramBucket{}
 }
 
-// NopCachedHistogramBucket is an implementation of tally.CachedHistogramBucket
+// NopCachedHistogramBucket is an implementation of tally.CachedHistogramBucket and same as other Nop types
+// don't do anything and should be used for testing purposes only.
 var NopCachedHistogramBucket tally.CachedHistogramBucket = nopCachedHistogramBucket{}
 
-type nopCachedHistogramBucket struct {
-}
+type nopCachedHistogramBucket struct{}
 
-func (nopCachedHistogramBucket) ReportSamples(value int64) {
-}
+func (nopCachedHistogramBucket) ReportSamples(value int64) {}

--- a/metrics/nop_reporter.go
+++ b/metrics/nop_reporter.go
@@ -62,6 +62,10 @@ func (nopCachedStatsReporter) AllocateGauge(name string, tags map[string]string)
 	return NopCachedGauge
 }
 
+func (nopCachedStatsReporter) AllocateHistogram(name string, tags map[string]string, buckets tally.Buckets) tally.CachedHistogram {
+	return NopCachedHistogram
+}
+
 func (nopCachedStatsReporter) AllocateTimer(name string, tags map[string]string) tally.CachedTimer {
 	return NopCachedTimer
 }
@@ -98,4 +102,32 @@ type nopCachedTimer struct {
 }
 
 func (nopCachedTimer) ReportTimer(interval time.Duration) {
+}
+
+// NopCachedHistogram is an implementation of tally.CachedHistogram
+var NopCachedHistogram tally.CachedHistogram = nopCachedHistogram{}
+
+type nopCachedHistogram struct {
+}
+
+func (nopCachedHistogram) ValueBucket(
+	bucketLowerBound, bucketUpperBound float64,
+) tally.CachedHistogramBucket {
+	return nopCachedHistogramBucket{}
+}
+
+func (nopCachedHistogram) DurationBucket(
+	bucketLowerBound, bucketUpperBound time.Duration,
+) tally.CachedHistogramBucket {
+	return nopCachedHistogramBucket{}
+}
+
+// NopCachedHistogramBucket is an implementation of tally.CachedHistogramBucket
+var NopCachedHistogramBucket tally.CachedHistogramBucket = nopCachedHistogramBucket{}
+
+type nopCachedHistogramBucket struct {
+}
+
+func (nopCachedHistogramBucket) ReportSamples(value int64) {
+
 }

--- a/metrics/nop_reporter.go
+++ b/metrics/nop_reporter.go
@@ -129,5 +129,4 @@ type nopCachedHistogramBucket struct {
 }
 
 func (nopCachedHistogramBucket) ReportSamples(value int64) {
-
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -28,24 +28,17 @@ import (
 
 	"go.uber.org/fx/config"
 	"go.uber.org/fx/testutils/metrics"
-	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 func TestServiceCreation(t *testing.T) {
 	r := metrics.NewTestStatsReporter()
 	r.CountersWG.Add(1)
-	opts := tally.ScopeOptions{
-		Tags:           nil,
-		Prefix:         "",
-		Reporter:       r,
-		CachedReporter: nil,
-		Separator:      tally.DefaultSeparator,
-		DefaultBuckets: tally.DefaultBuckets,
-	}
+	opts := tally.ScopeOptions{Reporter: r}
 
 	scope, closer := tally.NewRootScope(opts, 50*time.Millisecond)
 	defer closer.Close()

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -38,7 +38,16 @@ import (
 func TestServiceCreation(t *testing.T) {
 	r := metrics.NewTestStatsReporter()
 	r.CountersWG.Add(1)
-	scope, closer := tally.NewRootScope("", nil, r, 50*time.Millisecond, tally.DefaultSeparator)
+	opts := tally.ScopeOptions{
+		Tags:           nil,
+		Prefix:         "",
+		Reporter:       r,
+		CachedReporter: nil,
+		Separator:      tally.DefaultSeparator,
+		DefaultBuckets: tally.DefaultBuckets,
+	}
+
+	scope, closer := tally.NewRootScope(opts, 50*time.Millisecond)
 	defer closer.Close()
 	svc, err := newManager(
 		WithModule(nopModuleProvider).

--- a/testutils/metrics/metrics.go
+++ b/testutils/metrics/metrics.go
@@ -114,14 +114,7 @@ func NewTestStatsReporter() *TestStatsReporter {
 // NewTestScope returns a pair of scope and reporter that can be used for testing
 func NewTestScope() (tally.Scope, *TestStatsReporter) {
 	r := NewTestStatsReporter()
-	opts := tally.ScopeOptions{
-		Tags:           nil,
-		Prefix:         "",
-		Reporter:       r,
-		CachedReporter: nil,
-		Separator:      tally.DefaultSeparator,
-		DefaultBuckets: tally.DefaultBuckets,
-	}
+	opts := tally.ScopeOptions{Reporter: r}
 
 	scope, _ := tally.NewRootScope(opts, 100*time.Millisecond)
 	return scope, r


### PR DESCRIPTION
Tally introduced histograms to their interfaces and changed constructor for a scope, which requires us to implement it for NopReported and update some tests.

Will not merge, until migrate internal tools to the new tally version.