### PR TITLE
Reuse local listener when starting http server

### DIFF
--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -152,6 +152,11 @@ func (m *Module) Start() error {
 		m.lock.RLock()
 		listener := m.listener
 		m.lock.RUnlock()
+		if listener == nil {
+			m.log.Error("listener is nil, module was stopped before server is able to start")
+			return
+		}
+
 		// TODO(pedge): what to do about error?
 		if err := m.srv.Serve(listener); err != nil {
 			m.log.Error("HTTP Serve error", zap.Error(err))

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -149,14 +149,6 @@ func (m *Module) Start() error {
 	m.listener = listener
 	m.srv = &http.Server{Handler: mux}
 	go func() {
-		m.lock.RLock()
-		listener := m.listener
-		m.lock.RUnlock()
-		if listener == nil {
-			m.log.Error("listener is nil, module was stopped before server is able to start")
-			return
-		}
-
 		// TODO(pedge): what to do about error?
 		if err := m.srv.Serve(listener); err != nil {
 			m.log.Error("HTTP Serve error", zap.Error(err))


### PR DESCRIPTION
We start server in a separate go routine, which may start execution after module is stopped. In this case listener will be nil and server will panic, which will cause our tests to fail. Before:
```
go test -run TestHTTPModule_StartsAndStops -count 50
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12bdd7f]

goroutine 162 [running]:
net/http.(*Server).Serve(0xc42008cfd0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.8/libexec/src/net/http/server.go:2626 +0x4f
go.uber.org/fx/modules/uhttp.(*Module).Start.func1(0xc4205ca780)
	/Users/mortid0/go/src/go.uber.org/fx/modules/uhttp/http.go:160 +0xa2
created by go.uber.org/fx/modules/uhttp.(*Module).Start
	/Users/mortid0/go/src/go.uber.org/fx/modules/uhttp/http.go:163 +0x5d2
exit status 2
```

After:
```
go test -run TestHTTPModule_StartsAndStops -count 50000
PASS
ok  	go.uber.org/fx/modules/uhttp	6.760s
```

Fixes #365