### PR TITLE
Add ability to use unmarshaller on a channel or a function

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -181,13 +181,14 @@ Note that any fields you wish to deserialize into must be exported, just like
 Current performance benchmark data:
 
 ```
-BenchmarkYAMLCreateSingleFile-8                    	   50000	     31345 ns/op	   11144 B/op	     122 allocs/op
-BenchmarkYAMLCreateMultiFile-8                     	   30000	     51927 ns/op	   20080 B/op	     207 allocs/op
-BenchmarkYAMLSimpleGetLevel1-8                     	50000000	        26.8 ns/op	       0 B/op	       0 allocs/op
-BenchmarkYAMLSimpleGetLevel3-8                     	50000000	        27.3 ns/op	       0 B/op	       0 allocs/op
-BenchmarkYAMLSimpleGetLevel7-8                     	50000000	        26.2 ns/op	       0 B/op	       0 allocs/op
-BenchmarkYAMLPopulateStruct-8                      	 1000000	      1598 ns/op	     576 B/op	      16 allocs/op
-BenchmarkYAMLPopulateStructNested-8                	  300000	      3972 ns/op	    1056 B/op	      42 allocs/op
-BenchmarkYAMLPopulateStructNestedMultipleFiles-8   	  300000	      5013 ns/op	    1248 B/op	      52 allocs/op
-BenchmarkYAMLPopulateNestedTextUnmarshaler-8       	  100000	     18209 ns/op	    3368 B/op	     211 allocs/op
+BenchmarkYAMLCreateSingleFile-8                    	   50000	     30528 ns/op	   11112 B/op	     121 allocs/op
+BenchmarkYAMLCreateMultiFile-8                     	   30000	     50135 ns/op	   20016 B/op	     205 allocs/op
+BenchmarkYAMLSimpleGetLevel1-8                     	50000000	        28.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkYAMLSimpleGetLevel3-8                     	50000000	        27.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkYAMLSimpleGetLevel7-8                     	50000000	        26.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkYAMLPopulateStruct-8                      	 1000000	      1544 ns/op	     576 B/op	      16 allocs/op
+BenchmarkYAMLPopulateStructNested-8                	  300000	      3903 ns/op	    1056 B/op	      42 allocs/op
+BenchmarkYAMLPopulateStructNestedMultipleFiles-8   	  300000	      5007 ns/op	    1248 B/op	      52 allocs/op
+BenchmarkYAMLPopulateNestedTextUnmarshaler-8       	  100000	     17747 ns/op	    3368 B/op	     211 allocs/op
+BenchmarkZapConfigLoad-8                           	  100000	     20968 ns/op	    3289 B/op	     178 allocs/op
 ```

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -318,6 +318,10 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	}
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
+	if !value.CanAddr() {
+		return fmt.Errorf("can't use TextUnmarshaller because %s is not addressable", key)
+	}
+
 	switch t := value.Addr().Interface().(type) {
 	case encoding.TextUnmarshaler:
 		return t.UnmarshalText([]byte(str))

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -22,8 +22,8 @@ package config
 
 import (
 	"bytes"
-	"fmt"
 	"encoding"
+	"fmt"
 	"reflect"
 	"strconv"
 
@@ -309,7 +309,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	v := d.getGlobalProvider().Get(key)
 	if v.HasValue() {
 		str = v.String()
-	} else  if str == "" {
+	} else if str == "" {
 		return nil
 	}
 
@@ -318,7 +318,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	}
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
-	switch t := value.Addr().Interface().(type){
+	switch t := value.Addr().Interface().(type) {
 	case encoding.TextUnmarshaler:
 		return t.UnmarshalText([]byte(str))
 	}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -319,7 +319,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
 	if !value.CanAddr() {
-		return fmt.Errorf("can't use TextUnmarshaller because %s is not addressable", key)
+		return fmt.Errorf("can't use TextUnmarshaller because %q is not addressable", key)
 	}
 
 	switch t := value.Addr().Interface().(type) {

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -23,6 +23,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"encoding"
 	"reflect"
 	"strconv"
 
@@ -294,6 +295,37 @@ func (d *decoder) pointer(name string, value reflect.Value, def string) error {
 	return d.unmarshal(name, value.Elem(), def)
 }
 
+// Sets value to a channel type.
+func (d *decoder) channel(key string, value reflect.Value, def string) error {
+	return d.textUnmarshaller(key, value, def)
+}
+
+// Sets value to a function type.
+func (d *decoder) function(key string, value reflect.Value, def string) error {
+	return d.textUnmarshaller(key, value, def)
+}
+
+func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) error {
+	v := d.getGlobalProvider().Get(key)
+	if v.HasValue() {
+		str = v.String()
+	} else  if str == "" {
+		return nil
+	}
+
+	if value.IsNil() {
+		value.Set(reflect.New(value.Type()).Elem())
+	}
+
+	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
+	switch t := value.Addr().Interface().(type){
+	case encoding.TextUnmarshaler:
+		return t.UnmarshalText([]byte(str))
+	}
+
+	return nil
+}
+
 // Check if a value is a pointer and decoder set it before.
 // TODO(alsam) print only elements in the loop, not all elements.
 func (d *decoder) checkCycles(value reflect.Value) error {
@@ -340,9 +372,9 @@ func (d *decoder) unmarshal(name string, value reflect.Value, def string) error 
 	case reflect.Interface:
 		return d.mapping(name, value, def)
 	case reflect.Chan:
-		return nil
+		return d.channel(name, value, def)
 	case reflect.Func:
-		return nil
+		return d.function(name, value, def)
 	default:
 		return d.scalar(name, value, def)
 	}

--- a/config/doc.go
+++ b/config/doc.go
@@ -196,15 +196,16 @@
 //
 // Current performance benchmark data:
 //
-//   BenchmarkYAMLCreateSingleFile-8                    	   50000	     31345 ns/op	   11144 B/op	     122 allocs/op
-//   BenchmarkYAMLCreateMultiFile-8                     	   30000	     51927 ns/op	   20080 B/op	     207 allocs/op
-//   BenchmarkYAMLSimpleGetLevel1-8                     	50000000	        26.8 ns/op	       0 B/op	       0 allocs/op
-//   BenchmarkYAMLSimpleGetLevel3-8                     	50000000	        27.3 ns/op	       0 B/op	       0 allocs/op
-//   BenchmarkYAMLSimpleGetLevel7-8                     	50000000	        26.2 ns/op	       0 B/op	       0 allocs/op
-//   BenchmarkYAMLPopulateStruct-8                      	 1000000	      1598 ns/op	     576 B/op	      16 allocs/op
-//   BenchmarkYAMLPopulateStructNested-8                	  300000	      3972 ns/op	    1056 B/op	      42 allocs/op
-//   BenchmarkYAMLPopulateStructNestedMultipleFiles-8   	  300000	      5013 ns/op	    1248 B/op	      52 allocs/op
-//   BenchmarkYAMLPopulateNestedTextUnmarshaler-8       	  100000	     18209 ns/op	    3368 B/op	     211 allocs/op
+//   BenchmarkYAMLCreateSingleFile-8                    	   50000	     30528 ns/op	   11112 B/op	     121 allocs/op
+//   BenchmarkYAMLCreateMultiFile-8                     	   30000	     50135 ns/op	   20016 B/op	     205 allocs/op
+//   BenchmarkYAMLSimpleGetLevel1-8                     	50000000	        28.4 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkYAMLSimpleGetLevel3-8                     	50000000	        27.2 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkYAMLSimpleGetLevel7-8                     	50000000	        26.9 ns/op	       0 B/op	       0 allocs/op
+//   BenchmarkYAMLPopulateStruct-8                      	 1000000	      1544 ns/op	     576 B/op	      16 allocs/op
+//   BenchmarkYAMLPopulateStructNested-8                	  300000	      3903 ns/op	    1056 B/op	      42 allocs/op
+//   BenchmarkYAMLPopulateStructNestedMultipleFiles-8   	  300000	      5007 ns/op	    1248 B/op	      52 allocs/op
+//   BenchmarkYAMLPopulateNestedTextUnmarshaler-8       	  100000	     17747 ns/op	    3368 B/op	     211 allocs/op
+//   BenchmarkZapConfigLoad-8                           	  100000	     20968 ns/op	    3289 B/op	     178 allocs/op
 //
 //
 package config

--- a/config/value.go
+++ b/config/value.go
@@ -161,9 +161,9 @@ func (cv Value) ChildKeys() []string {
 	return nil
 }
 
-// String prints out underline value in Value with fmt.Srpintf.
+// String prints out underline value in Value with fmt.Sprintf.
 func (cv Value) String() string {
-	return fmt.Sprintf("%v", cv.value)
+	return fmt.Sprintf("%v", cv.Value())
 }
 
 // TryAsString attempts to return the configuration value as a string

--- a/config/yaml_benchmark_test.go
+++ b/config/yaml_benchmark_test.go
@@ -21,6 +21,7 @@
 package config
 
 import (
+	"go.uber.org/zap"
 	"testing"
 )
 
@@ -146,6 +147,23 @@ func BenchmarkYAMLPopulateNestedTextUnmarshaler(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		p.Get(Root).PopulateStruct(s)
+	}
+}
+
+func BenchmarkZapConfigLoad(b *testing.B) {
+	yaml := []byte(`
+level: info
+encoderConfig:
+  levelEncoder: color
+`)
+	p := NewYAMLProviderFromBytes(yaml)
+	cfg := &zap.Config{}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if err := p.Get(Root).PopulateStruct(cfg); err != nil {
+			b.Error(err)
+		}
 	}
 }
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -22,8 +22,8 @@ package config
 
 import (
 	"bytes"
-	"fmt"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -666,7 +666,7 @@ Say:
 
 type unmarshallerChan chan string
 
-func (m *unmarshallerChan) UnmarshalText(text []byte) error{
+func (m *unmarshallerChan) UnmarshalText(text []byte) error {
 	name := string(text)
 	if name == "error" {
 		return errors.New("unmarshaller channel error")
@@ -678,7 +678,7 @@ func (m *unmarshallerChan) UnmarshalText(text []byte) error{
 
 type unmarshallerFunc func(string) error
 
-func (m *unmarshallerFunc) UnmarshalText(text []byte) error{
+func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
 	str := string(text)
 	if str == "error" {
 		return errors.New("unmarshaller function error")
@@ -701,7 +701,7 @@ func TestHappyUnmarshallerChannelFunction(t *testing.T) {
 		var r Chart
 		p := NewYAMLProviderFromBytes(src)
 		require.NoError(t, p.Get(Root).PopulateStruct(&r))
-		require.Equal(t, band, <- r.Band)
+		require.Equal(t, band, <-r.Band)
 		assert.EqualError(t, r.Song("Get "), song)
 	}
 
@@ -711,12 +711,12 @@ Song: off my cloud
 `)
 
 	tests := map[string]func(){
-		"defaults":func(){f([]byte(``), "Hello Beatles", "Get back")},
-		"custom values":func(){f(b, "Hello Rolling Stones", "Get off my cloud")},
+		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
+		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
 	}
 
 	for k, v := range tests {
-		t.Run(k, func(*testing.T){v()})
+		t.Run(k, func(*testing.T) { v() })
 	}
 }
 
@@ -745,11 +745,11 @@ F: error
 `)
 
 	tests := map[string]func(){
-		"channel error":func(){f(chanError, "unmarshaller channel error")},
-		"function error":func(){f(funcError, "unmarshaller function error")},
+		"channel error":  func() { f(chanError, "unmarshaller channel error") },
+		"function error": func() { f(funcError, "unmarshaller function error") },
 	}
 
 	for k, v := range tests {
-		t.Run(k, func(*testing.T){v()})
+		t.Run(k, func(*testing.T) { v() })
 	}
 }


### PR DESCRIPTION
Struct fields can be functions or channels and we skip them right now, but some libraries e.g. Zap uses fields with these types and implement TextUnmarshaller to read configs: [LevelEncoder](https://github.com/uber-go/zap/blob/14d784558fd634fc33059b52572035ed2a1a99f3/zapcore/encoder.go#L68)

With this PR we can read these types.