### PR TITLE
Added sentry config for trace

### DIFF
--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -45,7 +45,6 @@ logging:
       disabled: true
       skip_frames: 10
       context_lines: 15
-
 `)
 )
 

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -24,9 +24,10 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/fx/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/fx/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/ulog/log_test.go
+++ b/ulog/log_test.go
@@ -44,8 +44,6 @@ logging:
     dsn:
     trace:
       disabled: true
-      skip_frames: 10
-      context_lines: 15
 `)
 )
 
@@ -69,6 +67,7 @@ func TestSetLogger(t *testing.T) {
 }
 
 func TestConfigureLogger(t *testing.T) {
+	t.Parallel()
 	var logConfig Configuration
 	cfg := config.NewYAMLProviderFromBytes(_logyaml).Get("logging")
 	err := logConfig.Configure(cfg)
@@ -80,15 +79,14 @@ func TestConfigureLogger(t *testing.T) {
 }
 
 func TestConfigureSentryLogger(t *testing.T) {
+	t.Parallel()
 	var logConfig Configuration
 	cfg := config.NewYAMLProviderFromBytes(_sentryyaml).Get("logging")
 	err := logConfig.Configure(cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, logConfig.Sentry)
 	assert.Equal(t, "", logConfig.Sentry.DSN)
-	assert.Equal(t, bool(true), logConfig.Sentry.Trace.Disabled)
-	assert.Equal(t, 10, *logConfig.Sentry.Trace.SkipFrames)
-	assert.Equal(t, 15, *logConfig.Sentry.Trace.ContextLines)
+	assert.Equal(t, true, logConfig.Sentry.Trace.Disabled)
 
 	logger, err := logConfig.Build()
 	require.NoError(t, err)

--- a/ulog/sentry/sentry_test.go
+++ b/ulog/sentry/sentry_test.go
@@ -70,6 +70,7 @@ func asCore(t testing.TB, iface zapcore.Core) *core {
 }
 
 func TestRavenSeverityMap(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		z zapcore.Level
 		r raven.Severity
@@ -96,6 +97,7 @@ func TestRavenSeverityMap(t *testing.T) {
 }
 
 func TestCoreWith(t *testing.T) {
+	t.Parallel()
 	cfg := Configuration{
 		DSN: "testdsn",
 	}
@@ -122,6 +124,7 @@ func TestCoreWith(t *testing.T) {
 }
 
 func TestCoreCheck(t *testing.T) {
+	t.Parallel()
 	cfg := Configuration{
 		DSN: "testdsn",
 	}
@@ -163,6 +166,7 @@ func TestConfigWrite(t *testing.T) {
 }
 
 func TestConfigBuild(t *testing.T) {
+	t.Parallel()
 	broken := Configuration{DSN: "invalid"}
 	_, err := broken.Build()
 	assert.Error(t, err, "Expected invalid DSN to make config building fail.")

--- a/ulog/sentry/sentry_test.go
+++ b/ulog/sentry/sentry_test.go
@@ -96,8 +96,11 @@ func TestRavenSeverityMap(t *testing.T) {
 }
 
 func TestCoreWith(t *testing.T) {
+	cfg := Configuration{
+		DSN: "testdsn",
+	}
 	// Ensure that we're not sharing map references across generations.
-	parent := newCore(nil, zapcore.ErrorLevel).With([]zapcore.Field{zap.String("parent", "parent")})
+	parent := newCore(cfg, nil, zapcore.ErrorLevel).With([]zapcore.Field{zap.String("parent", "parent")})
 	elder := parent.With([]zapcore.Field{zap.String("elder", "elder")})
 	younger := parent.With([]zapcore.Field{zap.String("younger", "younger")})
 
@@ -119,7 +122,10 @@ func TestCoreWith(t *testing.T) {
 }
 
 func TestCoreCheck(t *testing.T) {
-	core := newCore(nil, zapcore.ErrorLevel)
+	cfg := Configuration{
+		DSN: "testdsn",
+	}
+	core := newCore(cfg, nil, zapcore.ErrorLevel)
 	assert.Nil(t, core.Check(zapcore.Entry{}, nil), "Expected nil CheckedEntry for disabled levels.")
 	ent := zapcore.Entry{Level: zapcore.ErrorLevel}
 	assert.NotNil(t, core.Check(ent, nil), "Expected non-nil CheckedEntry for enabled levels.")
@@ -127,7 +133,10 @@ func TestCoreCheck(t *testing.T) {
 
 func TestConfigWrite(t *testing.T) {
 	s := &spy{}
-	core := newCore(s, zapcore.ErrorLevel)
+	cfg := Configuration{
+		DSN: "testdsn",
+	}
+	core := newCore(cfg, s, zapcore.ErrorLevel)
 
 	// Write a panic-level message, which should also fire a Sentry event.
 	ent := zapcore.Entry{Message: "oh no", Level: zapcore.PanicLevel, Time: time.Now()}


### PR DESCRIPTION
Teams are writing code against beta with trace disabled in production. So until filebeat is ready, this should work without requiring any config change.