### PR TITLE
Move interface parsing from map to its own method

### DIFF
--- a/config/decoder.go
+++ b/config/decoder.go
@@ -22,9 +22,13 @@ package config
 
 import (
 	"bytes"
+<<<<<<< HEAD
 	"encoding"
 	"fmt"
+=======
+>>>>>>> Fix fmt
 	"encoding"
+	"fmt"
 	"reflect"
 	"strconv"
 
@@ -311,10 +315,14 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	if v.HasValue() {
 		str = v.String()
 <<<<<<< HEAD
+<<<<<<< HEAD
 	} else if str == "" {
 =======
 	} else  if str == "" {
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+	} else if str == "" {
+>>>>>>> Fix fmt
 		return nil
 	}
 
@@ -324,6 +332,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
 <<<<<<< HEAD
+<<<<<<< HEAD
 	if !value.CanAddr() {
 		return fmt.Errorf("can't use TextUnmarshaller because %q is not addressable", key)
 	}
@@ -332,6 +341,9 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 =======
 	switch t := value.Addr().Interface().(type){
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+	switch t := value.Addr().Interface().(type) {
+>>>>>>> Fix fmt
 	case encoding.TextUnmarshaler:
 		return t.UnmarshalText([]byte(str))
 	}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -237,8 +237,13 @@ func (d *decoder) iface(key string, value reflect.Value, def string) error {
 		return nil
 	}
 
-	value.Set(reflect.ValueOf(v.Value()))
-	return nil
+	src := reflect.ValueOf(v.Value())
+	if src.Type().Implements(value.Type()) {
+		value.Set(src)
+		return nil
+	}
+
+	return fmt.Errorf("%v doesn't implement to %v", src.Type(), value.Type())
 }
 
 // Sets value to an object type.

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -22,11 +22,6 @@ package config
 
 import (
 	"bytes"
-<<<<<<< HEAD
-	"encoding"
-	"fmt"
-=======
->>>>>>> Fix fmt
 	"encoding"
 	"fmt"
 	"reflect"
@@ -323,15 +318,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	v := d.getGlobalProvider().Get(key)
 	if v.HasValue() {
 		str = v.String()
-<<<<<<< HEAD
-<<<<<<< HEAD
 	} else if str == "" {
-=======
-	} else  if str == "" {
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
-	} else if str == "" {
->>>>>>> Fix fmt
 		return nil
 	}
 
@@ -340,19 +327,11 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	}
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
-<<<<<<< HEAD
-<<<<<<< HEAD
 	if !value.CanAddr() {
 		return fmt.Errorf("can't use TextUnmarshaller because %q is not addressable", key)
 	}
 
 	switch t := value.Addr().Interface().(type) {
-=======
-	switch t := value.Addr().Interface().(type){
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
-	switch t := value.Addr().Interface().(type) {
->>>>>>> Fix fmt
 	case encoding.TextUnmarshaler:
 		return t.UnmarshalText([]byte(str))
 	}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -205,13 +205,6 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 	}
 
 	val := v.Value()
-
-	// We fallthrough for interface to maps
-	if valueType.Kind() == reflect.Interface {
-		value.Set(reflect.ValueOf(val))
-		return nil
-	}
-
 	destMap := reflect.ValueOf(reflect.MakeMap(valueType).Interface())
 
 	// child yamlNode parsed from yaml file is of type map[interface{}]interface{}
@@ -233,6 +226,18 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 		value.Set(destMap)
 	}
 
+	return nil
+}
+
+// Sets value to an interface type.
+func (d *decoder) iface(key string, value reflect.Value, def string) error {
+	v := d.getGlobalProvider().Get(key)
+
+	if !v.HasValue() || v.Value() == nil {
+		return nil
+	}
+
+	value.Set(reflect.ValueOf(v.Value()))
 	return nil
 }
 
@@ -395,7 +400,7 @@ func (d *decoder) unmarshal(name string, value reflect.Value, def string) error 
 	case reflect.Map:
 		return d.mapping(name, value, def)
 	case reflect.Interface:
