### PR TITLE
Refactor PopulateStruct

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -181,13 +181,13 @@ Note that any fields you wish to deserialize into must be exported, just like
 Current performance benchmark data:
 
 ```
-BenchmarkYAMLCreateSingleFile-8                       50000     31269 ns/op   11136 B/op     121 allocs/op
-BenchmarkYAMLCreateMultiFile-8                        30000     52378 ns/op   20064 B/op     205 allocs/op
-BenchmarkYAMLSimpleGetLevel1-8                     50000000      27.1 ns/op       0 B/op       0 allocs/op
-BenchmarkYAMLSimpleGetLevel3-8                     50000000      26.8 ns/op       0 B/op       0 allocs/op
-BenchmarkYAMLSimpleGetLevel7-8                     50000000      26.3 ns/op       0 B/op       0 allocs/op
-BenchmarkYAMLPopulateStruct-8                       2000000       861 ns/op     192 B/op      10 allocs/op
-BenchmarkYAMLPopulateStructNested-8                  500000      2616 ns/op     616 B/op      34 allocs/op
-BenchmarkYAMLPopulateStructNestedMultipleFiles-8     500000      3330 ns/op     744 B/op      42 allocs/op
-BenchmarkYAMLPopulateNestedTextUnmarshaler-8         100000     16775 ns/op    3201 B/op     209 allocs/op
+BenchmarkYAMLCreateSingleFile-8                    	   50000	     31345 ns/op	   11144 B/op	     122 allocs/op
+BenchmarkYAMLCreateMultiFile-8                     	   30000	     51927 ns/op	   20080 B/op	     207 allocs/op
+BenchmarkYAMLSimpleGetLevel1-8                     	50000000	        26.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkYAMLSimpleGetLevel3-8                     	50000000	        27.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkYAMLSimpleGetLevel7-8                     	50000000	        26.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkYAMLPopulateStruct-8                      	 1000000	      1598 ns/op	     576 B/op	      16 allocs/op
+BenchmarkYAMLPopulateStructNested-8                	  300000	      3972 ns/op	    1056 B/op	      42 allocs/op
+BenchmarkYAMLPopulateStructNestedMultipleFiles-8   	  300000	      5013 ns/op	    1248 B/op	      52 allocs/op
+BenchmarkYAMLPopulateNestedTextUnmarshaler-8       	  100000	     18209 ns/op	    3368 B/op	     211 allocs/op
 ```

--- a/config/doc.go
+++ b/config/doc.go
@@ -196,15 +196,15 @@
 //
 // Current performance benchmark data:
 //
