### PR TITLE
Restore logging functionality

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -118,7 +118,9 @@ func newManager(modules []ModuleCreateFunc, options ...Option) (Manager, error) 
 	// TODO(glib): add a logging reporter and use it by default, rather than nop
 	svc.setupMetrics()
 
-	svc.setupLogging()
+	if err := svc.setupLogging(); err != nil {
+		return nil, err
+	}
 
 	svc.setupAuthClient()
 

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -67,7 +67,7 @@ func (svc *serviceCore) setupLogging() error {
 
 	logger, err := svc.logConfig.Build(zap.Hooks(ulog.Metrics(svc.metrics)))
 	if err != nil {
-		return errors.Wrap(err, "Failed to configure logging")
+		return errors.Wrap(err, "failed to configure logging")
 	}
 
 	// TODO(glib): SetLogger returns a deferral to clean up global log which is not used

--- a/service/service_setup.go
+++ b/service/service_setup.go
@@ -38,8 +38,12 @@ func (svc *serviceCore) setupLogging() error {
 	cfg := svc.configProvider.Get("logging")
 	if cfg.HasValue() {
 		// populate struct if config was provided
-		if err := cfg.PopulateStruct(&svc.logConfig); err != nil {
+		zapCfg := zap.Config{Level: zap.NewAtomicLevel()}
+		if err := cfg.PopulateStruct(&zapCfg); err != nil {
 			return errors.Wrap(err, "unable to parse logging config")
+		}
+		svc.logConfig = ulog.Configuration{
+			Config: zapCfg,
 		}
 	} else {
 		// if no config - default to the regular one

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -117,6 +117,23 @@ logging:
 	zap.L().Info("Testing sentry call")
 }
 
+func TestLoggingSerialization(t *testing.T) {
+	data := []byte(`
+name: name
+owner: owner
+logging:
+  sentry:
+    dsn: http://user:secret@your.sentry.dsn/project
+`)
+
+	c := serviceCore{metricsCore: metricsCore{metrics: tally.NoopScope}}
+	c.configProvider = config.NewYAMLProviderFromBytes(data)
+
+	require.NoError(t, c.setupLogging())
+	require.NotNil(t, c.logConfig.Sentry)
+	require.Equal(t, "http://user:secret@your.sentry.dsn/project", c.logConfig.Sentry.DSN)
+}
+
 func TestBadOption_Panics(t *testing.T) {
 	opt := func(_ *manager) error {
 		return errors.New("nope")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -104,6 +104,7 @@ func TestServiceWithSentryHook(t *testing.T) {
 name: name
 owner: owner
 logging:
+  encoding: json
   sentry:
     dsn: http://user:secret@your.sentry.dsn/project
 `)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -117,11 +117,14 @@ logging:
 	zap.L().Info("Testing sentry call")
 }
 
-func TestLoggingSerialization(t *testing.T) {
+func TestLoggingConfigDeserialization(t *testing.T) {
 	data := []byte(`
 name: name
 owner: owner
 logging:
+  encoding: console
+  sampling:
+    initial: 777
   sentry:
     dsn: http://user:secret@your.sentry.dsn/project
 `)
@@ -132,6 +135,8 @@ logging:
 	require.NoError(t, c.setupLogging())
 	require.NotNil(t, c.logConfig.Sentry)
 	require.Equal(t, "http://user:secret@your.sentry.dsn/project", c.logConfig.Sentry.DSN)
+	require.Equal(t, 777, c.logConfig.Sampling.Initial)
+	require.Equal(t, "console", c.logConfig.Encoding)
 }
 
 func TestBadOption_Panics(t *testing.T) {

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -37,7 +37,7 @@ type Configuration struct {
 	Sentry *sentry.Configuration `yaml:"sentry"`
 }
 
-// Initialize from config
+// Configure initializes logging configuration struct from config provider
 func (c *Configuration) Configure(cfg config.Value) error {
 	// Uhhh... this process is not the most elegant.
 	//

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -39,6 +39,7 @@ type Configuration struct {
 
 // Configure initializes logging configuration struct from config provider
 func (c *Configuration) Configure(cfg config.Value) error {
+	// TODO: Fix after GFM-415
 	// Uhhh... this process is not the most elegant.
 	//
 	// Because log.Configuration embeds zap, the PopulateStruct

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -56,7 +56,7 @@ func (c Configuration) Build(opts ...zap.Option) (*zap.Logger, error) {
 func DefaultConfiguration() Configuration {
 	cfg := zap.NewProductionConfig()
 	cfg.OutputPaths = []string{"stdout"}
-	cfg.Encoding = "console"
+	cfg.Encoding = "json"
 
 	return Configuration{
 		Config: cfg,

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -56,7 +56,6 @@ func (c Configuration) Build(opts ...zap.Option) (*zap.Logger, error) {
 func DefaultConfiguration() Configuration {
 	cfg := zap.NewProductionConfig()
 	cfg.OutputPaths = []string{"stdout"}
-	cfg.Encoding = "json"
 
 	return Configuration{
 		Config: cfg,

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -56,6 +56,7 @@ func (c Configuration) Build(opts ...zap.Option) (*zap.Logger, error) {
 func DefaultConfiguration() Configuration {
 	cfg := zap.NewProductionConfig()
 	cfg.OutputPaths = []string{"stdout"}
+	cfg.Encoding = "console"
 
 	return Configuration{
 		Config: cfg,


### PR DESCRIPTION
There was a flurry of different issues, which meant that as things stood
all logging output was discarded.

The most important one is the populateStruct error was not the corrent
condition to check for use of the default logger.

Secondary, embedding `zap.Config` does not work properly with `PopulateStruct`, 
or indeed yaml serialization at all, I believe (need to test). Essentially we weren't
properly creating log configs out of yaml.

Logging setup function now returns an error if it's not able to properly parse
the config.

Default encoding is now also "console", since not providing one is a zap
error.

before
```
$ ./simple
```

after
```
$ ./simple
1.4883359655306897e+09  info    /Users/glib/gocode/src/go.uber.org/fx/modules/uhttp/http.go:173 Server listening on port     {"trace": {}, "moduleName": "http", "port": 8080}
1.4883359655307891e+09  info    /Users/glib/gocode/src/go.uber.org/fx/service/host.go:350       Module started up cleanly    {"module": "http"}
```