### PR TITLE
Allow integers to be used for floats in PopulateStruct

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -197,6 +197,21 @@ func TestSimpleConfigValues(t *testing.T) {
 	assert.NoError(t, v.PopulateStruct(nested))
 }
 
+func TestPopulateStructIntToFloat64(t *testing.T) {
+	provider := NewProviderGroup(
+		"test",
+		NewYAMLProviderFromBytes([]byte("foo: 1")),
+	)
+
+	myStruct := struct {
+		Foo float64
+	}{}
+
+	require.NoError(t, provider.Get(Root).PopulateStruct(&myStruct))
+
+	assert.Equal(t, float64(1), myStruct.Foo)
+}
+
 func TestGetAsIntegerValue(t *testing.T) {
 	testCases := []struct {
 		value interface{}

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -61,7 +61,15 @@ func convertValueFromStruct(value interface{}, targetType reflect.Type, fieldTyp
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		fieldValue.SetUint(uint64(value.(int)))
 	case reflect.Float32, reflect.Float64:
-		fieldValue.SetFloat(value.(float64))
+		var valueToSet float64
+
+		switch value := value.(type) {
+		case int:
+			valueToSet = float64(value)
+		default:
+			valueToSet = value.(float64)
+		}
+		fieldValue.SetFloat(valueToSet)
 	case reflect.Bool:
 		fieldValue.SetBool(value.(bool))
 	case reflect.String:


### PR DESCRIPTION
This isn't very elegant, but it does fix the issue.

Open to suggestions.

Verified test fails on master before fix:

```
go test -run=TestPopulateStructIntToFloat64
FAIL | PopulateStructIntToFloat64 (0.00s)
     | panic: interface conversion: interface {} is int, not float64 [recovered]
     |   panic: interface conversion: interface {} is int, not float64
     | goroutine 5 [running]:
     | testing.tRunner.func1(0xc42006f110)
     |   /usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:622 +0x29d
     | panic(0x12f1860, 0xc42001d900)
     |   /usr/local/Cellar/go/1.8/libexec/src/runtime/panic.go:489 +0x2cf
     | go.uber.org/fx/config.convertValueFromStruct(0x12d7a00, 0xc420108570, 0x149a000, 0x12d6740, 0x149a000, 0x12d6740, 0x12d6740, 0xc420108578, 0x18e, 0x12d7a00, ...)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/decoder.go:64 +0x39c
     | go.uber.org/fx/config.(*decoder).scalar(0xc42004de10, 0x12a58d3, 0x3, 0x12d6740, 0xc420108578, 0x18e, 0x0, 0x0, 0x0, 0x0)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/decoder.go:111 +0x327
     | go.uber.org/fx/config.(*decoder).unmarshal(0xc42004de10, 0x12a58d3, 0x3, 0x12d6740, 0xc420108578, 0x18e, 0x0, 0x0, 0x0, 0xc4201085b8)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/decoder.go:347 +0x10a
     | go.uber.org/fx/config.(*decoder).valueStruct(0xc42004de10, 0x0, 0x0, 0x12cf3a0, 0xc420108578, 0x16, 0xc42004dd50)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/decoder.go:276 +0x381
     | go.uber.org/fx/config.(*decoder).object(0xc42004de10, 0x0, 0x0, 0x12cf3a0, 0xc420108578, 0x16, 0xc42004dda8, 0x1099b23)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/decoder.go:242 +0xd5
     | go.uber.org/fx/config.(*decoder).unmarshal(0xc42004de10, 0x0, 0x0, 0x12f4740, 0xc420108578, 0x199, 0x0, 0x0, 0x0, 0xed05674dd)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/decoder.go:333 +0x422
     | go.uber.org/fx/config.Value.PopulateStruct(0x1496360, 0xc420013e30, 0x1496480, 0xc4201085a0, 0x0, 0x0, 0x12ed300, 0xc420013c50, 0x1, 0x0, ...)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/value.go:328 +0x14d
     | go.uber.org/fx/config.TestPopulateStructIntToFloat64(0xc42006f110)
     |   /Users/aiden/src/go/src/go.uber.org/fx/config/config_test.go:210 +0x210
     | testing.tRunner(0xc42006f110, 0x1359650)
     |   /usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:657 +0x96
     | created by testing.(*T).Run
     |   /usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:697 +0x2ca
     | exit status 2
```

References #336