### PR TITLE
Add task.MustRegister which panics on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.0-beta3 (unreleased)
 
-* Add `task.MustRegister` convenience function which fails fast by panic-ing
+* Add `task.MustRegister` convenience function which fails fast by panicking
   Note that this should only be used during app initialization, and is provided
   to avoid repetetive error checking for services which register many tasks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## v1.0.0-beta3 (unreleased)
 
+* Add `task.MustRegister` convenience function which fails fast by panic-ing
+  Note that this should only be used during app initialization, and is provided
+  to avoid repetetive error checking for services which register many tasks.
+
 ## v1.0.0-beta2 (09 Mar 2017)
 
 * [Breaking] Remove `ulog.Logger` interface and expose `*zap.Logger` directly.
 * [Breaking] Rename config and module from `modules.rpc` to `modules.yarpc`
-* [Breaking] Rename config key from `modules.http` to `modules.uhttp` to match the module name
+* [Breaking] Rename config key from `modules.http` to `modules.uhttp` to match
+  the module name
 * [Breaking] Upgrade `zap` to `v1.0.0-rc.3` (now go.uber.org/zap, was
     github.com/uber-go/zap)
 * Remove now-unused `config.IsDevelopmentEnv()` helper to encourage better
@@ -23,7 +28,8 @@
   as it is not thrift-specific.
 * Report version metrics for company-wide version usage information.
 * Allow configurable service name and module name via service options.
-* DIG constructors now support returning a tuple with the second argument being an error.
+* DIG constructors now support returning a tuple with the second argument being
+  an error.
 
 ## v1.0.0-beta1 (20 Feb 2017)
 

--- a/modules/task/execution.go
+++ b/modules/task/execution.go
@@ -133,6 +133,15 @@ func Register(fn interface{}) error {
 	return nil
 }
 
+// MustRegister registers a function for an async task or panics
+// Since Task registration is performed in main() we want to fail-fast and
+// reduce the amount of error-checking
+func MustRegister(fn interface{}) {
+	if err := Register(fn); err != nil {
+		panic(err)
+	}
+}
+
 // Run decodes the message and executes as a task
 func Run(ctx context.Context, message []byte) error {
 	stopwatch := globalBackendStatsClient().TaskExecutionTime().Start()

--- a/modules/task/execution_test.go
+++ b/modules/task/execution_test.go
@@ -95,11 +95,22 @@ func TestRegisterFnWithMismatchedArgCount(t *testing.T) {
 	assert.Contains(t, err.Error(), "2 function arg(s) but found 0")
 }
 
+func TestMustRegisterPanicsOnBadType(t *testing.T) {
+	assert.Panics(t, func() {
+		MustRegister("not a function")
+	})
+}
+
+func TestMustRegisterOkOnGoodFunc(t *testing.T) {
+	assert.NotPanics(t, func() {
+		MustRegister(validTaskFunc)
+	})
+}
+
 func TestEnqueueFnWithMismatchedArgType(t *testing.T) {
-	fn := func(ctx context.Context, s string) error { return nil }
-	err := Register(fn)
+	err := Register(validTaskFunc)
 	require.NoError(t, err)
-	err = Enqueue(fn, _ctx, 1)
+	err = Enqueue(validTaskFunc, _ctx, 1)
 	require.Error(t, err)
 	assert.Contains(
 		t, err.Error(), "argument: 2 from type: int to type: string",
@@ -268,4 +279,8 @@ func TestCastToError(t *testing.T) {
 	err := castToError(reflect.ValueOf(s))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "be error but found")
+}
+
+func validTaskFunc(ctx context.Context, s string) error {
+	return nil
 }


### PR DESCRIPTION
Although panics are generally frowned upon, there are certain cases
where they can make developers' lives easier. Particularly for the task
module, the general use case is that in the `main` func (or some other
func called by `main` during initialization), there is no way to recover
from the error and we want to crash the process.

In abscence of MustRegister, a developer who wishes to register many
tasks must check the error of each, and upon encountering an error will
almost certainly want to exit the program with a non-zero exit code
since the service should not start if the task functions are not
properly defined.

In other words, it turns this:

```go
  if err := task.Register(FirstTaskFunc); err != nil {
    log.Fatal("Could not register task", err.Error())
  }
  if err := task.Register(SecondTaskFunc); err != nil {
    log.Fatal("Could not register task", err.Error())
  }
```

Into this:

```go
  task.MustRegister(FirstTaskFunc)
  task.MustRegister(SecondTaskFunc)
```

Both of which behave semantically similar (although the output may be
slightly different).

This gives developers the flexibility to choose which behavior they
want, similar to `regexp.MustCompile` from the standard library, where a
program should not start if the developer incorrectly constructed a
regular expression.