### PR TITLE
Override provider in value returned by Get for group provider

### DIFF
--- a/config/provider_group.go
+++ b/config/provider_group.go
@@ -58,6 +58,7 @@ func (p providerGroup) Get(key string) Value {
 	// here we add a new root, which defines the "scope" at which
 	// PopulateStructs will look for values.
 	cv.root = p
+	cv.provider = p
 	return cv
 }
 

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -119,6 +119,19 @@ func TestScope_WithGetFromValue(t *testing.T) {
 	require.False(t, fx.Get("fx").HasValue())
 }
 
+func TestProviderGroupScopingValue(t *testing.T) {
+	t.Parallel()
+	fst := []byte(`
+logging:`)
+
+	snd := []byte(`
+logging:
+  enabled: true
+`)
+	pg := NewProviderGroup("group", NewYAMLProviderFromBytes(snd), NewYAMLProviderFromBytes(fst))
+	assert.True(t, pg.Get("logging").Get("enabled").AsBool())
+}
+
 type mockDynamicProvider struct {
 	data      map[string]interface{}
 	callBacks map[string]ChangeCallback


### PR DESCRIPTION
Value returned by Get has the provider that returned it, which limit following lookups to only that provider.