### PR TITLE
Stop running make examples explicitly on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
 script:
   - make lint
   - make test
-  - make examples
 
 after_success:
    - '[ "${TRAVIS_GO_VERSION}" == "1.8" ] && make coveralls'


### PR DESCRIPTION
make lint calls make examples, so there is no need to spend more time on travis builds for this