### PR TITLE
Clean up service package

### DIFF
--- a/service/builder.go
+++ b/service/builder.go
@@ -20,13 +20,6 @@
 
 package service
 
-import "github.com/pkg/errors"
-
-type moduleInfo struct {
-	provider ModuleProvider
-	options  []ModuleOption
-}
-
 // A Builder is a helper to create a service
 type Builder struct {
 	options     []Option
@@ -53,9 +46,10 @@ func (b *Builder) WithOptions(options ...Option) *Builder {
 
 // Build returns the service, or any errors encountered during build phase.
 func (b *Builder) Build() (Manager, error) {
-	svc, err := newManager(b)
-	if err != nil {
-		return nil, errors.Wrap(err, "service instantiation failed")
-	}
-	return svc, nil
+	return newManager(b)
+}
+
+type moduleInfo struct {
+	provider ModuleProvider
+	options  []ModuleOption
 }

--- a/service/module.go
+++ b/service/module.go
@@ -51,14 +51,6 @@ func ModuleProviderFromFunc(name string, createFunc func(Host) (Module, error)) 
 	return &moduleProviderFunc{name, createFunc}
 }
 
-type moduleProviderFunc struct {
-	name       string
-	createFunc func(Host) (Module, error)
-}
-
-func (m *moduleProviderFunc) DefaultName() string              { return m.name }
-func (m *moduleProviderFunc) Create(host Host) (Module, error) { return m.createFunc(host) }
-
 // ModuleOption is a function that configures module creation.
 type ModuleOption func(*moduleOptions) error
 
@@ -92,6 +84,14 @@ func WithModuleRole(role string) ModuleOption {
 func NewScopedHost(host Host, name string, roles ...string) (Host, error) {
 	return newScopedHost(host, name, roles...)
 }
+
+type moduleProviderFunc struct {
+	name       string
+	createFunc func(Host) (Module, error)
+}
+
+func (m *moduleProviderFunc) DefaultName() string              { return m.name }
+func (m *moduleProviderFunc) Create(host Host) (Module, error) { return m.createFunc(host) }
 
 type moduleOptions struct {
 	name  string

--- a/service/service.go
+++ b/service/service.go
@@ -108,6 +108,11 @@ type Exit struct {
 	ExitCode int
 }
 
+// AfterStart will create an observer that will execute f() immediately after service starts.
+func AfterStart(f func()) Observer {
+	return niladicStart(f)
+}
+
 type niladicStart func()
 
 func (n niladicStart) OnInit(service Host) error      { return nil }
@@ -117,9 +122,4 @@ func (n niladicStart) OnStateChange(old State, curr State) {
 	if old == Starting && curr == Running {
 		n()
 	}
-}
-
-// AfterStart will create an observer that will execute f() immediately after service starts.
-func AfterStart(f func()) Observer {
-	return niladicStart(f)
 }


### PR DESCRIPTION
This is some more cleaning up of the service package. The primary point of this PR is to have public types before private types. This also removes some newlines and comments that seem unnecessary due to the code being self-documenting.