### PR TITLE
Fix race condition that caused flaky task test failure

### DIFF
--- a/modules/task/backend_test.go
+++ b/modules/task/backend_test.go
@@ -33,7 +33,7 @@ import (
 
 func withBackendSetup(t *testing.T, backend Backend) func() {
 	_globalBackend = backend
-	_ = _globalBackend.Start()
+	require.NoError(t, _globalBackend.Start())
 	return func() {
 		assert.NoError(t, _globalBackend.Stop())
 		_globalBackend = NopBackend{}

--- a/modules/task/execution_test.go
+++ b/modules/task/execution_test.go
@@ -40,13 +40,16 @@ var (
 	_ctx       = context.Background()
 )
 
-func init() {
+func globalBackendSetup() func() {
 	host, _ := service.NewScopedHost(service.NopHost(), "task", "hello")
 	_testScope = host.Metrics()
 	_globalBackend = NewInMemBackend(host)
 	_ = _globalBackend.Start()
 	_errorCh = _globalBackend.(*inMemBackend).ErrorCh()
-	_globalBackend.Encoder().Register(context.Background())
+	return func() {
+		_globalBackend.Stop()
+		_globalBackend = NopBackend{}
+	}
 }
 
 func TestRegisterNonFunction(t *testing.T) {
@@ -114,21 +117,33 @@ func TestEnqueueWithoutRegister(t *testing.T) {
 }
 
 func TestConsumeWithoutRegister(t *testing.T) {
+	host, _ := service.NewScopedHost(service.NopHost(), "task", "hello")
+	_testScope = host.Metrics()
+	_globalBackend = NewInMemBackend(host)
+	_errorCh = _globalBackend.(*inMemBackend).ErrorCh()
+	defer func() {
+		_globalBackend.Stop()
+		_globalBackend = NopBackend{}
+	}()
 	fn := func(ctx context.Context, num float64) error { return nil }
 	err := Register(fn)
 	require.NoError(t, err)
 	err = Enqueue(fn, _ctx, float64(1.0))
 	require.NoError(t, err)
+	// This clears the previous register
 	fnLookup.setFnNameMap(make(map[string]interface{}))
+	// Start after clearing the register to avoid race condition where consume happens before clearing
+	_ = _globalBackend.Start()
 	err = <-_errorCh
 	require.Error(t, err)
 	assert.Contains(
-		t, err.Error(), "\"go.uber.org/fx/modules/task.TestConsumeWithoutRegister.func1\""+
+		t, err.Error(), "\"go.uber.org/fx/modules/task.TestConsumeWithoutRegister.func2\""+
 			" not found",
 	)
 }
 
 func TestEnqueueEncodingError(t *testing.T) {
+	defer globalBackendSetup()()
 	// Struct with all private members cannot be encoded
 	type prStr struct {
 		a int
@@ -143,12 +158,14 @@ func TestEnqueueEncodingError(t *testing.T) {
 }
 
 func TestRunDecodeError(t *testing.T) {
+	defer globalBackendSetup()()
 	err := Run(context.Background(), []byte{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to decode the message")
 }
 
 func TestEnqueueNoArgsFn(t *testing.T) {
+	defer globalBackendSetup()()
 	err := Register(OnlyContext)
 	require.NoError(t, err)
 	err = Enqueue(OnlyContext, _ctx)
@@ -158,6 +175,7 @@ func TestEnqueueNoArgsFn(t *testing.T) {
 }
 
 func TestEnqueueSimpleFn(t *testing.T) {
+	defer globalBackendSetup()()
 	err := Register(SimpleWithError)
 	require.NoError(t, err)
 	err = Enqueue(SimpleWithError, _ctx, "hello")
@@ -176,6 +194,7 @@ func TestEnqueueSimpleFn(t *testing.T) {
 }
 
 func TestEnqueueMapFn(t *testing.T) {
+	defer globalBackendSetup()()
 	fn := func(ctx context.Context, arg map[string]string) error { return nil }
 	err := Register(fn)
 	require.NoError(t, err)
@@ -186,6 +205,7 @@ func TestEnqueueMapFn(t *testing.T) {
 }
 
 func TestEnqueueFnClosure(t *testing.T) {
+	defer globalBackendSetup()()
 	var wg sync.WaitGroup
 	fn := func(ctx context.Context) error { return nil }
 	wg.Add(1)
@@ -210,6 +230,7 @@ func TestEnqueueFnClosure(t *testing.T) {
 }
 
 func TestEnqueueWithStructFnWithError(t *testing.T) {
+	defer globalBackendSetup()()
 	require.NoError(t, Register(WithStruct))
 	err := Enqueue(WithStruct, _ctx, Car{Brand: "infinity", Year: 2017})
 	require.NoError(t, err)

--- a/modules/task/task_test.go
+++ b/modules/task/task_test.go
@@ -22,7 +22,6 @@ package task
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -63,7 +62,6 @@ func TestMemBackendModuleWorkflowWithContext(t *testing.T) {
 	b := createModule(t, _memBackendFn) // we will just get the singleton in mem backend here
 	require.NoError(t, b.Start())
 	fn := func(ctx context.Context) error {
-		fmt.Printf("Hello")
 		return errors.New("hello error")
 	}
 	require.NoError(t, Register(fn))


### PR DESCRIPTION
TestConsumeWithoutRegister was failing intermittently depending on whether the enqueued message was consumed before or after clearing the register cache. Fixed this by starting consume only after the register cache is cleared.