### PR TITLE
Remove scope method from the provider interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v1.0.0-beta3 (unreleased)
+* Remove `Scope` method from the `config.Provider` interface.
 
 ## v1.0.0-beta2 (09 Mar 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## v1.0.0-beta3 (unreleased)
-* Remove `Scope` method from the `config.Provider` interface.
+* [Breaking] Simplify Provider interface: remove `Scope` method from the `config.Provider` interface, one can
+  use either ScopedProvider and Value.Get() to access sub fields.
 
 ## v1.0.0-beta2 (09 Mar 2017)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,10 +153,10 @@ func TestScopedAccess(t *testing.T) {
 		NewEnvProvider(defaultEnvPrefix, mapEnvironmentProvider{values: envValues}),
 	)
 
-	provider = provider.Scope("n1")
+	p1 := provider.Get("n1")
 
-	v1 := provider.Get("id1")
-	v2 := provider.Get("idx").WithDefault("nope")
+	v1 := p1.Get("id1")
+	v2 := p1.Get("idx").WithDefault("nope")
 
 	assert.True(t, v1.HasValue())
 	assert.Equal(t, 111, v1.AsInt())
@@ -402,8 +402,8 @@ func TestResolvePathAbs(t *testing.T) {
 func TestEnvProviderWithEmptyPrefix(t *testing.T) {
 	p := NewEnvProvider("", mapEnvironmentProvider{map[string]string{"key": "value"}})
 	require.Equal(t, "value", p.Get("key").AsString())
-	emptyScope := p.Scope("")
+	emptyScope := p.Get("")
 	require.Equal(t, "value", emptyScope.Get("key").AsString())
-	scope := emptyScope.Scope("key")
+	scope := emptyScope.Get("key")
 	require.Equal(t, "value", scope.Get("").AsString())
 }

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -227,7 +227,7 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 // Sets value to an interface type.
 func (d *decoder) iface(key string, value reflect.Value, def string) error {
 	v := d.getGlobalProvider().Get(key)
-  
+
 	if !v.HasValue() || v.Value() == nil {
 		return nil
 	}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -200,13 +200,6 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 	}
 
 	val := v.Value()
-
-	// We fallthrough for interface to maps
-	if valueType.Kind() == reflect.Interface {
-		value.Set(reflect.ValueOf(val))
-		return nil
-	}
-
 	destMap := reflect.ValueOf(reflect.MakeMap(valueType).Interface())
 
 	// child yamlNode parsed from yaml file is of type map[interface{}]interface{}
@@ -228,6 +221,18 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 		value.Set(destMap)
 	}
 
+	return nil
+}
+
+// Sets value to an interface type.
+func (d *decoder) iface(key string, value reflect.Value, def string) error {
+	v := d.getGlobalProvider().Get(key)
+
+	if !v.HasValue() || v.Value() == nil {
+		return nil
+	}
+
+	value.Set(reflect.ValueOf(v.Value()))
 	return nil
 }
 
@@ -370,7 +375,7 @@ func (d *decoder) unmarshal(name string, value reflect.Value, def string) error 
 	case reflect.Map:
 		return d.mapping(name, value, def)
 	case reflect.Interface:
-		return d.mapping(name, value, def)
+		return d.iface(name, value, def)
 	case reflect.Chan:
 		return d.channel(name, value, def)
 	case reflect.Func:

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -22,8 +22,8 @@ package config
 
 import (
 	"bytes"
-	"fmt"
 	"encoding"
+	"fmt"
 	"reflect"
 	"strconv"
 
@@ -309,7 +309,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	v := d.getGlobalProvider().Get(key)
 	if v.HasValue() {
 		str = v.String()
-	} else  if str == "" {
+	} else if str == "" {
 		return nil
 	}
 
@@ -318,7 +318,7 @@ func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) 
 	}
 
 	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
-	switch t := value.Addr().Interface().(type){
+	switch t := value.Addr().Interface().(type) {
 	case encoding.TextUnmarshaler:
 		return t.UnmarshalText([]byte(str))
 	}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -232,8 +232,13 @@ func (d *decoder) iface(key string, value reflect.Value, def string) error {
 		return nil
 	}
 
-	value.Set(reflect.ValueOf(v.Value()))
-	return nil
+	src := reflect.ValueOf(v.Value())
+	if src.Type().Implements(value.Type()) {
+		value.Set(src)
+		return nil
+	}
+
+	return fmt.Errorf("%v doesn't implement to %v", src.Type(), value.Type())
 }
 
 // Sets value to an object type.

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -23,6 +23,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"encoding"
 	"reflect"
 	"strconv"
 