-//   BenchmarkYAMLCreateSingleFile-8                       50000     31269 ns/op   11136 B/op     121 allocs/op
-//   BenchmarkYAMLCreateMultiFile-8                        30000     52378 ns/op   20064 B/op     205 allocs/op
-//   BenchmarkYAMLSimpleGetLevel1-8                     50000000      27.1 ns/op       0 B/op       0 allocs/op
-//   BenchmarkYAMLSimpleGetLevel3-8                     50000000      26.8 ns/op       0 B/op       0 allocs/op
-//   BenchmarkYAMLSimpleGetLevel7-8                     50000000      26.3 ns/op       0 B/op       0 allocs/op
-//   BenchmarkYAMLPopulateStruct-8                       2000000       861 ns/op     192 B/op      10 allocs/op
-//   BenchmarkYAMLPopulateStructNested-8                  500000      2616 ns/op     616 B/op      34 allocs/op
-//   BenchmarkYAMLPopulateStructNestedMultipleFiles-8     500000      3330 ns/op     744 B/op      42 allocs/op
-//   BenchmarkYAMLPopulateNestedTextUnmarshaler-8         100000     16775 ns/op    3201 B/op     209 allocs/op
+//   BenchmarkYAMLCreateSingleFile-8                    	   50000	     31345 ns/op	   11144 B/op	     122 allocs/op
+//   BenchmarkYAMLCreateMultiFile-8                     	   30000	     51927 ns/op	   20080 B/op	     207 allocs/op
+//   BenchmarkYAMLSimpleGetLevel1-8                     	50000000	        26.8 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkYAMLSimpleGetLevel3-8                     	50000000	        27.3 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkYAMLSimpleGetLevel7-8                     	50000000	        26.2 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkYAMLPopulateStruct-8                      	 1000000	      1598 ns/op	     576 B/op	      16 allocs/op
+//   BenchmarkYAMLPopulateStructNested-8                	  300000	      3972 ns/op	    1056 B/op	      42 allocs/op
+//   BenchmarkYAMLPopulateStructNestedMultipleFiles-8   	  300000	      5013 ns/op	    1248 B/op	      52 allocs/op
+//   BenchmarkYAMLPopulateNestedTextUnmarshaler-8       	  100000	     18209 ns/op	    3368 B/op	     211 allocs/op
 //
 //
 package config

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStaticProvider_Name(t *testing.T) {
@@ -98,7 +99,7 @@ func TestNilStaticProviderSetDefaultTagValue(t *testing.T) {
 	}{}
 
 	p := NewStaticProvider(nil)
-	p.Get("hello").PopulateStruct(&data)
+	require.NoError(t, p.Get("hello").PopulateStruct(&data))
 
 	assert.Equal(t, 10, data.ID0)
 	assert.Equal(t, "string", data.ID1)

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -93,7 +93,7 @@ func TestNilStaticProviderSetDefaultTagValue(t *testing.T) {
 		ID3 []Inner         `yaml:"id3"`
 		ID4 map[Inner]Inner `yaml:"id4"`
 		ID5 *Inner          `yaml:"id5"`
-		//ID6 [6]Inner        `yaml:"id6"`
+		ID6 [6]Inner        `yaml:"id6"`
 		ID7 [7]*Inner `yaml:"id7"`
 	}{}
 
@@ -106,7 +106,6 @@ func TestNilStaticProviderSetDefaultTagValue(t *testing.T) {
 	assert.Nil(t, data.ID3)
 	assert.Nil(t, data.ID4)
 	assert.Nil(t, data.ID5)
-	// TODO (yutong) uncomment following assert after DRI-12.
-	// assert.True(t, data.ID6[0].Set)
+	assert.True(t, data.ID6[0].Set)
 	assert.Nil(t, data.ID7[0])
 }

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -94,7 +94,7 @@ func TestNilStaticProviderSetDefaultTagValue(t *testing.T) {
 		ID4 map[Inner]Inner `yaml:"id4"`
 		ID5 *Inner          `yaml:"id5"`
 		ID6 [6]Inner        `yaml:"id6"`
-		ID7 [7]*Inner `yaml:"id7"`
+		ID7 [7]*Inner       `yaml:"id7"`
 	}{}
 
 	p := NewStaticProvider(nil)

--- a/config/value.go
+++ b/config/value.go
@@ -130,7 +130,6 @@ func (cv Value) Source() string {
 	if cv.provider == nil {
 		return ""
 	}
-
 	return cv.provider.Name()
 }
 
@@ -139,7 +138,6 @@ func (cv Value) LastUpdated() time.Time {
 	if !cv.HasValue() {
 		return time.Time{} // zero value if never updated?
 	}
-
 	return cv.Timestamp
 }
 
@@ -175,10 +173,9 @@ func (cv Value) String() string {
 // TryAsString attempts to return the configuration value as a string
 func (cv Value) TryAsString() (string, bool) {
 	v := cv.Value()
-	if val, err := convertValue(v, _typeOfString); v != nil && err == nil {
+	if val, err := convertValue(v, reflect.TypeOf("")); v != nil && err == nil {
 		return val.(string), true
 	}
-
 	return "", false
 }
 
@@ -208,7 +205,6 @@ func (cv Value) TryAsBool() (bool, bool) {
 	if val, err := convertValue(v, reflect.TypeOf(true)); v != nil && err == nil {
 		return val.(bool), true
 	}
-
 	return false, false
 
 }
@@ -219,7 +215,6 @@ func (cv Value) TryAsFloat() (float64, bool) {
 	if val, err := convertValue(v, reflect.TypeOf(_float64Zero)); v != nil && err == nil {
 		return val.(float64), true
 	}
-
 	switch val := v.(type) {
 	case int:
 		return float64(val), true
@@ -237,41 +232,41 @@ func (cv Value) TryAsFloat() (float64, bool) {
 // AsString returns the configuration value as a string, or panics if not
 // string-able
 func (cv Value) AsString() string {
-	if s, ok := cv.TryAsString(); ok {
-		return s
+	s, ok := cv.TryAsString()
+	if !ok {
+		panic(fmt.Sprintf("Can't convert to string: %v", cv.Value()))
 	}
-
-	panic(fmt.Sprintf("Can't convert to string: %v", cv.Value()))
+	return s
 }
 
 // AsInt returns the configuration value as an int, or panics if not
 // int-able
 func (cv Value) AsInt() int {
-	if s, ok := cv.TryAsInt(); ok {
-		return s
+	s, ok := cv.TryAsInt()
+	if !ok {
+		panic(fmt.Sprintf("Can't convert to int: %T %v", cv.Value(), cv.Value()))
 	}
-
-	panic(fmt.Sprintf("Can't convert to int: %T %v", cv.Value(), cv.Value()))
+	return s
 }
 
 // AsFloat returns the configuration value as an float64, or panics if not
 // float64-able
 func (cv Value) AsFloat() float64 {
-	if s, ok := cv.TryAsFloat(); ok {
-		return s
+	s, ok := cv.TryAsFloat()
+	if !ok {
+		panic(fmt.Sprintf("Can't convert to float64: %v", cv.Value()))
 	}
-
-	panic(fmt.Sprintf("Can't convert to float64: %v", cv.Value()))
+	return s
 }
 
 // AsBool returns the configuration value as an bool, or panics if not
 // bool-able
 func (cv Value) AsBool() bool {
-	if s, ok := cv.TryAsBool(); ok {
-		return s
+	s, ok := cv.TryAsBool()
+	if !ok {
+		panic(fmt.Sprintf("Can't convert to bool: %v", cv.Value()))
 	}
-
-	panic(fmt.Sprintf("Can't convert to bool: %v", cv.Value()))
+	return s
 }
 
 // IsDefault returns whether the return value is the default.
@@ -291,7 +286,6 @@ func (cv Value) Value() interface{} {
 	if cv.found {
 		return cv.value
 	}
-
 	return cv.defaultValue
 }
 

--- a/config/value.go
+++ b/config/value.go
@@ -412,7 +412,7 @@ type decoder struct {
 	m map[interface{}]struct{}
 }
 
-func (d decoder) getGlobalProvider() Provider {
+func (d *decoder) getGlobalProvider() Provider {
 	if d.root == nil {
 		return d.provider
 	}

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -264,8 +264,9 @@ func (n *yamlNode) Children() []*yamlNode {
 			for k, v := range n.value.(map[interface{}]interface{}) {
 				n2 := &yamlNode{
 					nodeType: getNodeType(v),
-					key:      fmt.Sprintf("%s", k),
-					value:    v,
+					// We need to use a default format, because key may be not a string.
+					key:   fmt.Sprintf("%v", k),
+					value: v,
 				}
 
 				n.children = append(n.children, n2)

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -580,3 +580,19 @@ func TestLoops(t *testing.T) {
 	p := testProvider{}
 	assert.Contains(t, p.Get(Root).PopulateStruct(&b).Error(), "cycles")
 }
+
+
+func TestInternalFieldsAreNotSet(t *testing.T) {
+	t.Parallel()
+	type External struct {
+		internal string
+	}
+
+	b := []byte(`
+internal: set
+`)
+	p := NewYAMLProviderFromBytes(b)
+	var r External
+	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	assert.Equal(t, "", r.internal)
+}

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 var yamlConfig1 = []byte(`
@@ -46,6 +47,7 @@ modules:
 `)
 
 func TestYamlSimple(t *testing.T) {
+	t.Parallel()
 	provider := NewYAMLProviderFromBytes(yamlConfig1)
 
 	c := provider.Get("modules.rpc.bind")
@@ -62,6 +64,7 @@ type configStruct struct {
 }
 
 func TestYamlStructRoot(t *testing.T) {
+	t.Parallel()
 	provider := NewYAMLProviderFromBytes(yamlConfig1)
 
 	cs := &configStruct{}
@@ -77,6 +80,8 @@ type rpcStruct struct {
 }
 
 func TestYamlStructChild(t *testing.T) {
+	t.Parallel()
+
 	provider := NewYAMLProviderFromBytes(yamlConfig1)
 
 	cs := &rpcStruct{}
@@ -87,6 +92,7 @@ func TestYamlStructChild(t *testing.T) {
 }
 
 func TestExtends(t *testing.T) {
+	t.Parallel()
 	provider := NewYAMLProviderFromFiles(false, NewRelativeResolver("./testdata"), "base.yaml", "dev.yaml", "secrets.yaml")
 
 	baseValue := provider.Get("value").AsString()
@@ -100,6 +106,7 @@ func TestExtends(t *testing.T) {
 }
 
 func TestAppRoot(t *testing.T) {
+	t.Parallel()
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
@@ -117,6 +124,7 @@ func TestAppRoot(t *testing.T) {
 }
 
 func TestNewYAMLProviderFromReader(t *testing.T) {
+	t.Parallel()
 	buff := bytes.NewBuffer([]byte(yamlConfig1))
 	provider := NewYAMLProviderFromReader(ioutil.NopCloser(buff))
 	cs := &configStruct{}
@@ -127,6 +135,7 @@ func TestNewYAMLProviderFromReader(t *testing.T) {
 }
 
 func TestYAMLNode(t *testing.T) {
+	t.Parallel()
 	buff := bytes.NewBuffer([]byte("a: b"))
 	node := &yamlNode{value: make(map[interface{}]interface{})}
 	err := unmarshalYAMLValue(ioutil.NopCloser(buff), &node.value)
@@ -136,6 +145,7 @@ func TestYAMLNode(t *testing.T) {
 }
 
 func TestYamlNodeWithNil(t *testing.T) {
+	t.Parallel()
 	provider := NewYAMLProviderFromFiles(false, nil)
 	assert.NotNil(t, provider)
 	assert.Panics(t, func() {
@@ -144,18 +154,20 @@ func TestYamlNodeWithNil(t *testing.T) {
 }
 
 func TestYamlNode_Callbacks(t *testing.T) {
+	t.Parallel()
 	p := NewYAMLProviderFromFiles(false, nil)
 	assert.NoError(t, p.RegisterChangeCallback("test", nil))
 	assert.NoError(t, p.UnregisterChangeCallback("token"))
 }
 
-func withYamlBytes(t *testing.T, yamlBytes []byte, f func(Provider)) {
+func withYamlBytes(yamlBytes []byte, f func(Provider)) {
 	provider := NewProviderGroup("global", NewYAMLProviderFromBytes(yamlBytes))
 	f(provider)
 }
 
 func TestMatchEmptyStruct(t *testing.T) {
-	withYamlBytes(t, []byte(``), func(provider Provider) {
+	t.Parallel()
+	withYamlBytes([]byte(``), func(provider Provider) {
 		es := emptystruct{}
 		provider.Get("emptystruct").PopulateStruct(&es)
 		empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
@@ -164,7 +176,8 @@ func TestMatchEmptyStruct(t *testing.T) {
 }
 
 func TestMatchPopulatedEmptyStruct(t *testing.T) {
-	withYamlBytes(t, emptyyaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(emptyyaml, func(provider Provider) {
 		es := emptystruct{}
 		provider.Get("emptystruct").PopulateStruct(&es)
 		empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
@@ -173,7 +186,8 @@ func TestMatchPopulatedEmptyStruct(t *testing.T) {
 }
 
 func TestPopulateStructWithPointers(t *testing.T) {
-	withYamlBytes(t, pointerYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(pointerYaml, func(provider Provider) {
 		ps := pointerStruct{}
 		provider.Get("pointerStruct").PopulateStruct(&ps)
 		assert.True(t, *ps.MyTrueBool)
@@ -183,7 +197,8 @@ func TestPopulateStructWithPointers(t *testing.T) {
 }
 
 func TestNonExistingPopulateStructWithPointers(t *testing.T) {
-	withYamlBytes(t, []byte(``), func(provider Provider) {
+	t.Parallel()
+	withYamlBytes([]byte(``), func(provider Provider) {
 		ps := pointerStruct{}
 		provider.Get("pointerStruct").PopulateStruct(&ps)
 		assert.Nil(t, ps.MyTrueBool)
@@ -193,7 +208,8 @@ func TestNonExistingPopulateStructWithPointers(t *testing.T) {
 }
 
 func TestMapParsing(t *testing.T) {
-	withYamlBytes(t, complexMapYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(complexMapYaml, func(provider Provider) {
 		ms := mapStruct{}
 		provider.Get("mapStruct").PopulateStruct(&ms)
 
@@ -213,7 +229,8 @@ func TestMapParsing(t *testing.T) {
 }
 
 func TestMapParsingSimpleMap(t *testing.T) {
-	withYamlBytes(t, simpleMapYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(simpleMapYaml, func(provider Provider) {
 		ms := mapStruct{}
 		provider.Get("mapStruct").PopulateStruct(&ms)
 		assert.Equal(t, 1, ms.MyMap["one"])
@@ -224,7 +241,8 @@ func TestMapParsingSimpleMap(t *testing.T) {
 }
 
 func TestMapParsingMapWithNonStringKeys(t *testing.T) {
-	withYamlBytes(t, intKeyMapYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(intKeyMapYaml, func(provider Provider) {
 		ik := intKeyMapStruct{}
 		err := provider.Get("intKeyMapStruct").PopulateStruct(&ik)
 		assert.NoError(t, err)
@@ -233,7 +251,8 @@ func TestMapParsingMapWithNonStringKeys(t *testing.T) {
 }
 
 func TestDurationParsing(t *testing.T) {
-	withYamlBytes(t, durationYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(durationYaml, func(provider Provider) {
 		ds := durationStruct{}
 		err := provider.Get("durationStruct").PopulateStruct(&ds)
 		assert.NoError(t, err)
@@ -244,7 +263,8 @@ func TestDurationParsing(t *testing.T) {
 }
 
 func TestParsingUnparsableDuration(t *testing.T) {
-	withYamlBytes(t, unparsableDurationYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(unparsableDurationYaml, func(provider Provider) {
 		ds := durationStruct{}
 		err := provider.Get("durationStruct").PopulateStruct(&ds)
 		assert.Error(t, err)
@@ -252,7 +272,8 @@ func TestParsingUnparsableDuration(t *testing.T) {
 }
 
 func TestTypeOfTypes(t *testing.T) {
-	withYamlBytes(t, typeStructYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(typeStructYaml, func(provider Provider) {
 		tts := typeStructStruct{}
 		err := provider.Get(Root).PopulateStruct(&tts)
 		assert.NoError(t, err)
@@ -268,7 +289,8 @@ func TestTypeOfTypes(t *testing.T) {
 }
 
 func TestTypeOfTypesPtr(t *testing.T) {
-	withYamlBytes(t, typeStructYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(typeStructYaml, func(provider Provider) {
 		tts := typeStructStructPtr{}
 		err := provider.Get(Root).PopulateStruct(&tts)
 		assert.NoError(t, err)
@@ -284,7 +306,8 @@ func TestTypeOfTypesPtr(t *testing.T) {
 }
 
 func TestTypeOfTypesPtrPtr(t *testing.T) {
-	withYamlBytes(t, typeStructYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(typeStructYaml, func(provider Provider) {
 		tts := typeStructStructPtrPtr{}
 		err := provider.Get(Root).PopulateStruct(&tts)
 		assert.NoError(t, err)
@@ -300,7 +323,8 @@ func TestTypeOfTypesPtrPtr(t *testing.T) {
 }
 
 func TestHappyTextUnMarshallerParsing(t *testing.T) {
-	withYamlBytes(t, happyTextUnmarshallerYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(happyTextUnmarshallerYaml, func(provider Provider) {
 		ds := duckTales{}
 		err := provider.Get("duckTales").PopulateStruct(&ds)
 		assert.NoError(t, err)
@@ -310,7 +334,8 @@ func TestHappyTextUnMarshallerParsing(t *testing.T) {
 }
 
 func TestGrumpyTextUnMarshallerParsing(t *testing.T) {
-	withYamlBytes(t, grumpyTextUnmarshallerYaml, func(provider Provider) {
+	t.Parallel()
+	withYamlBytes(grumpyTextUnmarshallerYaml, func(provider Provider) {
 		ds := duckTales{}
 		err := provider.Get("darkwingDuck").PopulateStruct(&ds)
 		assert.EqualError(t, err, "Unknown character: DarkwingDuck")
@@ -376,6 +401,7 @@ map:
 }
 
 func TestYamlProviderFmtPrintOnValueNoPanic(t *testing.T) {
+	t.Parallel()
 	provider := NewYAMLProviderFromBytes(yamlConfig1)
 	c := provider.Get("modules.rpc.bind")
 
@@ -386,6 +412,7 @@ func TestYamlProviderFmtPrintOnValueNoPanic(t *testing.T) {
 }
 
 func TestArrayTypeNoPanic(t *testing.T) {
+	t.Parallel()
 	// This test will panic if we treat array the same as slice.
 	provider := NewYAMLProviderFromBytes(yamlConfig1)
 
@@ -397,6 +424,7 @@ func TestArrayTypeNoPanic(t *testing.T) {
 }
 
 func TestNilYAMLProviderSetDefaultTagValue(t *testing.T) {
+	t.Parallel()
 	type Inner struct {
 		Set bool `yaml:"set" default:"true"`
 	}
@@ -426,6 +454,7 @@ func TestNilYAMLProviderSetDefaultTagValue(t *testing.T) {
 }
 
 func TestDefaultWithMergeConfig(t *testing.T) {
+	t.Parallel()
 	base := []byte(`
 abc:
   str: "base"
@@ -449,4 +478,29 @@ abc:
 	assert.Equal(t, 1, cfg.Int)
 	assert.Equal(t, true, cfg.Bool)
 	assert.Nil(t, cfg.BoolPtr)
+}
+
+func TestMapOfStructs(t *testing.T) {
+	t.Parallel()
+	type Bag struct {
+		S string
+		I int
+	}
+	type Map struct {
+		M map[string]Bag
+	}
+
+	v := Map{M: map[string]Bag{
+		"first":  {S: "one", I: 1},
+		"second": {S: "two", I: 2},
+	}}
+
+	b, err := yaml.Marshal(v)
+	require.NoError(t, err)
+
+	p := NewYAMLProviderFromBytes(b)
+	var r Map
+	if err := p.Get(Root).PopulateStruct(&r); err != nil {
+		assert.Fail(t, err.Error())
+	}
 }

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -581,7 +581,6 @@ func TestLoops(t *testing.T) {
 	assert.Contains(t, p.Get(Root).PopulateStruct(&b).Error(), "cycles")
 }
 
-
 func TestInternalFieldsAreNotSet(t *testing.T) {
 	t.Parallel()
 	type External struct {

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -550,6 +550,6 @@ s:
 	p := NewYAMLProviderFromBytes(b)
 	var r Map
 	require.NoError(t, p.Get(Root).PopulateStruct(&r))
-	assert.Equal(t, [2]time.Duration{time.Second, 4*time.Minute}, r.S["first"])
+	assert.Equal(t, [2]time.Duration{time.Second, 4 * time.Minute}, r.S["first"])
 	assert.Equal(t, [2]time.Duration{2 * time.Minute, 3 * time.Hour}, r.S["second"])
 }


### PR DESCRIPTION
config.PopulateStruct is not really recursive now: primitive types are available in full only for structs, but not arrays; maps can't have arrays or structs as values, etc. There is also some code duplication: the dispatch for populating values for an array, map, struct fields should be the same.

This PR splits valueStruct method in several smaller methods, that are called recursively. Which solves all the problems above.

- [x] Arrays of fixed length(they are different types than regular slices)
- [x] More tests for a new functionality(existing cover lots of cases, but e.g. we can do maps of structs now)
- [x] Check for cycles
- [x] Populate only exported fields