### PR TITLE
Prototype: interpolation of env vars in YAML

### DIFF
--- a/config/yaml.go
+++ b/config/yaml.go
@@ -41,8 +41,10 @@ type yamlConfigProvider struct {
 }
 
 var (
-	_envSeparator          = []byte(":")
-	_             Provider = &yamlConfigProvider{}
+	_envSeparator = []byte(":")
+	_emptyString  = []byte(`""`)
+
+	_ Provider = &yamlConfigProvider{}
 )
 
 func newYAMLProviderCore(files ...io.ReadCloser) Provider {
@@ -357,7 +359,7 @@ func interpolateEnvVars(data []byte) ([]byte, error) {
 		}
 
 		// return empty byte slices for "" as the default
-		if bytes.Compare(def, []byte(`""`)) == 0 {
+		if bytes.Compare(def, _emptyString) == 0 {
 			return nil
 		}
 

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -327,7 +327,7 @@ func unmarshalYAMLValue(reader io.ReadCloser, value interface{}) error {
 // TODO: what if someone wanted a literal ${FOO} in config? need a small escape hatch
 func interpolateEnvVars(data []byte) ([]byte, error) {
 	// ${VAR_NAME:default} or ${VAR_NAME}
-	reg := regexp.MustCompile(`\$\{\w+:?[\w"]*}`)
+	reg := regexp.MustCompile(`\$\{\w+:?[^}]*}`)
 
 	var regErr error
 	data = reg.ReplaceAllFunc(data, func(in []byte) []byte {

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -350,7 +350,7 @@ func interpolateEnvVars(data []byte) ([]byte, error) {
 		}
 
 		// return the default
-		def := split[1]
+		def := bytes.Join(split[1:], _envSeparator)
 		if len(def) == 0 {
 			errs = append(errs, fmt.Sprintf(`default is empty for %s (use "" for empty string)`, key))
 			return in

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -25,11 +25,14 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	"strconv"
 )
 
 type yamlConfigProvider struct {
@@ -37,7 +40,10 @@ type yamlConfigProvider struct {
 	vCache map[string]Value
 }
 
-var _ Provider = &yamlConfigProvider{}
+var (
+	_envSeparator          = []byte(":")
+	_             Provider = &yamlConfigProvider{}
+)
 
 func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 	var root interface{} = make(map[interface{}]interface{})
@@ -290,13 +296,68 @@ func (n *yamlNode) Children() []*yamlNode {
 }
 
 func unmarshalYAMLValue(reader io.ReadCloser, value interface{}) error {
-	if data, err := ioutil.ReadAll(reader); err != nil {
-		return err
-	} else if err = yaml.Unmarshal(data, value); err != nil {
+	raw, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return errors.Wrap(err, "failed to read the yaml config")
+	}
+
+	data, err := interpolateEnvVars(raw)
+	if err != nil {
+		return errors.Wrap(err, "failed to interpolate environment variables")
+	}
+
+	if err = yaml.Unmarshal(data, value); err != nil {
 		return err
 	}
 
 	return reader.Close()
+}
+
+// Function pre-parses all the YAML bytes to allow value overrides from the environment
+// For example, if an HTTP_PORT environment variable should be used for the HTTP module
+// port, the config would look like this:
+//
+//   modules:
+//     http:
+//       port: ${HTTP_PORT:8080}
+//
+// In the case that HTTP_PORT is not provided, default value (in this case 8080)
+// will be used
+//
+// TODO: what if someone wanted a literal ${FOO} in config? need a small escape hatch
+func interpolateEnvVars(data []byte) ([]byte, error) {
+	// ${VAR_NAME:default} or ${VAR_NAME}
+	reg := regexp.MustCompile(`\$\{\w+(:\w+)?}`)
+
+	var regErr error
+	data = reg.ReplaceAllFunc(data, func(in []byte) []byte {
+		// remove ${ and }, just look inside the braces
+		valAndMaybeDefault := in[2 : len(in)-1]
+
+		// ${VALUE:DEFAULT} -> VALUE, DEFAULT
+		// ${VALUE} -> VALUE, empty default
+		split := bytes.Split(valAndMaybeDefault, _envSeparator)
+		key := string(split[0])
+
+		if envVal, ok := os.LookupEnv(key); ok {
+			return []byte(envVal)
+		}
+
+		// value not found in the env, lets check if there is a default
+		if len(split) < 2 {
+			regErr = fmt.Errorf("environment variable %s not found and default is not provided", key)
+			return in
+		}
+
+		// return the default
+		return split[1]
+	})
+
+	if regErr != nil {
+		return nil, regErr
+	}
+
+	return data, nil
 }
 
 func getNodeType(val interface{}) nodeType {

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -105,11 +105,11 @@ func TestYAMLEnvInterpolationEmptyString(t *testing.T) {
 	t.Parallel()
 
 	cfg := []byte(`
-name: ""
+name: ${APP_NAME:my shiny app}
 fullTel: 1-800-LOLZ${TELEPHONE_EXTENSION:""}`)
 
 	p := NewYAMLProviderFromBytes(cfg)
-	require.Equal(t, "", p.Get("name").AsString())
+	require.Equal(t, "my shiny app", p.Get("name").AsString())
 	require.Equal(t, "1-800-LOLZ", p.Get("fullTel").AsString())
 }
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -57,7 +57,6 @@ func TestYAMLSimple(t *testing.T) {
 }
 
 func TestYAMLEnvInterpolation(t *testing.T) {
-	t.Parallel()
 	defer env.Override(t, "OWNER_EMAIL", "hello@there.yasss")()
 
 	cfg := []byte(`
@@ -77,12 +76,10 @@ module:
 	require.Equal(t, "hello@there.yasss", owner)
 }
 
-func TestYAMLEnvInterpolationMissingDefault(t *testing.T) {
-	t.Parallel()
-
+func TestYAMLEnvInterpolationMissing(t *testing.T) {
 	cfg := []byte(`
 name: some name here
-owner: ${OWNER_EMAIL}`)
+email: ${EMAIL_ADDRESS}`)
 
 	require.Panics(t, func() {
 		NewYAMLProviderFromBytes(cfg)
@@ -138,7 +135,6 @@ func TestExtends(t *testing.T) {
 }
 
 func TestAppRoot(t *testing.T) {
-	t.Parallel()
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -57,6 +57,7 @@ func TestYAMLSimple(t *testing.T) {
 }
 
 func TestYAMLEnvInterpolation(t *testing.T) {
+	t.Parallel()
 	defer env.Override(t, "OWNER_EMAIL", "hello@there.yasss")()
 
 	cfg := []byte(`
@@ -77,6 +78,8 @@ module:
 }
 
 func TestYAMLEnvInterpolationMissing(t *testing.T) {
+	t.Parallel()
+
 	cfg := []byte(`
 name: some name here
 email: ${EMAIL_ADDRESS}`)
@@ -135,6 +138,8 @@ func TestExtends(t *testing.T) {
 }
 
 func TestAppRoot(t *testing.T) {
+	t.Parallel()
+
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -89,6 +89,30 @@ email: ${EMAIL_ADDRESS}`)
 	})
 }
 
+func TestYAMLEnvInterpolationIncomplete(t *testing.T) {
+	t.Parallel()
+
+	cfg := []byte(`
+name: some name here
+telephone: ${SUPPORT_TEL:}`)
+
+	require.Panics(t, func() {
+		NewYAMLProviderFromBytes(cfg)
+	})
+}
+
+func TestYAMLEnvInterpolationEmptyString(t *testing.T) {
+	t.Parallel()
+
+	cfg := []byte(`
+name: ""
+fullTel: 1-800-LOLZ${TELEPHONE_EXTENSION:""}`)
+
+	p := NewYAMLProviderFromBytes(cfg)
+	require.Equal(t, "", p.Get("name").AsString())
+	require.Equal(t, "1-800-LOLZ", p.Get("fullTel").AsString())
+}
+
 type configStruct struct {
 	AppID string
 	Desc  string

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -101,6 +101,14 @@ telephone: ${SUPPORT_TEL:}`)
 	})
 }
 
+func TestYAMLEnvInterpolationWithColon(t *testing.T) {
+	t.Parallel()
+
+	cfg := []byte(`fullValue: ${MISSING_ENV:this:is:my:value}`)
+	p := NewYAMLProviderFromBytes(cfg)
+	require.Equal(t, "this:is:my:value", p.Get("fullValue").AsString())
+}
+
 func TestYAMLEnvInterpolationEmptyString(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Here is what I'm proposing to completely remove the `envProvider`. I've hard some concerns about going with Regexp and I'm not set in stone on this. We can write a more sophisticated parser, but I'd prefer to keep the functionality to just this use-case. I don't want to add an open-ended template support.

Seems to have worked out pretty well, there is one TODO to think through the syntax of what it looks like if people want to use `${FOO}` as-is (super rare).

/cc @breerly @abhinav for comments