### PR TITLE
Re-introduce a simple Sentry integration

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
 hash: f5c7c493baa0a29039c147f7244c37d573f95eee31ee448577a64024dabd6770
-updated: 2017-02-23T17:37:32.832575-08:00
+updated: 2017-02-27T09:12:47.84121939-08:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
   subpackages:
   - lib/go/thrift
+- name: github.com/certifi/gocertifi
+  version: 03be5e6bb9874570ea7fb0961225d193cbc374c5
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
@@ -124,12 +126,12 @@ imports:
   - testutils
   - zapcore
 - name: golang.org/x/net
-  version: dd2d9a67c97da0afa00d5726e28086007a0acce5
+  version: bb807669a61aca6092d8137da1fab2150bb96ad7
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/tools
-  version: 219e654bb7266d3b73c4610ed24c33d12560826a
+  version: 496819729719f9d07692195e0a94d6edd2251389
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/yaml.v2
@@ -158,7 +160,7 @@ testImports:
 - name: github.com/mattn/goveralls
   version: 8482d0ebd2a64f95ce02d2b9b7065b0d6fe9151b
 - name: github.com/mvdan/interfacer
-  version: e2f2db5bb7b0f89a41d2e1d905ff7b78fc09c88d
+  version: 588bd9940e912b1b2760d41bd836ef28ff97164d
   subpackages:
   - cmd/interfacer
 - name: github.com/pborman/uuid

--- a/ulog/sentry/doc.go
+++ b/ulog/sentry/doc.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package sentry integrates the exception-tracking service Sentry with
+// application logging.
+//
+// Note that this increases the CPU and allocation cost of logging by 5-10x. If
+// your application logs are already being aggregated (in Splunk,
+// ElasticSearch, or something similar), consider using those tools instead.
+package sentry

--- a/ulog/sentry/sentry.go
+++ b/ulog/sentry/sentry.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sentry
+
+import (
+	raven "github.com/getsentry/raven-go"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	_platform          = "go"
+	_traceContextLines = 3
+	_traceSkipFrames   = 2
+)
+
+func ravenSeverity(lvl zapcore.Level) raven.Severity {
+	switch lvl {
+	case zapcore.DebugLevel:
+		return raven.INFO
+	case zapcore.InfoLevel:
+		return raven.INFO
+	case zapcore.WarnLevel:
+		return raven.WARNING
+	case zapcore.ErrorLevel:
+		return raven.ERROR
+	case zapcore.DPanicLevel:
+		return raven.FATAL
+	case zapcore.PanicLevel:
+		return raven.FATAL
+	case zapcore.FatalLevel:
+		return raven.FATAL
+	default:
+		// Unrecognized levels are fatal.
+		return raven.FATAL
+	}
+}
+
+type client interface {
+	Capture(*raven.Packet, map[string]string) (string, chan error)
+	Wait()
+}
+
+// Configuration is a minimal set of parameters for Sentry integration.
+type Configuration struct {
+	DSN string `yaml:"DSN"`
+}
+
+// Build uses the provided configuration to construct a Sentry-backed logging
+// core.
+func (c Configuration) Build() (zapcore.Core, error) {
+	client, err := raven.New(c.DSN)
+	if err != nil {
+		return zapcore.NewNopCore(), err
+	}
+	return newCore(client, zapcore.ErrorLevel), nil
+}
+
+type core struct {
+	client
+	zapcore.LevelEnabler
+
+	fields map[string]interface{}
+}
+
+func newCore(c client, enab zapcore.LevelEnabler) *core {
+	return &core{
+		client:       c,
+		LevelEnabler: enab,
+		fields:       make(map[string]interface{}),
+	}
+}
+
+func (c *core) With(fs []zapcore.Field) zapcore.Core {
+	return c.with(fs)
+}
+
+func (c *core) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
+	clone := c.with(fs)
+
+	packet := &raven.Packet{
+		Message:   ent.Message,
+		Timestamp: raven.Timestamp(ent.Time),
+		Level:     ravenSeverity(ent.Level),
+		Platform:  _platform,
+		Extra:     clone.fields,
+	}
+
+	trace := raven.NewStacktrace(_traceSkipFrames, _traceContextLines, nil /* app prefixes */)
+	if trace != nil {
+		packet.Interfaces = append(packet.Interfaces, trace)
+	}
+
+	// TODO: Consume the errors channel in the background, incrementing a
+	// counter on each failure.
+	_, _ = c.Capture(packet, nil)
+
+	// We may be crashing the program, so should flush any buffered events.
+	if ent.Level > zapcore.ErrorLevel {
+		c.Wait()
+	}
+	return nil
+}
+
+func (c *core) with(fs []zapcore.Field) *core {
+	// Copy our map.
+	m := make(map[string]interface{}, len(c.fields))
+	for k, v := range c.fields {
+		m[k] = v
+	}
+
+	// Add fields to an in-memory encoder.
+	enc := zapcore.NewMapObjectEncoder()
+	for _, f := range fs {
+		f.AddTo(enc)
+	}
+
+	// Merge the two maps.
+	for k, v := range enc.Fields {
+		m[k] = v
+	}
+
+	return &core{
+		client:       c.client,
+		LevelEnabler: c.LevelEnabler,
+		fields:       m,
+	}
+}

