### PR TITLE
Increase module startup timeout to 10 seconds

### DIFF
--- a/service/manager.go
+++ b/service/manager.go
@@ -410,7 +410,10 @@ func (s *manager) startModules() []error {
 					}
 				case <-time.After(defaultStartupWait):
 					lock.Lock()
-					results = append(results, fmt.Errorf("module didn't start after %v", defaultStartupWait))
+					results = append(
+						results,
+						fmt.Errorf("module: %s didn't start after %v", m.Name(), defaultStartupWait),
+					)
 					lock.Unlock()
 				}
 			}

--- a/service/manager.go
+++ b/service/manager.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultStartupWait = 20 * time.Second
+	defaultStartupWait = 10 * time.Second
 )
 
 // Implements Manager interface

--- a/service/manager.go
+++ b/service/manager.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultStartupWait = time.Second
+	defaultStartupWait = 20 * time.Second
 )
 
 // Implements Manager interface


### PR DESCRIPTION
Test service is failing on startup because it;s unable to startup modules in 1 second.
"msg":"Error starting the module","error":"module didn't start after 1s"
