### PR TITLE
Add panic variations of all DIG functions

### DIFF
--- a/dig/default.go
+++ b/dig/default.go
@@ -33,9 +33,19 @@ func Register(i interface{}) error {
 	return defaultGraph.Register(i)
 }
 
+// MustRegister calls Register and panics if an error is encountered
+func MustRegister(i interface{}) {
+	defaultGraph.MustRegister(i)
+}
+
 // RegisterAll into the default graph
 func RegisterAll(is ...interface{}) error {
 	return defaultGraph.RegisterAll(is...)
+}
+
+// MustRegisterAll into the default graph
+func MustRegisterAll(is ...interface{}) {
+	defaultGraph.MustRegisterAll(is...)
 }
 
 // Resolve an object through the default graph
@@ -43,9 +53,19 @@ func Resolve(i interface{}) error {
 	return defaultGraph.Resolve(i)
 }
 
-// ResolveAll the passed in pointers through the dependency graph
+// MustResolve through the default graph
+func MustResolve(i interface{}) {
+	defaultGraph.MustResolve(i)
+}
+
+// ResolveAll through the default graph
 func ResolveAll(is ...interface{}) error {
 	return defaultGraph.ResolveAll(is...)
+}
+
+// MustResolveAll on the default graph
+func MustResolveAll(is ...interface{}) {
+	defaultGraph.MustResolveAll(is...)
 }
 
 // Reset the default graph

--- a/dig/default_test.go
+++ b/dig/default_test.go
@@ -42,23 +42,35 @@ func TestDefaultGraph(t *testing.T) {
 	defer Reset()
 
 	t1 := &Type1{t: 42}
-	require.NoError(t, Register(t1))
+	require.NotPanics(t, func() {
+		MustRegister(t1)
+	})
 
 	t2 := &Type2{s: "42"}
 	t3 := &Type3{f: 4.2}
-	require.NoError(t, RegisterAll(t2, t3))
+	require.NoError(t, RegisterAll(t2))
+	require.NotPanics(t, func() {
+		MustRegisterAll(t3)
+	})
 
 	var t1g *Type1
-	require.NoError(t, Resolve(&t1g))
+	require.NotPanics(t, func() {
+		MustResolve(&t1g)
+	})
 	require.True(t, t1g == t1)
 
 	var t2g *Type2
 	var t3g *Type3
-	require.NoError(t, ResolveAll(&t2g, &t3g))
+	require.NotPanics(t, func() {
+		MustResolveAll(&t2g, &t3g)
+	})
 	require.True(t, t2g == t2)
 	require.True(t, t3g == t3)
 
 	var t2g2 *Type2
 	require.NoError(t, DefaultGraph().Resolve(&t2g2))
+	require.NotPanics(t, func() {
+		MustResolve(&t2g2)
+	})
 	require.Equal(t, t2, t2g2)
 }

--- a/dig/dig.go
+++ b/dig/dig.go
@@ -80,6 +80,13 @@ func (g *Graph) Register(c interface{}) error {
 	}
 }
 
+// MustRegister will attempt to register the object and panic if error is encountered
+func (g *Graph) MustRegister(c interface{}) {
+	if err := g.Register(c); err != nil {
+		panic(err)
+	}
+}
+
 // Resolve all of the dependencies of the provided class
 //
 // Provided object must be a pointer
@@ -120,6 +127,13 @@ func (g *Graph) Resolve(obj interface{}) (err error) {
 	return nil
 }
 
