### PR TITLE
Check return values from provider for maps

### DIFF
--- a/config/value.go
+++ b/config/value.go
@@ -564,15 +564,16 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 	valueType := value.Type()
 	global := d.getGlobalProvider()
 
-	val := global.Get(childKey).Value()
+	v := global.Get(childKey)
+	if !v.HasValue() || v.Value() == nil {
+		return nil
+	}
+
+	val := v.Value()
 
 	// We fallthrough for interface to maps
 	if valueType.Kind() == reflect.Interface {
 		value.Set(reflect.ValueOf(val))
-		return nil
-	}
-
-	if val == nil {
 		return nil
 	}
 
@@ -623,7 +624,6 @@ func (d *decoder) object(childKey string, value reflect.Value) error {
 	if value.IsNil() {
 		tmp := reflect.New(value.Type().Elem())
 		value.Set(tmp)
-		//return nil
 	}
 
 	return d.valueStruct(childKey, value.Interface())

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -595,3 +595,70 @@ internal: set
 	require.NoError(t, p.Get(Root).PopulateStruct(&r))
 	assert.Equal(t, "", r.internal)
 }
+
+func TestEmbeddedStructs(t *testing.T) {
+	t.Skip("TODO(alsam) GFM(415)")
+	t.Parallel()
+	type Config struct {
+		Foo string
+	}
+
+	type Sentry struct {
+		DSN string
+	}
+
+	type Logging struct {
+		Config
+		Sentry
+	}
+
+	b := []byte(`
+logging:
+   foo: bar
+   sentry:
+      dsn: asdf
+`)
+	p := NewYAMLProviderFromBytes(b)
+	var r Config
+	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	assert.Equal(t, "bar", r.Foo)
+}
+
+func TestEmptyValuesSetForMaps(t *testing.T) {
+	t.Parallel()
+	type Hello interface {
+		Hello()
+	}
+
+	type Foo struct {
+		M map[string]Hello
+	}
+
+	b := []byte(`
+M:
+   sayHello:
+`)
+	p := NewYAMLProviderFromBytes(b)
+	var r Foo
+	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	assert.Equal(t, r.M, map[string]Hello{"sayHello": Hello(nil)})
+}
+
+func TestEmptyValuesSetForStructs(t *testing.T) {
+	t.Parallel()
+	type Hello interface {
+		Hello()
+	}
+
+	type Foo struct {
+		Say Hello
+	}
+
+	b := []byte(`
+Say:
+`)
+	p := NewYAMLProviderFromBytes(b)
+	var r Foo
+	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	assert.Nil(t, r.Say)
+}


### PR DESCRIPTION
We panic if a config provider returns an empty value to fill the map type.