### PR TITLE
[WIP] Consume yarpc config v2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f5c7c493baa0a29039c147f7244c37d573f95eee31ee448577a64024dabd6770
-updated: 2017-02-27T09:12:47.84121939-08:00
+hash: 6de480589f930a144aa55b939a591db54e78842a643bea0693b58dda388efdc7
+updated: 2017-03-06T10:08:27.957997616-08:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -10,7 +10,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -27,6 +27,8 @@ imports:
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+- name: github.com/mitchellh/mapstructure
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
@@ -35,7 +37,7 @@ imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
@@ -48,7 +50,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 43c1379c0577ac1eb74f9f3869cea07191c9992b
 - name: github.com/uber/jaeger-client-go
-  version: a1c7be77e82c1ccd832ace5c4c04b25700d90b1f
+  version: 2505ffc229cbe642a1af9387e8251f7e699c2f6e
   subpackages:
   - config
   - internal/spanlog
@@ -66,7 +68,7 @@ imports:
   - metrics
   - metrics/tally
 - name: github.com/uber/tchannel-go
-  version: 79387824978f91318be3bfb43ae12e04c38cfe97
+  version: 2feb388c9d0c0303f98481d1621308d634093ffb
   subpackages:
   - internal/argreader
   - relay
@@ -93,7 +95,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 47ebfe9337d943e637cc1748254727ec1fa89bf4
+  version: 949b1b73d617a21d4a0a9083a8f80c82ba80005c
   subpackages:
   - api/encoding
   - api/middleware
@@ -103,6 +105,7 @@ imports:
   - encoding/thrift/internal
   - internal
   - internal/clientconfig
+  - internal/decode
   - internal/encoding
   - internal/errors
   - internal/inboundmiddleware
@@ -116,6 +119,7 @@ imports:
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
+  - x/config
 - name: go.uber.org/zap
   version: a03b90bc236f3def382f17743518889a31f8187c
   subpackages:
@@ -126,12 +130,12 @@ imports:
   - testutils
   - zapcore
 - name: golang.org/x/net
-  version: bb807669a61aca6092d8137da1fab2150bb96ad7
+  version: d379faa25cbdc04d653984913a2ceb43b0bc46d7
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/tools
-  version: 496819729719f9d07692195e0a94d6edd2251389
+  version: a99f4ece3600c1664c2ee4e345e3c3dbe8e90b52
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/yaml.v2
@@ -146,7 +150,7 @@ testImports:
 - name: github.com/go-playground/overalls
   version: b52dfefba43cf6f75bb177ba45697ed12e0d10a2
 - name: github.com/golang/lint
-  version: b8599f7d71e7fead76b25aeb919c0e2558672f4a
+  version: cb00e5669539f047b2f4c53a421a01b0c8e172c6
   subpackages:
   - golint
 - name: github.com/jessevdk/go-flags
@@ -160,7 +164,7 @@ testImports:
 - name: github.com/mattn/goveralls
   version: 8482d0ebd2a64f95ce02d2b9b7065b0d6fe9151b
 - name: github.com/mvdan/interfacer
-  version: 588bd9940e912b1b2760d41bd836ef28ff97164d
+  version: e2f2db5bb7b0f89a41d2e1d905ff7b78fc09c88d
   subpackages:
   - cmd/interfacer
 - name: github.com/pborman/uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: github.com/gorilla/context
   version: ^1.1.0
 - package: go.uber.org/yarpc
-  version: ^v1.4.0
+  version: config-examples
 - package: go.uber.org/thriftrw
   version: ^1
 - package: github.com/go-validator/validator

--- a/modules/yarpc/yarpc.go
+++ b/modules/yarpc/yarpc.go
@@ -23,8 +23,6 @@ package yarpc
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strconv"
 	"sync"
 
 	"go.uber.org/fx/service"
@@ -35,8 +33,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/transport/http"
-	tch "go.uber.org/yarpc/transport/tchannel"
 	cfg "go.uber.org/yarpc/x/config"
 	"go.uber.org/zap"
 )
@@ -60,7 +56,7 @@ func New(hookup ServiceCreateFunc, options ...ModuleOption) service.ModuleCreate
 type Module struct {
 	host        service.Host
 	statsClient *statsClient
-	config      yarpcConfig
+	config      configWrapper
 	log         *zap.Logger
 	controller  *dispatcherController
 }