@@ -294,6 +295,37 @@ func (d *decoder) pointer(name string, value reflect.Value, def string) error {
 	return d.unmarshal(name, value.Elem(), def)
 }
 
+// Sets value to a channel type.
+func (d *decoder) channel(key string, value reflect.Value, def string) error {
+	return d.textUnmarshaller(key, value, def)
+}
+
+// Sets value to a function type.
+func (d *decoder) function(key string, value reflect.Value, def string) error {
+	return d.textUnmarshaller(key, value, def)
+}
+
+func (d *decoder) textUnmarshaller(key string, value reflect.Value, str string) error {
+	v := d.getGlobalProvider().Get(key)
+	if v.HasValue() {
+		str = v.String()
+	} else  if str == "" {
+		return nil
+	}
+
+	if value.IsNil() {
+		value.Set(reflect.New(value.Type()).Elem())
+	}
+
+	// Value has to have a pointer receiver to be able to modify itself with TextUnmarshaller
+	switch t := value.Addr().Interface().(type){
+	case encoding.TextUnmarshaler:
+		return t.UnmarshalText([]byte(str))
+	}
+
+	return nil
+}
+
 // Check if a value is a pointer and decoder set it before.
 // TODO(alsam) print only elements in the loop, not all elements.
 func (d *decoder) checkCycles(value reflect.Value) error {
@@ -340,9 +372,9 @@ func (d *decoder) unmarshal(name string, value reflect.Value, def string) error 
 	case reflect.Interface:
 		return d.mapping(name, value, def)
 	case reflect.Chan:
-		return nil
+		return d.channel(name, value, def)
 	case reflect.Func:
-		return nil
+		return d.function(name, value, def)
 	default:
 		return d.scalar(name, value, def)
 	}

--- a/config/env.go
+++ b/config/env.go
@@ -76,10 +76,6 @@ func (p envConfigProvider) Get(key string) Value {
 	return cv
 }
 