--- a/ulog/sentry/sentry_test.go
+++ b/ulog/sentry/sentry_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sentry
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type spy struct {
+	sync.Mutex
+	packets []*raven.Packet
+	waits   int
+}
+
+func (s *spy) Capture(p *raven.Packet, tags map[string]string) (string, chan error) {
+	if len(tags) > 0 {
+		panic("Sentry integration shouldn't depend on capture-site tags.")
+	}
+	s.Lock()
+	defer s.Unlock()
+	s.packets = append(s.packets, p)
+	return "", nil
+}
+
+func (s *spy) Wait() {
+	s.Lock()
+	s.waits++
+	s.Unlock()
+}
+
+func (s *spy) Packets() []*raven.Packet {
+	s.Lock()
+	defer s.Unlock()
+	if len(s.packets) == 0 {
+		return nil
+	}
+	return append([]*raven.Packet{}, s.packets...)
+}
+
+func asCore(t testing.TB, iface zapcore.Core) *core {
+	c, ok := iface.(*core)
+	require.True(t, ok, "Failed to cast Core to sentry *core.")
+	return c
+}
+
+func TestRavenSeverityMap(t *testing.T) {
+	tests := []struct {
+		z zapcore.Level
+		r raven.Severity
+	}{
+		{zap.DebugLevel, raven.INFO},
+		{zap.InfoLevel, raven.INFO},
+		{zap.WarnLevel, raven.WARNING},
+		{zap.ErrorLevel, raven.ERROR},
+		{zap.DPanicLevel, raven.FATAL},
+		{zap.PanicLevel, raven.FATAL},
+		{zap.FatalLevel, raven.FATAL},
+		{zapcore.Level(-42), raven.FATAL},
+		{zapcore.Level(100), raven.FATAL},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(
+			t,
+			tt.r,
+			ravenSeverity(tt.z),
+			"Unexpected output converting zap Level %s to raven Severity.", tt.z,
+		)
+	}
+}
+
+func TestCoreWith(t *testing.T) {
+	// Ensure that we're not sharing map references across generations.
+	parent := newCore(nil, zapcore.ErrorLevel).With([]zapcore.Field{zap.String("parent", "parent")})
+	elder := parent.With([]zapcore.Field{zap.String("elder", "elder")})
+	younger := parent.With([]zapcore.Field{zap.String("younger", "younger")})
+
+	parentC := asCore(t, parent)
+	elderC := asCore(t, elder)
+	youngerC := asCore(t, younger)
+
+	assert.Equal(t, map[string]interface{}{
+		"parent": "parent",
+	}, parentC.fields, "Unexpected fields on parent.")
+	assert.Equal(t, map[string]interface{}{
+		"parent": "parent",
+		"elder":  "elder",
+	}, elderC.fields, "Unexpected fields on first child core.")
+	assert.Equal(t, map[string]interface{}{
+		"parent":  "parent",
+		"younger": "younger",
+	}, youngerC.fields, "Unexpected fields on second child core.")
+}
+
+func TestCoreCheck(t *testing.T) {
+	core := newCore(nil, zapcore.ErrorLevel)
+	assert.Nil(t, core.Check(zapcore.Entry{}, nil), "Expected nil CheckedEntry for disabled levels.")
+	ent := zapcore.Entry{Level: zapcore.ErrorLevel}
+	assert.NotNil(t, core.Check(ent, nil), "Expected non-nil CheckedEntry for enabled levels.")
+}
+
+func TestConfigWrite(t *testing.T) {
+	s := &spy{}
+	core := newCore(s, zapcore.ErrorLevel)
+
+	// Write a panic-level message, which should also fire a Sentry event.
+	ent := zapcore.Entry{Message: "oh no", Level: zapcore.PanicLevel, Time: time.Now()}
+	ce := core.With([]zapcore.Field{zap.String("foo", "bar")}).Check(ent, nil)
+	require.NotNil(t, ce, "Expected Check to return non-nil CheckedEntry at enabled levels.")
+	ce.Write(zap.String("bar", "baz"))
+
+	// Assert that we wrote and flushed a packet.
+	require.Equal(t, 1, len(s.packets), "Expected to write one Sentry packet.")
+	assert.Equal(t, 1, s.waits, "Expected to flush buffered events before crashing.")
+
+	// Assert that the captured packet is shaped correctly.
+	p := s.packets[0]
+	assert.Equal(t, "oh no", p.Message, "Unexpected message in captured packet.")
+	assert.Equal(t, raven.FATAL, p.Level, "Unexpected severity in captured packet.")
+	require.Equal(t, 1, len(p.Interfaces), "Expected a stacktrace in packet interfaces.")
+	trace, ok := p.Interfaces[0].(*raven.Stacktrace)
+	require.True(t, ok, "Expected only interface in packet to be a stacktrace.")
+	// Trace should contain this test and testing harness main.
+	require.Equal(t, 2, len(trace.Frames), "Expected stacktrace to contain at least two frame.")
+
+	frame := trace.Frames[len(trace.Frames)-1]
+	assert.Equal(t, "TestConfigWrite", frame.Function, "Expected frame to point to this test function.")
+}
+
+func TestConfigBuild(t *testing.T) {
+	broken := Configuration{DSN: "invalid"}
+	_, err := broken.Build()
+	assert.Error(t, err, "Expected invalid DSN to make config building fail.")
+}


### PR DESCRIPTION
This PR re-introduces a simple, `map[string]interface{}`-based Sentry integration. Performance should be comparable to the previous iteration of this code. This should close out the last remaining issue with the zap library upgrade.

@sectioneight, someone from your team should commandeer this PR and make sure documentation, etc. meet your standards.