@@ -81,11 +77,11 @@ type transports struct {
 	inbounds []transport.Inbound
 }
 
-type yarpcConfig struct {
+type configWrapper struct {
 	inboundMiddleware       []middleware.UnaryInbound
 	onewayInboundMiddleware []middleware.OnewayInbound
 
-	cfg *yarpc.Config
+	cfg yarpc.Config
 }
 
 type handlerWithDispatcher func(dispatcher *yarpc.Dispatcher) error
@@ -102,13 +98,13 @@ type dispatcherController struct {
 	stopError  error
 	startError error
 
-	configs    []*yarpcConfig
+	configs    []*configWrapper
 	handlers   []handlerWithDispatcher
 	dispatcher yarpc.Dispatcher
 }
 
 // Adds the config to the controller.
-func (c *dispatcherController) addConfig(config yarpcConfig) {
+func (c *dispatcherController) addConfig(config configWrapper) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -136,7 +132,7 @@ func (c *dispatcherController) applyHandlers() error {
 
 // Adds the default middleware: context propagation and auth.
 func (c *dispatcherController) addDefaultMiddleware(host service.Host, statsClient *statsClient) {
-	cfg := yarpcConfig{
+	cfg := configWrapper{
 		inboundMiddleware: []middleware.UnaryInbound{
 			contextInboundMiddleware{host, statsClient},
 			panicInboundMiddleware{statsClient},
@@ -204,12 +200,12 @@ func (c *dispatcherController) Stop() error {
 
 // Merge all the YARPC configs in the collection: transports and middleware are going to be shared.
 // The name comes from the first config in the collection and is the same among all configs.
-func (c *dispatcherController) mergeConfigs(name string) (conf yarpc.Config, err error) {
-	c.RLock()
-	defer c.RUnlock()
+func (controller *dispatcherController) mergeConfigs(name string) (conf yarpc.Config, err error) {
+	controller.RLock()
+	defer controller.RUnlock()
 
 	// Config collection should always have an additional config with the default middleware.
-	if len(c.configs) <= 1 {
+	if len(controller.configs) <= 1 {
 		return conf, errors.New("unable to merge empty configs")
 	}
 
@@ -218,10 +214,10 @@ func (c *dispatcherController) mergeConfigs(name string) (conf yarpc.Config, err
 	// Collect all Inbounds and middleware from all configs
 	var inboundMiddleware []middleware.UnaryInbound
 	var onewayInboundMiddleware []middleware.OnewayInbound
-	for _, cfg := range c.configs {
-		conf.Inbounds = append(conf.Inbounds, cfg.cfg.Inbounds)
-		inboundMiddleware = append(inboundMiddleware, cfg.inboundMiddleware...)
-		onewayInboundMiddleware = append(onewayInboundMiddleware, cfg.onewayInboundMiddleware...)
+	for _, c := range controller.configs {
+		conf.Inbounds = append(conf.Inbounds, c.cfg.Inbounds...)
+		inboundMiddleware = append(inboundMiddleware, c.inboundMiddleware...)
+		onewayInboundMiddleware = append(onewayInboundMiddleware, c.onewayInboundMiddleware...)
 	}
 
 	// Build the inbound middleware
@@ -251,18 +247,19 @@ func newYARPCModule(
 		statsClient: newStatsClient(host.Metrics()),
 		log:         ulog.Logger(context.Background()).With(zap.String("module", host.Name())),
 	}
+
 	if err := host.Config().Scope("modules").Get(host.Name()).PopulateStruct(&module.config); err != nil {
 		return nil, errs.Wrap(err, "can't read inbounds")
 	}
 
 	// iterate over inbounds
 	c, err := cfg.New().LoadConfig(host.Config().Scope("modules").Get(host.Name()).Value())
-	transportsIn, err := prepareInbounds(module.config.Inbounds, host.Name())
 	if err != nil {
-		return nil, errs.Wrap(err, "can't process inbounds")
+		module.log.Error("failed to load config", zap.Error(err))
+		return nil, err
 	}
 
-	module.config.transports.inbounds = transportsIn
+	module.config.cfg = c
 	module.config.inboundMiddleware = moduleOptions.unaryInbounds
 	module.config.onewayInboundMiddleware = moduleOptions.onewayInbounds
 
@@ -294,34 +291,8 @@ func newYARPCModule(
 		return nil
 	})
 
-	module.log.Info("Module successfuly created", zap.Any("inbounds", module.config.Inbounds))
+	module.log.Info("Module successfuly created", zap.Reflect("config", c))
 	return module, nil
-}
-
-// Iterate over all inbounds and prepare corresponding transports
-func prepareInbounds(inbounds []Inbound, serviceName string) (transportsIn []transport.Inbound, err error) {
-	transportsIn = make([]transport.Inbound, 0, 2*len(inbounds))
-	for _, in := range inbounds {
-		if h := in.HTTP; h != nil {
-			transportsIn = append(
-				transportsIn,
-				http.NewTransport().NewInbound(fmt.Sprintf(":%d", h.Port)))
-		}
-
-		if t := in.TChannel; t != nil {
-			chn, err := tch.NewChannelTransport(
-				tch.ServiceName(serviceName),
-				tch.ListenAddr(fmt.Sprintf(":%d", t.Port)))
-
-			if err != nil {
-				return nil, errs.Wrap(err, "can't create tchannel transport")
-			}
-
-			transportsIn = append(transportsIn, chn.NewInbound())
-		}
-	}
-
-	return transportsIn, nil
 }
 
 // Start begins serving requests with YARPC.

--- a/modules/yarpc/yarpc_test.go
+++ b/modules/yarpc/yarpc_test.go
@@ -22,7 +22,6 @@ package yarpc
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"go.uber.org/fx/config"
@@ -33,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/transport/http"
 )
 
 func TestNew_OK(t *testing.T) {
@@ -98,17 +96,17 @@ func TestDispatcher(t *testing.T) {
 	t.Parallel()
 	c := dispatcherController{}
 	host := service.NopHost()
-	c.addConfig(yarpcConfig{transports: transports{inbounds: []transport.Inbound{}}})
+	c.addConfig(configWrapper{cfg:yarpc.Config{}})
 	assert.NoError(t, c.Start(host, newStatsClient(host.Metrics())))
 }
 
 func TestBindToBadPortReturnsError(t *testing.T) {
 	t.Parallel()
 	c := dispatcherController{}
-	cfg := yarpcConfig{
-		transports: transports{
+	cfg := configWrapper{
+		/*transports: transports{
 			inbounds: []transport.Inbound{http.NewTransport().NewInbound("-1")},
-		},
+		},*/
 	}
 
 	c.addConfig(cfg)
@@ -123,21 +121,6 @@ func TestMergeOfEmptyConfigCollectionReturnsError(t *testing.T) {
 	assert.EqualError(t, err, "unable to merge empty configs")
 	host := service.NopHost()
 	assert.EqualError(t, c.Start(host, newStatsClient(host.Metrics())), err.Error())
-}
-
-func TestInboundPrint(t *testing.T) {
-	t.Parallel()
-	var i *Inbound
-	assert.Equal(t, "", fmt.Sprint(i))
-
-	i = &Inbound{}
-	assert.Equal(t, "Inbound:{HTTP: none; TChannel: none}", fmt.Sprint(i))
-	i.HTTP = &Address{8080}
-	assert.Equal(t, "Inbound:{HTTP: 8080; TChannel: none}", fmt.Sprint(i))
-	i.TChannel = &Address{9876}
-	assert.Equal(t, "Inbound:{HTTP: 8080; TChannel: 9876}", fmt.Sprint(i))
-	i.HTTP = nil
-	assert.Equal(t, "Inbound:{HTTP: none; TChannel: 9876}", fmt.Sprint(i))
 }
 
 type testHost struct {


### PR DESCRIPTION
YARPC team is creating a new way to configure dispatcher, which would change the config structure and improves the way it is loaded: 
[Config](https://github.com/yarpc/yarpc-go/pull/747/files)
[Examples](https://github.com/yarpc/yarpc-go/pull/751/files)

This change will show, how we can consume it. For FX the pros of a new config is that parsing is done entirely by YARPC, so we don't have to keep types that mimic yarpc.Config.
Also FX doesn't handle outbounds yet, so eliminated code could be even bigger.