-func (p envConfigProvider) Scope(prefix string) Provider {
-	return NewScopedProvider(prefix, p)
-}
-
 func (p envConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Environments don't receive callback events
 	return nil

--- a/config/provider.go
+++ b/config/provider.go
@@ -33,7 +33,6 @@ type Provider interface {
 	Name() string
 	// Get pulls a config value
 	Get(key string) Value
-	Scope(prefix string) Provider
 
 	// A RegisterChangeCallback provides callback registration for config providers.
 	// These callbacks are nop if a dynamic provider is not configured for the service.
@@ -71,15 +70,6 @@ func (sp scopedProvider) addPrefix(key string) string {
 // Get returns configuration value
 func (sp scopedProvider) Get(key string) Value {
 	return sp.Provider.Get(sp.addPrefix(key))
-}
-
-// Scope returns new scoped provider, given a prefix
-func (sp scopedProvider) Scope(prefix string) Provider {
-	if prefix == "" {
-		return sp
-	}
-
-	return NewScopedProvider(sp.addPrefix(prefix), sp.Provider)
 }
 
 // RegisterChangeCallback registers the callback in the underlying provider

--- a/config/provider_group.go
+++ b/config/provider_group.go
@@ -82,7 +82,3 @@ func (p providerGroup) UnregisterChangeCallback(token string) error {
 	}
 	return nil
 }
-
-func (p providerGroup) Scope(prefix string) Provider {
-	return NewScopedProvider(prefix, p)
-}

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -42,7 +42,7 @@ func TestProviderGroupScope(t *testing.T) {
 	t.Parallel()
 	data := map[string]interface{}{"hello": map[string]int{"world": 42}}
 	pg := NewProviderGroup("test-group", NewStaticProvider(data))
-	assert.Equal(t, 42, pg.Scope("hello").Get("world").AsInt())
+	assert.Equal(t, 42, pg.Get("hello").Get("world").AsInt())
 }
 
 func TestCallbacks_WithDynamicProvider(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCallbacks_WithScopedProvider(t *testing.T) {
 	assert.Equal(t, 1, callCount)
 }
 
-func TestScope_WithScopedProvider(t *testing.T) {
+func TestScope_WithGetFromValue(t *testing.T) {
 	t.Parallel()
 	mock := &mockDynamicProvider{}
 	mock.Set("uber.fx", "go-lang")
@@ -106,15 +106,15 @@ func TestScope_WithScopedProvider(t *testing.T) {
 	require.Equal(t, "go-lang", scope.Get("uber.fx").AsString())
 	require.False(t, scope.Get("uber").HasValue())
 
-	base := scope.Scope("uber")
+	base := scope.Get("uber")
 	require.Equal(t, "go-lang", base.Get("fx").AsString())
 	require.False(t, base.Get("").HasValue())
 
-	uber := base.Scope("")
+	uber := base.Get(Root)
 	require.Equal(t, "go-lang", uber.Get("fx").AsString())
 	require.False(t, uber.Get("").HasValue())
 
-	fx := uber.Scope("fx")
+	fx := uber.Get("fx")
 	require.Equal(t, "go-lang", fx.Get("").AsString())
 	require.False(t, fx.Get("fx").HasValue())
 }
@@ -149,10 +149,6 @@ func (s *mockDynamicProvider) Set(key string, value interface{}) {
 	if cb, ok := s.callBacks[key]; ok {
 		cb(key, s.Name(), "randomConfig")
 	}
-}
-
-func (s *mockDynamicProvider) Scope(prefix string) Provider {
-	return NewScopedProvider(prefix, s)
 }
 
 func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -52,7 +52,7 @@ func TestStaticProvider_WithData(t *testing.T) {
 	assert.Equal(t, "world", val.AsString())
 }
 
-func TestStaticProvider_WithScope(t *testing.T) {
+func TestStaticProvider_WithGet(t *testing.T) {
 	data := map[string]interface{}{
 		"hello": map[string]int{"world": 42},
 	}
@@ -61,7 +61,7 @@ func TestStaticProvider_WithScope(t *testing.T) {
 	val := p.Get("hello")
 	assert.True(t, val.HasValue())
 
-	sub := p.Scope("hello")
+	sub := p.Get("hello")
 	val = sub.Get("world")
 	assert.True(t, val.HasValue())
 	assert.Equal(t, 42, val.AsInt())

--- a/config/value.go
+++ b/config/value.go
@@ -287,15 +287,7 @@ func (cv Value) Value() interface{} {
 
 // Get returns a value scoped in the current value
 func (cv Value) Get(key string) Value {
-	if cv.key == "" {
-		return cv.provider.Get(key)
-	}
-
-	if key == "" {
-		return cv
-	}
-
-	return cv.provider.Get(cv.key + _separator + key)
+	return NewScopedProvider(cv.key, cv.provider).Get(key)
 }
 
 // this is a quick-and-dirty conversion method that only handles

--- a/config/value.go
+++ b/config/value.go
@@ -285,6 +285,19 @@ func (cv Value) Value() interface{} {
 	return cv.defaultValue
 }
 
+// Get returns a value scoped in the current value
+func (cv Value) Get(key string) Value {
+	if cv.key == "" {
+		return cv.provider.Get(key)
+	}
+
+	if key == "" {
+		return cv
+	}
+
+	return cv.provider.Get(cv.key + _separator + key)
+}
+
 // this is a quick-and-dirty conversion method that only handles
 // a couple of cases and complains if it finds one it doesn't like.
 // needs a bunch more cases.

--- a/config/value.go
+++ b/config/value.go
@@ -161,9 +161,9 @@ func (cv Value) ChildKeys() []string {
 	return nil
 }
 
-// String prints out underline value in Value with fmt.Srpintf.
+// String prints out underline value in Value with fmt.Sprintf.
 func (cv Value) String() string {
-	return fmt.Sprintf("%v", cv.value)
+	return fmt.Sprintf("%v", cv.Value())
 }
 
 // TryAsString attempts to return the configuration value as a string

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -177,11 +177,6 @@ func (y yamlConfigProvider) Get(key string) Value {
 	return value
 }
 
-// Scope returns a scoped configuration provider
-func (y yamlConfigProvider) Scope(prefix string) Provider {
-	return NewScopedProvider(prefix, y)
-}
-
 func (y yamlConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
 	// Yaml configuration don't receive callback events
 	return nil

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -22,8 +22,8 @@ package config
 
 import (
 	"bytes"
-	"fmt"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -666,7 +666,7 @@ Say:
 
 type unmarshallerChan chan string
 
-func (m *unmarshallerChan) UnmarshalText(text []byte) error{
+func (m *unmarshallerChan) UnmarshalText(text []byte) error {
 	name := string(text)
 	if name == "error" {
 		return errors.New("unmarshaller channel error")
@@ -678,7 +678,7 @@ func (m *unmarshallerChan) UnmarshalText(text []byte) error{
 
 type unmarshallerFunc func(string) error
 
-func (m *unmarshallerFunc) UnmarshalText(text []byte) error{
+func (m *unmarshallerFunc) UnmarshalText(text []byte) error {
 	str := string(text)
 	if str == "error" {
 		return errors.New("unmarshaller function error")
@@ -701,7 +701,7 @@ func TestHappyUnmarshallerChannelFunction(t *testing.T) {
 		var r Chart
 		p := NewYAMLProviderFromBytes(src)
 		require.NoError(t, p.Get(Root).PopulateStruct(&r))
-		require.Equal(t, band, <- r.Band)
+		require.Equal(t, band, <-r.Band)
 		assert.EqualError(t, r.Song("Get "), song)
 	}
 
@@ -711,12 +711,12 @@ Song: off my cloud
 `)
 
 	tests := map[string]func(){
-		"defaults":func(){f([]byte(``), "Hello Beatles", "Get back")},
-		"custom values":func(){f(b, "Hello Rolling Stones", "Get off my cloud")},
+		"defaults":      func() { f([]byte(``), "Hello Beatles", "Get back") },
+		"custom values": func() { f(b, "Hello Rolling Stones", "Get off my cloud") },
 	}
 
 	for k, v := range tests {
-		t.Run(k, func(*testing.T){v()})
+		t.Run(k, func(*testing.T) { v() })
 	}
 }
 
@@ -745,11 +745,11 @@ F: error
 `)
 
 	tests := map[string]func(){
-		"channel error":func(){f(chanError, "unmarshaller channel error")},
-		"function error":func(){f(funcError, "unmarshaller function error")},
+		"channel error":  func() { f(chanError, "unmarshaller channel error") },
+		"function error": func() { f(funcError, "unmarshaller function error") },
 	}
 
 	for k, v := range tests {
-		t.Run(k, func(*testing.T){v()})
+		t.Run(k, func(*testing.T) { v() })
 	}
 }

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -129,7 +129,6 @@ func TestNewYAMLProviderFromReader(t *testing.T) {
 	provider := NewYAMLProviderFromReader(ioutil.NopCloser(buff))
 	cs := &configStruct{}
 	assert.NoError(t, provider.Get(Root).PopulateStruct(cs))
-	assert.Equal(t, "yaml", provider.Scope(Root).Name())
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "owner@service.com", cs.Owner)
 }

--- a/examples/keyvalue/kv/keyvalueclient/client.go
+++ b/examples/keyvalue/kv/keyvalueclient/client.go
@@ -26,10 +26,10 @@ package keyvalueclient
 import (
 	"context"
 	"go.uber.org/fx/examples/keyvalue/kv"
+	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift"
-	"go.uber.org/yarpc"
-	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is a client for the KeyValue service.

--- a/examples/keyvalue/kv/keyvalueserver/server.go
+++ b/examples/keyvalue/kv/keyvalueserver/server.go
@@ -26,9 +26,9 @@ package keyvalueserver
 import (
 	"context"
 	"go.uber.org/fx/examples/keyvalue/kv"
+	"go.uber.org/thriftrw/wire"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift"
-	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is the server-side interface for the KeyValue service.

--- a/examples/keyvalue/kv/keyvaluetest/client.go
+++ b/examples/keyvalue/kv/keyvaluetest/client.go
@@ -25,9 +25,9 @@ package keyvaluetest
 
 import (
 	"context"
+	"github.com/golang/mock/gomock"
 	"go.uber.org/fx/examples/keyvalue/kv/keyvalueclient"
 	"go.uber.org/yarpc"
-	"github.com/golang/mock/gomock"
 )
 
 // MockClient implements a gomock-compatible mock client for service

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -107,7 +107,7 @@ func newModule(
 		Timeout: defaultTimeout,
 	}
 	log := ulog.Logger(context.Background()).With(zap.String("module", host.ModuleName()))
-	if err := host.Config().Scope("modules").Get(host.ModuleName()).PopulateStruct(&cfg); err != nil {
+	if err := host.Config().Get("modules").Get(host.ModuleName()).PopulateStruct(&cfg); err != nil {
 		log.Error("Error loading http module configuration", zap.Error(err))
 	}
 	module := &Module{

--- a/modules/yarpc/yarpc.go
+++ b/modules/yarpc/yarpc.go
@@ -135,7 +135,7 @@ func newModule(
 		statsClient: newStatsClient(host.Metrics()),
 		log:         ulog.Logger(context.Background()).With(zap.String("module", host.ModuleName())),
 	}
-	if err := host.Config().Scope("modules").Get(host.ModuleName()).PopulateStruct(&module.config); err != nil {
+	if err := host.Config().Get("modules").Get(host.ModuleName()).PopulateStruct(&module.config); err != nil {
 		return nil, errs.Wrap(err, "can't read inbounds")
 	}
 


### PR DESCRIPTION
@peter-edge mentioned, that using Scope in Provider is very clumsy and we actually don't really need every Provider to implement Scope method, Get should be enough. Users can either use ScopedProvider to create a new scope for a provider or we can add this functionality to the Value. Users can simply call: 
`config.Get("yarpc").Get("http").Get("port")`
instead of 
`config.Scope("yarpc").Scope("http").Get("port")`