### PR TITLE
dig: Constructors can now return errors

### DIFF
--- a/dig/dig_setup_test.go
+++ b/dig/dig_setup_test.go
@@ -20,6 +20,8 @@
 
 package dig
 
+import "errors"
+
 // Parent ->
 //     Child1 ->
 //         Grandchild1
@@ -29,6 +31,8 @@ package dig
 //     Child3 ->
 //         GrandchildInt1 (Grandchild1 object)
 //         GrandchildInt2 (Grandchild2 object)
+//     FlakyChild ->
+//         FlakyGrandchild1
 
 type Parent1 struct {
 	c1   *Child1
@@ -143,3 +147,21 @@ func (gc1 *Grandchild2) WhatGrandchild2() string {
 // Grandchild2 struct does not have a constructor on purpose
 // The only way to provide it as a dependency is through object injection
 type Grandchild2 struct{}
+
+type FlakyParent struct {
+	c1 *FlakyChild
+}
+
+func NewFlakyParent(c1 *FlakyChild) (*FlakyParent, error) {
+	return &FlakyParent{c1: c1}, nil
+}
+
+type FlakyChild struct{}
+
+func NewFlakyChild() (*FlakyChild, error) {
+	return &FlakyChild{}, nil
+}
+
+func NewFlakyChildFailure() (*FlakyChild, error) {
+	return nil, errors.New("great sadness")
+}

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -153,6 +153,47 @@ func TestBasicRegisterResolve(t *testing.T) {
 	require.True(t, first == second, "Must point to the same object")
 }
 
+func TestConstructorErrors(t *testing.T) {
+	tests := []struct {
+		desc      string
+		registers []interface{}
+		wantErr   string
+	}{
+		{
+			desc: "success",
+			registers: []interface{}{
+				NewFlakyParent,
+				NewFlakyChild,
+			},
+		},
+		{
+			desc: "failure",
+			registers: []interface{}{
+				NewFlakyParent,
+				NewFlakyChildFailure,
+			},
+			wantErr: "unable to resolve **dig.FlakyParent: " +
+				"unable to resolve *dig.FlakyChild: " +
+				"great sadness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			g := New()
+			require.NoError(t, g.RegisterAll(tt.registers...))
+
+			var p1 *FlakyParent
+			err := g.Resolve(&p1)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestRegisterAll(t *testing.T) {
 	t.Parallel()
 	g := New()

--- a/dig/node.go
+++ b/dig/node.go
@@ -126,9 +126,14 @@ func (n *funcNode) value(g *Graph) (reflect.Value, error) {
 
 	cv := reflect.ValueOf(n.constructor)
 
-	vs := cv.Call(args)
-	v := vs[0]
-	err, _ := vs[1].Interface().(error)
+	values := cv.Call(args)
+	v := values[0]
+
+	// If the function has two return values, the second one is an error.
+	var err error
+	if len(values) > 1 {
+		err, _ = values[1].Interface().(error)
+	}
 
 	n.cached = true
 	n.cachedValue = v


### PR DESCRIPTION
This allows constructors to fail with an error.

    func NewMyResult(...) (*MyResult, error) {
        // ..
    }

The error is wrapped for every layer so that you get,

    unable to resolve Foo:
      unable to resolve *MyResult:
        root cause

This works by changing `funcNode`s to always be functions in the form,

    func(...) ($ResultType, error)

When constructors are initially registered, we wrap them to always return a
`nil` error if they are in the no-error form.

---

CC @glibsm @breerly

I would also like feedback on whether we want error wrapping or not. I think
that if you have a missing dependency, there isn't much you can do to recover
from it so getting the original error back doesn't serve much value. Getting an
error message wrapped in 5 layers of context tells you exactly what failed, why
it failed, and why it was even needed in the first place.

Resolves #283