### PR TITLE
Do not run make lint on pushes with overcommit

### DIFF
--- a/.build/check_lint.sh
+++ b/.build/check_lint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Overcommit requires custom commands to be checked in
-make lint

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -48,11 +48,6 @@ PreCommit:
     exclude:
       - '.build/*.sh'
 
-PrePush:
-  UberfxGoLint:
-    enabled: true
-    required_executable: './.build/check_lint.sh'
-
 #PostCheckout:
 #  ALL: # Special hook name that customizes all hooks of this type
 #    quiet: true # Change all post-checkout hooks to only display output on failure


### PR DESCRIPTION
While I am working on speeding up the dev process here, I want to remove `make lint` from being run on pushes. @glibsm has argued that it prevents bad builds from going into CI, but I argue it just adds 40 seconds to the push process - this is what CI is for. If you really want to do this and make sure there are not bad builds, you really should be running `make dockerci` - `make lint` only catches some stuff. So right now, the push hook checks some stuff but not all, so there still can be bad builds, and if you want the push hook to check for bad builds, it should just run `make dockerci`, but this is exactly what travis does anyways, so why make the time to check a push twice as long? Just let travis do what it does.