### PR TITLE
Temporarily disable tip while gimme is broken in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 go:
   - 1.7
   - 1.8
-  - tip
+  # TODO(aiden) re-enable tip once "gimme tip" works in travis again
 
 go_import_path: go.uber.org/fx
 


### PR DESCRIPTION
Travis just started complaining (see #325):

```
32.36s$ GIMME_OUTPUT=$(gimme tip) && eval "$GIMME_OUTPUT"
I don't have any idea what to do with 'tip'.
  (using type 'auto')
The command "GIMME_OUTPUT=$(gimme tip) && eval "$GIMME_OUTPUT"" failed and exited with 1 during .
```

Disabling this to unblock PRs until we can triage and figure out what's wrong, since we haven't changed this on our side.