### PR TITLE
gRPC example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ examples:
 	@$(call label,Building examples)
 	@echo
 	$(ECHO_V)$(MAKE) -C examples/keyvalue ECHO_V=$(ECHO_V)
+	$(ECHO_V)$(MAKE) -C examples/ugrpc
 	$(ECHO_V)go test ./examples/simple
 	$(ECHO_V)go test ./examples/dig
 

--- a/examples/ugrpc/.gitignore
+++ b/examples/ugrpc/.gitignore
@@ -1,0 +1,1 @@
+kv/kv.pb.go

--- a/examples/ugrpc/Makefile
+++ b/examples/ugrpc/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all
+all: proto
+
+.PHONY: proto
+proto:
+	go install ../../vendor/github.com/golang/protobuf/protoc-gen-go
+	protoc --go_out=plugins=grpc:. kv/kv.proto
+
+.PHONY: server
+server:
+	cd ./server && go run *.go
+
+.PHONY: client
+client:
+	cd ./client && go run *.go set one hello
+	cd ./client && go run *.go get one

--- a/examples/ugrpc/README.md
+++ b/examples/ugrpc/README.md
@@ -1,0 +1,9 @@
+# gRPC Example
+
+This is an example of how to build a Module using gRPC. To run this example:
+
+```
+make proto
+make server # starts the server
+make client # runs the client to set and get a key
+```