+// MustResolve calls Resolve and panics if an error is encountered
+func (g *Graph) MustResolve(obj interface{}) {
+	if err := g.Resolve(obj); err != nil {
+		panic(err)
+	}
+}
+
 // ResolveAll the dependencies of each provided object
 // Returns the first error encountered
 func (g *Graph) ResolveAll(objs ...interface{}) error {
@@ -131,6 +145,13 @@ func (g *Graph) ResolveAll(objs ...interface{}) error {
 	return nil
 }
 
+// MustResolveAll calls ResolveAll and panics if an error is encountered
+func (g *Graph) MustResolveAll(objs ...interface{}) {
+	if err := g.ResolveAll(objs...); err != nil {
+		panic(err)
+	}
+}
+
 // RegisterAll registers all the provided args in the dependency graph
 func (g *Graph) RegisterAll(cs ...interface{}) error {
 	for _, c := range cs {
@@ -139,6 +160,13 @@ func (g *Graph) RegisterAll(cs ...interface{}) error {
 		}
 	}
 	return nil
+}
+
+// MustRegisterAll calls RegisterAll and panics is an error is encountered
+func (g *Graph) MustRegisterAll(cs ...interface{}) {
+	if err := g.RegisterAll(cs...); err != nil {
+		panic(err)
+	}
 }
 
 // Reset the graph by removing all the registered nodes

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -254,3 +254,65 @@ func TestPanicConstructor(t *testing.T) {
 	require.Contains(t, err.Error(), "panic during Resolve")
 	require.Contains(t, err.Error(), "RUH ROH")
 }
+
+func TestMustFunctions(t *testing.T) {
+	t.Parallel()
+	tts := []struct {
+		name          string
+		f             func(g *Graph)
+		panicExpected bool
+	}{
+		{
+			"wrong register type",
+			func(g *Graph) { g.MustRegister(2) },
+			true,
+		},
+		{
+			"wrong register all types",
+			func(g *Graph) { g.MustRegisterAll("2", "3") },
+			true,
+		},
+		{
+			"unregistered type",
+			func(g *Graph) {
+				var v *Type1
+				g.MustResolve(&v)
+			},
+			true,
+		},
+		{
+			"correct register",
+			func(g *Graph) { g.MustRegister(NewChild1) },
+			false,
+		},
+		{
+			"correct register all",
+			func(g *Graph) { g.MustRegisterAll(NewChild1, NewChild2) },
+			false,
+		},
+		{
+			"unregistered types",
+			func(g *Graph) {
+				var v *Type1
+				var v2 *Type2
+				g.MustResolveAll(&v, &v2)
+			},
+			true,
+		},
+	}
+
+	for _, tc := range tts {
+		t.Run(tc.name, func(t *testing.T) {
+			g := New()
+			f := func() {
+				tc.f(g)
+			}
+
+			if tc.panicExpected {
+				require.Panics(t, f)
+			} else {
+				require.NotPanics(t, f)
+			}
+		})
+	}
+}

--- a/dig/node_test.go
+++ b/dig/node_test.go
@@ -23,58 +23,19 @@ package dig
 import (
 	"testing"
 
+	"reflect"
+
 	"github.com/stretchr/testify/require"
 )
 
-type Type1 struct {
-	t int
-}
+func TestNodeStrings(t *testing.T) {
+	n := objNode{}
+	require.Contains(t, n.String(), "(object)")
 
-type Type2 struct {
-	s string
-}
-
-type Type3 struct {
-	f float32
-}
-
-type Type4 struct{}
-
-func TestDefaultGraph(t *testing.T) {
-	defer Reset()
-
-	t1 := &Type1{t: 42}
-	require.NoError(t, Register(t1))
-
-	t2 := &Type2{s: "42"}
-	t3 := &Type3{f: 4.2}
-	t4 := &Type4{}
-	require.NoError(t, RegisterAll(t2))
-	require.NotPanics(t, func() {
-		MustRegister(t3)
-		MustRegisterAll(t4)
-	})
-
-	var t1g *Type1
-	require.NoError(t, Resolve(&t1g))
-	require.NotPanics(t, func() {
-		MustResolve(&t1g)
-	})
-	require.True(t, t1g == t1)
-
-	var t2g *Type2
-	var t3g *Type3
-	require.NoError(t, ResolveAll(&t2g, &t3g))
-	require.NotPanics(t, func() {
-		MustResolveAll(&t2g, &t3g)
-	})
-	require.True(t, t2g == t2)
-	require.True(t, t3g == t3)
-
-	var t2g2 *Type2
-	require.NoError(t, DefaultGraph().Resolve(&t2g2))
-	require.NotPanics(t, func() {
-		MustResolve(&t2g2)
-	})
-	require.Equal(t, t2, t2g2)
+	fn := funcNode{
+		node: node{
+			objType: reflect.TypeOf(n),
+		},
+	}
+	require.Contains(t, fn.String(), "(function)")
 }


### PR DESCRIPTION
Provides a little more flexibility for the developer, without having to add a small wrapper in each service.

I've been using `Must*` in my recent prototypes, so I feel good about upstreaming these.