### PR TITLE
Allow modifiable struct handler names in thriftsync

### DIFF
--- a/modules/yarpc/thriftrw-plugin-thriftsync/generate.go
+++ b/modules/yarpc/thriftrw-plugin-thriftsync/generate.go
@@ -33,20 +33,21 @@ const newHandlerTemplate = `
 
 <$pkgname   := .HandlerPackageName>
 <$yarpcServerPath   := .YARPCServer>
+<$handlerStructName   := .HandlerStructName>
 package <$pkgname>
 
 <$context   := import "context">
 <$transport := import "go.uber.org/yarpc/api/transport">
 <$service   := import "go.uber.org/fx/service">
 
-type YARPCHandler struct{
+type <$handlerStructName> struct{
   host <$service>.Host
   // TODO: modify the <.Service.Name> handler with your suitable structure
 }
 
 // NewYARPCThriftHandler for your service
 func NewYARPCThriftHandler(host <$service>.Host) ([]<$transport>.Procedure, error) {
-  handler := &YARPCHandler{
+  handler := &<$handlerStructName>{
     host: host,
   }
   <$yarpcserver := import $yarpcServerPath>
@@ -56,7 +57,7 @@ func NewYARPCThriftHandler(host <$service>.Host) ([]<$transport>.Procedure, erro
 <$name := lower .Service.Name>
 <range .Service.Functions>
 
-func (h *YARPCHandler)<.Name>(ctx <$context>.Context, <range .Arguments> <lowerFirst .Name> <formatType .Type>, <end>)<if .ReturnType> (<formatType .ReturnType>, error) <else> error <end> {
+func (h *<$handlerStructName>)<.Name>(ctx <$context>.Context, <range .Arguments> <lowerFirst .Name> <formatType .Type>, <end>)<if .ReturnType> (<formatType .ReturnType>, error) <else> error <end> {
   // TODO: write your code here
   panic("To be implemented")
 }

--- a/modules/yarpc/thriftrw-plugin-thriftsync/main.go
+++ b/modules/yarpc/thriftrw-plugin-thriftsync/main.go
@@ -37,6 +37,9 @@ var (
 	_baseDir = flag.String("base-dir",
 		"server",
 		"Path from root where handlers should live")
+	_handlerStructName = flag.String("handler-struct",
+		"YARPCHandler",
+		"Struct name of the handler")
 	_handlerPackageName = flag.String("handler-package",
 		"server",
 		"Handler package name, defaults to 'main'")
@@ -77,6 +80,7 @@ func (generator) Generate(req *api.GenerateServiceRequest) (*api.GenerateService
 			Service            *api.Service
 			Parent             *api.Service
 			ParentModule       *api.Module
+			HandlerStructName  string
 			HandlerPackageName string
 			YARPCServer        string
 		}{
@@ -84,6 +88,7 @@ func (generator) Generate(req *api.GenerateServiceRequest) (*api.GenerateService
 			Service:            service,
 			Parent:             parent,
 			ParentModule:       parentModule,
+			HandlerStructName:  *_handlerStructName,
 			HandlerPackageName: *_handlerPackageName,
 			YARPCServer:        fmt.Sprintf("%s/%sserver", module.ImportPath, strings.ToLower(service.Name)),
 		}
@@ -100,7 +105,7 @@ func (generator) Generate(req *api.GenerateServiceRequest) (*api.GenerateService
 			files[gofilePath] = handlerContents
 		} else {
 			f := NewUpdater(opts)
-			if err := f.UpdateExistingHandlerFile(service, gofilePath, *_baseDir); err != nil {
+			if err := f.UpdateExistingHandlerFile(service, gofilePath, *_baseDir, *_handlerStructName); err != nil {
 				return nil, err
 			} else if err = f.RefreshAll(service, gofilePath); err != nil {
 				return nil, err


### PR DESCRIPTION
Providing some additional functionality with naming. Currently the handler structs are named as "YARPCHandler". Now this can be configured in thriftsync args. 