### PR TITLE
Allow overriding list of config files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -206,7 +206,7 @@ func Load() Provider {
 	var static []Provider
 
 	if len(_configFiles) == 0 {
-		_configFiles = getConfigFiles(baseFiles()...)
+		SetConfigFiles(baseFiles()...)
 	}
 	for _, providerFunc := range _staticProviderFuncs {
 		cp, err := providerFunc()

--- a/config/config.go
+++ b/config/config.go
@@ -52,8 +52,8 @@ var (
 
 	_envPrefix            = "APP"
 	_staticProviderFuncs  = []ProviderFunc{YamlProvider(), EnvProvider()}
+	_configFiles          = baseFiles()
 	_dynamicProviderFuncs []DynamicProviderFunc
-	_configFiles          []string
 )
 
 var (
@@ -205,9 +205,6 @@ func UnregisterProviders() {
 func Load() Provider {
 	var static []Provider
 
-	if len(_configFiles) == 0 {
-		SetConfigFiles(baseFiles()...)
-	}
 	for _, providerFunc := range _staticProviderFuncs {
 		cp, err := providerFunc()
 		if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,8 +26,6 @@ import (
 	"path"
 	"testing"
 
-	"go.uber.org/fx/testutils/env"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -100,8 +98,6 @@ bool: true
 int: 123
 string: test string
 `)
-
-var testDatacenter = "TEST_DATACENTER"
 
 type arrayOfStructs struct {
 	Things []nested `yaml:"things"`
@@ -361,7 +357,6 @@ func TestEnvProvider_Callbacks(t *testing.T) {
 
 func TestGetConfigFiles(t *testing.T) {
 	SetEnvironmentPrefix("TEST")
-	defer env.Override(t, testDatacenter, "dc")()
 
 	files := getConfigFiles(baseFiles()...)
 	assert.Contains(t, files, "./base.yaml")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -363,15 +363,22 @@ func TestGetConfigFiles(t *testing.T) {
 	SetEnvironmentPrefix("TEST")
 	defer env.Override(t, testDatacenter, "dc")()
 
-	files := getConfigFiles()
+	files := getConfigFiles(baseFiles()...)
 	assert.Contains(t, files, "./base.yaml")
 	assert.Contains(t, files, "./development.yaml")
 	assert.Contains(t, files, "./secrets.yaml")
-	assert.Contains(t, files, "./development-dc.yaml")
 	assert.Contains(t, files, "./config/base.yaml")
 	assert.Contains(t, files, "./config/development.yaml")
 	assert.Contains(t, files, "./config/secrets.yaml")
-	assert.Contains(t, files, "./config/development-dc.yaml")
+}
+
+func TestSetConfigFiles(t *testing.T) {
+	SetConfigFiles("x", "y")
+	files := getConfigFiles(_configFiles...)
+	assert.Contains(t, files, "./x.yaml")
+	assert.Contains(t, files, "./y.yaml")
+	assert.Contains(t, files, "./config/x.yaml")
+	assert.Contains(t, files, "./config/y.yaml")
 }
 
 func expectedResolvePath(t *testing.T) string {


### PR DESCRIPTION
* removed dc specific details from base config files so that fx users don't have to follow env-dc type config naming. 
* `SetConfigFiles` introduced to allow downstream dependencies to inject set of config files for use