### PR TITLE
Make static provider recursive

### DIFF
--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -40,7 +40,7 @@ func TestProviderGroup(t *testing.T) {
 
 func TestProviderGroupScope(t *testing.T) {
 	t.Parallel()
-	data := map[string]interface{}{"hello.world": 42}
+	data := map[string]interface{}{"hello": map[string]int{"world": 42}}
 	pg := NewProviderGroup("test-group", NewStaticProvider(data))
 	assert.Equal(t, 42, pg.Scope("hello").Get("world").AsInt())
 }

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -54,12 +54,12 @@ func TestStaticProvider_WithData(t *testing.T) {
 
 func TestStaticProvider_WithScope(t *testing.T) {
 	data := map[string]interface{}{
-		"hello.world": 42,
+		"hello": map[string]int{"world": 42},
 	}
 	p := NewStaticProvider(data)
 
 	val := p.Get("hello")
-	assert.False(t, val.HasValue())
+	assert.True(t, val.HasValue())
 
 	sub := p.Scope("hello")
 	val = sub.Get("world")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -80,9 +80,9 @@ func TestServiceCreation_MissingRequiredParams(t *testing.T) {
 
 func TestServiceWithRoles(t *testing.T) {
 	data := map[string]interface{}{
-		"name":    "name",
-		"owner":   "owner",
-		"roles.0": "foo",
+		"name":  "name",
+		"owner": "owner",
+		"roles": []string{"foo"},
 	}
 	cfgOpt := withConfig(data)
 


### PR DESCRIPTION
Right now static provider is not recursive, which make is hard to use.
We can improve it by simply wrapping the YAML config provider.