### PR TITLE
Only run make coveralls in travis on go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
   - make examples
 
 after_success:
-   - '[ "${TRAVIS_GO_VERSION}" != "tip" ] && make coveralls'
+   - '[ "${TRAVIS_GO_VERSION}" == "1.8" ] && make coveralls'


### PR DESCRIPTION
Coveralls is making two comments on every PR about code coverage, this will make it just one comment I think.