-		return d.mapping(name, value, def)
+		return d.iface(name, value, def)
 	case reflect.Chan:
 		return d.channel(name, value, def)
 	case reflect.Func:

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"encoding"
 	"fmt"
+	"encoding"
 	"reflect"
 	"strconv"
 
@@ -309,7 +310,11 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	v := d.getGlobalProvider().Get(key)
 	if v.HasValue() {
 		str = v.String()
+<<<<<<< HEAD
 	} else if str == "" {
+=======
+	} else  if str == "" {
+>>>>>>> Add ability to unmarshal channel and functional fields
 		return nil
 	}
 
@@ -318,11 +323,15 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	}
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
+<<<<<<< HEAD
 	if !value.CanAddr() {
 		return fmt.Errorf("can't use TextUnmarshaller because %q is not addressable", key)
 	}
 
 	switch t := value.Addr().Interface().(type) {
+=======
+	switch t := value.Addr().Interface().(type){
+>>>>>>> Add ability to unmarshal channel and functional fields
 	case encoding.TextUnmarshaler:
 		return t.UnmarshalText([]byte(str))
 	}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -242,7 +242,7 @@ func (d *decoder) iface(key string, value reflect.Value, def string) error {
 		return nil
 	}
 
-	return fmt.Errorf("%v doesn't implement %v", src.Type(), value.Type())
+	return fmt.Errorf("%q doesn't implement %q", src.Type(), value.Type())
 }
 
 // Sets value to an object type.

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -232,7 +232,6 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 // Sets value to an interface type.
 func (d *decoder) iface(key string, value reflect.Value, def string) error {
 	v := d.getGlobalProvider().Get(key)
-
 	if !v.HasValue() || v.Value() == nil {
 		return nil
 	}
@@ -243,7 +242,7 @@ func (d *decoder) iface(key string, value reflect.Value, def string) error {
 		return nil
 	}
 
-	return fmt.Errorf("%v doesn't implement to %v", src.Type(), value.Type())
+	return fmt.Errorf("%v doesn't implement %v", src.Type(), value.Type())
 }
 
 // Sets value to an object type.

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -22,9 +22,13 @@ package config
 
 import (
 	"bytes"
+<<<<<<< HEAD
 	"errors"
 	"fmt"
+=======
+>>>>>>> Fix fmt
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -668,10 +672,14 @@ Say:
 type unmarshallerChan chan string
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (m *unmarshallerChan) UnmarshalText(text []byte) error {
 =======
 func (m *unmarshallerChan) UnmarshalText(text []byte) error{
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+func (m *unmarshallerChan) UnmarshalText(text []byte) error {
+>>>>>>> Fix fmt
 	name := string(text)
 	if name == "error" {
 		return errors.New("unmarshaller channel error")
@@ -684,10 +692,14 @@ func (m *unmarshallerChan) UnmarshalText(text []byte) error{
 type unmarshallerFunc func(string) error
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
 =======
 func (m *unmarshallerFunc) UnmarshalText(text []byte) error{
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
+>>>>>>> Fix fmt
 	str := string(text)
 	if str == "error" {
 		return errors.New("unmarshaller function error")
@@ -711,10 +723,14 @@ func TestHappyUnmarshallerChannelFunction(t *testing.T) {
 		p := NewYAMLProviderFromBytes(src)
 		require.NoError(t, p.Get(Root).PopulateStruct(&r))
 <<<<<<< HEAD
+<<<<<<< HEAD
 		require.Equal(t, band, <-r.Band)
 =======
 		require.Equal(t, band, <- r.Band)
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+		require.Equal(t, band, <-r.Band)
+>>>>>>> Fix fmt
 		assert.EqualError(t, r.Song("Get "), song)
 	}
 
@@ -724,6 +740,7 @@ Song: off my cloud
 `)
 
 	tests := map[string]func(){
+<<<<<<< HEAD
 <<<<<<< HEAD
 		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
 		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
@@ -739,6 +756,14 @@ Song: off my cloud
 	for k, v := range tests {
 		t.Run(k, func(*testing.T){v()})
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
+		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
+	}
+
+	for k, v := range tests {
+		t.Run(k, func(*testing.T) { v() })
+>>>>>>> Fix fmt
 	}
 }
 
@@ -768,6 +793,7 @@ F: error
 
 	tests := map[string]func(){
 <<<<<<< HEAD
+<<<<<<< HEAD
 		"channel error":  func() { f(chanError, "unmarshaller channel error") },
 		"function error": func() { f(funcError, "unmarshaller function error") },
 	}
@@ -779,10 +805,17 @@ F: error
 =======
 		"channel error":func(){f(chanError, "unmarshaller channel error")},
 		"function error":func(){f(funcError, "unmarshaller function error")},
+=======
+		"channel error":  func() { f(chanError, "unmarshaller channel error") },
+		"function error": func() { f(funcError, "unmarshaller function error") },
+>>>>>>> Fix fmt
 	}
 
 	for k, v := range tests {
-		t.Run(k, func(*testing.T){v()})
+		t.Run(k, func(*testing.T) { v() })
 	}
 }
+<<<<<<< HEAD
 >>>>>>> Add ability to unmarshal channel and functional fields
+=======
+>>>>>>> Fix fmt

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -666,7 +667,11 @@ Say:
 
 type unmarshallerChan chan string
 
+<<<<<<< HEAD
 func (m *unmarshallerChan) UnmarshalText(text []byte) error {
+=======
+func (m *unmarshallerChan) UnmarshalText(text []byte) error{
+>>>>>>> Add ability to unmarshal channel and functional fields
 	name := string(text)
 	if name == "error" {
 		return errors.New("unmarshaller channel error")
@@ -678,7 +683,11 @@ func (m *unmarshallerChan) UnmarshalText(text []byte) error {
 
 type unmarshallerFunc func(string) error
 
+<<<<<<< HEAD
 func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
+=======
+func (m *unmarshallerFunc) UnmarshalText(text []byte) error{
+>>>>>>> Add ability to unmarshal channel and functional fields
 	str := string(text)
 	if str == "error" {
 		return errors.New("unmarshaller function error")
@@ -701,7 +710,11 @@ func TestHappyUnmarshallerChannelFunction(t *testing.T) {
 		var r Chart
 		p := NewYAMLProviderFromBytes(src)
 		require.NoError(t, p.Get(Root).PopulateStruct(&r))
+<<<<<<< HEAD
 		require.Equal(t, band, <-r.Band)
+=======
+		require.Equal(t, band, <- r.Band)
+>>>>>>> Add ability to unmarshal channel and functional fields
 		assert.EqualError(t, r.Song("Get "), song)
 	}
 
@@ -711,12 +724,21 @@ Song: off my cloud
 `)
 
 	tests := map[string]func(){
+<<<<<<< HEAD
 		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
 		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
 	}
 
 	for k, v := range tests {
 		t.Run(k, func(*testing.T) { v() })
+=======
+		"defaults":func(){f([]byte(``), "Hello Beatles", "Get back")},
+		"custom values":func(){f(b, "Hello Rolling Stones", "Get off my cloud")},
+	}
+
+	for k, v := range tests {
+		t.Run(k, func(*testing.T){v()})
+>>>>>>> Add ability to unmarshal channel and functional fields
 	}
 }
 
@@ -745,6 +767,7 @@ F: error
 `)
 
 	tests := map[string]func(){
+<<<<<<< HEAD
 		"channel error":  func() { f(chanError, "unmarshaller channel error") },
 		"function error": func() { f(funcError, "unmarshaller function error") },
 	}
@@ -753,3 +776,13 @@ F: error
 		t.Run(k, func(*testing.T) { v() })
 	}
 }
+=======
+		"channel error":func(){f(chanError, "unmarshaller channel error")},
+		"function error":func(){f(funcError, "unmarshaller function error")},
+	}
+
+	for k, v := range tests {
+		t.Run(k, func(*testing.T){v()})
+	}
+}
+>>>>>>> Add ability to unmarshal channel and functional fields

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -718,10 +718,6 @@ Song: off my cloud
 	for k, v := range tests {
 		t.Run(k, func(*testing.T) { v() })
 	}
-
-	for k, v := range tests {
-		t.Run(k, func(*testing.T) { v() })
-	}
 }
 
 func TestGrumpyUnmarshallerChannelFunction(t *testing.T) {

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -22,11 +22,6 @@ package config
 
 import (
 	"bytes"
-<<<<<<< HEAD
-	"errors"
-	"fmt"
-=======
->>>>>>> Fix fmt
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -671,15 +666,7 @@ Say:
 
 type unmarshallerChan chan string
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (m *unmarshallerChan) UnmarshalText(text []byte) error {
-=======
-func (m *unmarshallerChan) UnmarshalText(text []byte) error{
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
-func (m *unmarshallerChan) UnmarshalText(text []byte) error {
->>>>>>> Fix fmt
 	name := string(text)
 	if name == "error" {
 		return errors.New("unmarshaller channel error")
@@ -691,15 +678,7 @@ func (m *unmarshallerChan) UnmarshalText(text []byte) error {
 
 type unmarshallerFunc func(string) error
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
-=======
-func (m *unmarshallerFunc) UnmarshalText(text []byte) error{
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
-func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
->>>>>>> Fix fmt
 	str := string(text)
 	if str == "error" {
 		return errors.New("unmarshaller function error")
@@ -722,15 +701,7 @@ func TestHappyUnmarshallerChannelFunction(t *testing.T) {
 		var r Chart
 		p := NewYAMLProviderFromBytes(src)
 		require.NoError(t, p.Get(Root).PopulateStruct(&r))
-<<<<<<< HEAD
-<<<<<<< HEAD
 		require.Equal(t, band, <-r.Band)
-=======
-		require.Equal(t, band, <- r.Band)
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
-		require.Equal(t, band, <-r.Band)
->>>>>>> Fix fmt
 		assert.EqualError(t, r.Song("Get "), song)
 	}
 
@@ -740,30 +711,16 @@ Song: off my cloud
 `)
 
 	tests := map[string]func(){
-<<<<<<< HEAD
-<<<<<<< HEAD
 		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
 		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
 	}
 
 	for k, v := range tests {
 		t.Run(k, func(*testing.T) { v() })
-=======
-		"defaults":func(){f([]byte(``), "Hello Beatles", "Get back")},
-		"custom values":func(){f(b, "Hello Rolling Stones", "Get off my cloud")},
-	}
-
-	for k, v := range tests {
-		t.Run(k, func(*testing.T){v()})
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
-		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
-		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
 	}
 
 	for k, v := range tests {
 		t.Run(k, func(*testing.T) { v() })
->>>>>>> Fix fmt
 	}
 }
 
@@ -792,8 +749,6 @@ F: error
 `)
 
 	tests := map[string]func(){
-<<<<<<< HEAD
-<<<<<<< HEAD
 		"channel error":  func() { f(chanError, "unmarshaller channel error") },
 		"function error": func() { f(funcError, "unmarshaller function error") },
 	}
@@ -802,20 +757,3 @@ F: error
 		t.Run(k, func(*testing.T) { v() })
 	}
 }
-=======
-		"channel error":func(){f(chanError, "unmarshaller channel error")},
-		"function error":func(){f(funcError, "unmarshaller function error")},
-=======
-		"channel error":  func() { f(chanError, "unmarshaller channel error") },
-		"function error": func() { f(funcError, "unmarshaller function error") },
->>>>>>> Fix fmt
-	}
-
-	for k, v := range tests {
-		t.Run(k, func(*testing.T) { v() })
-	}
-}
-<<<<<<< HEAD
->>>>>>> Add ability to unmarshal channel and functional fields
-=======
->>>>>>> Fix fmt


### PR DESCRIPTION
Parsing of interface fields is done through fields right now. This PR moves it to its own method and add a check, that a value from config provider actually implements the interface.