### PR TITLE
Fix examples to use "standard" names

### DIFF
--- a/examples/keyvalue/server/main.go
+++ b/examples/keyvalue/server/main.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	svc, err := service.WithModule(
-		"example",
+		"yarpc",
 		yarpc.New(
 			yarpc.CreateThriftServiceFunc(NewYARPCThriftHandler),
 		),

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -28,7 +28,10 @@ import (
 )
 
 func main() {
-	svc, err := service.WithModule("example", uhttp.New(registerHTTPers, uhttp.WithInboundMiddleware(simpleInboundMiddleware{}))).Build()
+	svc, err := service.WithModule(
+		"http", uhttp.New(registerHTTPers, uhttp.WithInboundMiddleware(simpleInboundMiddleware{})),
+	).Build()
+
 	if err != nil {
 		log.Fatal("Unable to initialize service", "error", err)
 	}


### PR DESCRIPTION
Otherwise config values are not picked up correctly (the simple example
was litening to port 3001 for instance as opposed to promised 8080)