--- a/examples/ugrpc/client/main.go
+++ b/examples/ugrpc/client/main.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"go.uber.org/fx/examples/ugrpc/kv"
+	"google.golang.org/grpc"
+)
+
+var (
+	flagPort = flag.Int("port", 8080, "The port to connect to")
+
+	errUsage = fmt.Errorf("usage: %s [get/set/unset] [key] [value]", os.Args[0])
+)
+
+func main() {
+	flag.Parse()
+	if err := do(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func do() error {
+	apiClient, err := newAPIClient()
+	if err != nil {
+		return err
+	}
+	if len(os.Args) < 3 {
+		return errUsage
+	}
+	switch os.Args[1] {
+	case "get":
+		if len(os.Args) != 3 {
+			return errUsage
+		}
+		return get(apiClient, os.Args[2])
+	case "set":
+		if len(os.Args) != 4 {
+			return errUsage
+		}
+		return set(apiClient, os.Args[2], os.Args[3])
+	case "unset":
+		if len(os.Args) != 3 {
+			return errUsage
+		}
+		return unset(apiClient, os.Args[2])
+	default:
+		return errUsage
+	}
+}
+
+func get(apiClient kv.APIClient, key string) error {
+	value, err := apiClient.Get(context.Background(), &kv.Key{key})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("got key %s with value %s\n", key, value.Value)
+	return nil
+}
+
+func set(apiClient kv.APIClient, key string, value string) error {
+	if _, err := apiClient.Set(context.Background(), &kv.KeyValue{key, value}); err != nil {
+		return err
+	}
+	fmt.Printf("set key %s to value %s\n", key, value)
+	return nil
+}
+
+func unset(apiClient kv.APIClient, key string) error {
+	if _, err := apiClient.Set(context.Background(), &kv.KeyValue{key, ""}); err != nil {
+		return err
+	}
+	fmt.Printf("unset key %s\n", key)
+	return nil
+}
+
+func newAPIClient() (kv.APIClient, error) {
+	clientConn, err := grpc.Dial(fmt.Sprintf("0.0.0.0:%d", *flagPort), grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	return kv.NewAPIClient(clientConn), nil
+}

--- a/examples/ugrpc/doc.go
+++ b/examples/ugrpc/doc.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package ugrpc is the gRPC Example.
+//
+// This is an example of how to build a Module using gRPC. To run this example:
+//
+//   make proto
+//   make server # starts the server
+//   make client # runs the client to set and get a key
+//
+//
+package ugrpc

--- a/examples/ugrpc/kv/kv.proto
+++ b/examples/ugrpc/kv/kv.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package kv;
+
+message Key {
+  string key = 1;
+}
+
+message Value {
+  string value = 1;
+}
+
+message KeyValue {
+  string key = 1;
+  string value = 2;
+}
+
+message Void {}
+
+service API {
+    rpc Get(Key) returns (Value);
+    rpc Set(KeyValue) returns (Void);
+}

--- a/examples/ugrpc/server/api_server.go
+++ b/examples/ugrpc/server/api_server.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"go.uber.org/fx/examples/ugrpc/kv"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var voidInstance = &kv.Void{}
+
+type apiServer struct {
+	data map[string]string
+}
+
+func newAPIServer() *apiServer {
+	return &apiServer{make(map[string]string)}
+}
+
+func (a *apiServer) Get(_ context.Context, key *kv.Key) (*kv.Value, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+	value, ok := a.data[key.Key]
+	if !ok {
+		return nil, grpc.Errorf(codes.NotFound, "no value for key: %s", key.Key)
+	}
+	return &kv.Value{value}, nil
+}
+
+func (a *apiServer) Set(_ context.Context, keyValue *kv.KeyValue) (*kv.Void, error) {
+	if err := validateKeyValue(keyValue); err != nil {
+		return nil, err
+	}
+	if keyValue.Value == "" {
+		delete(a.data, keyValue.Key)
+		return voidInstance, nil
+	}
+	a.data[keyValue.Key] = keyValue.Value
+	return voidInstance, nil
+}
+
+func validateKey(key *kv.Key) error {
+	if key.Key == "" {
+		return grpc.Errorf(codes.InvalidArgument, "key is empty")
+	}
+	return nil
+}
+
+func validateKeyValue(keyValue *kv.KeyValue) error {
+	if keyValue.Key == "" {
+		return grpc.Errorf(codes.InvalidArgument, "key is empty")
+	}
+	return nil
+}

--- a/examples/ugrpc/server/config/base.yaml
+++ b/examples/ugrpc/server/config/base.yaml
@@ -1,0 +1,6 @@
+name: grpc
+description: grpc usage example
+owner: owner@service.com
+modules:
+  keyvalue:
+    port: 8080

--- a/examples/ugrpc/server/main.go
+++ b/examples/ugrpc/server/main.go
@@ -33,9 +33,8 @@ func main() {
 	manager, err := service.WithModule(
 		"keyvalue",
 		ugrpc.Module(
-			func(server *grpc.Server) {
-				kv.RegisterAPIServer(server, newAPIServer())
-			},
+			func(server *grpc.Server) { kv.RegisterAPIServer(server, newAPIServer()) },
+			grpc.UnaryInterceptor(ugrpc.LoggingUnaryServerInterceptor),
 		),
 	).Build()
 	if err != nil {

--- a/examples/ugrpc/server/main.go
+++ b/examples/ugrpc/server/main.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"log"
+
+	"go.uber.org/fx/examples/ugrpc"
+	"go.uber.org/fx/examples/ugrpc/kv"
+	"go.uber.org/fx/service"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	manager, err := service.WithModule(
+		"keyvalue",
+		ugrpc.Module(
+			func(server *grpc.Server) {
+				kv.RegisterAPIServer(server, newAPIServer())
+			},
+		),
+	).Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+	manager.Start()
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f5c7c493baa0a29039c147f7244c37d573f95eee31ee448577a64024dabd6770
-updated: 2017-02-27T09:12:47.84121939-08:00
+hash: 4e8f3aa47685831420bf1a9af3ce8bd500a90b65e92a5c0922b32e7279e68af3
+updated: 2017-03-01T16:00:59.368112+01:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -48,7 +48,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 43c1379c0577ac1eb74f9f3869cea07191c9992b
 - name: github.com/uber/jaeger-client-go
-  version: a1c7be77e82c1ccd832ace5c4c04b25700d90b1f
+  version: 2505ffc229cbe642a1af9387e8251f7e699c2f6e
   subpackages:
   - config
   - internal/spanlog
@@ -126,7 +126,7 @@ imports:
   - testutils
   - zapcore
 - name: golang.org/x/net
-  version: bb807669a61aca6092d8137da1fab2150bb96ad7
+  version: 906cda9512f77671ab44f8c8563b13a8e707b230
   subpackages:
   - context
   - context/ctxhttp
@@ -149,6 +149,8 @@ testImports:
   version: b8599f7d71e7fead76b25aeb919c0e2558672f4a
   subpackages:
   - golint
+- name: github.com/golang/protobuf
+  version: 69b215d01a5606c843240eab4937eab3acee6530
 - name: github.com/jessevdk/go-flags
   version: 460c7bb0abd6e927f2767cadc91aa6ef776a98b4
 - name: github.com/kisielk/errcheck
@@ -173,3 +175,5 @@ testImports:
   version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/yookoala/realpath
   version: c416d99ab5ed256fa30c1f3bab73152deb59bb69
+- name: google.golang.org/grpc
+  version: aefc96d792e01c7be09afa69b8c1cbfe3a21e2fc

--- a/glide.yaml
+++ b/glide.yaml
@@ -57,3 +57,5 @@ testImport:
 - package: github.com/shurcooL/sanitized_anchor_name
 - package: github.com/mvdan/interfacer/cmd/interfacer
 - package: github.com/kyoh86/richgo
+- package: github.com/golang/protobuf
+- package: google.golang.org/grpc


### PR DESCRIPTION
This is a quick example of a module implementation for gRPC based on https://github.com/uber-go/fx/pull/275. It could be extended more, the first thing that comes to mind is adding options for interceptors, but this does the basics. Note that this will fail on travis for now due to not properly setting up protoc and some generated file issues.