### PR TITLE
Split out `make license` into it's own rule

### DIFF
--- a/.build/lint.mk
+++ b/.build/lint.mk
@@ -33,11 +33,15 @@ lint:
 	$(ECHO_V)$(foreach dir,$(PKGS),errcheck $(ERRCHECK_FLAGS) $(dir) 2>&1 | $(FILTER_LINT) | tee -a $(LINT_LOG);)
 	@echo "Checking for unresolved FIXMEs..."
 	$(ECHO_V)git grep -i fixme | grep -v -e vendor -e $(_THIS_MAKEFILE) -e CONTRIBUTING.md | tee -a $(LINT_LOG)
-	@echo "Checking for license headers..."
-	$(ECHO_V)$(_THIS_DIR)/check_license.sh | tee -a $(LINT_LOG)
+	$(MAKE) license
 	@echo "Checking for imports of log package"
 	$(ECHO_V)go list -f '{{ .ImportPath }}: {{ .Imports }}' $(shell glide nv) | grep -e "\blog\b" | $(FILTER_LOG) | tee -a $(LINT_LOG)
 	@echo "Ensuring generated doc.go are up to date"
 	$(ECHO_V)$(MAKE) gendoc
 	$(ECHO_V)[ -z "$(shell git status --porcelain | grep '\bdoc.go$$')" ] || echo "Commit updated doc.go changes" | tee -a $(LINT_LOG)
 	$(ECHO_V)[ ! -s $(LINT_LOG) ]
+
+.PHONY: license
+license:
+	@echo "Checking for license headers..."
+	$(ECHO_V)$(_THIS_DIR)/check_license.sh | tee -a $(LINT_LOG)


### PR DESCRIPTION
Right after adding new files, it's not always desirable to run the full `make
lint` as it does a lot of validations and takes a long time.