### PR TITLE
Add mock dynamic provider

### DIFF
--- a/config/mock_dynamic_provider.go
+++ b/config/mock_dynamic_provider.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"errors"
+	"sync"
+)
+
+// MockDynamicProvider is simple implementation of Provider that can be used to test dynamic features.
+// It is safe to use with multiple go routines, but doesn't support nested objects.
+type MockDynamicProvider struct {
+	sync.RWMutex
+	data      map[string]interface{}
+	callBacks map[string]ChangeCallback
+}
+
+// NewMockDynamicProvider returns a new MockDynamicProvider
+func NewMockDynamicProvider(data map[string]interface{}) *MockDynamicProvider {
+	return &MockDynamicProvider{
+		data: data,
+	}
+}
+
+// Name is MockDynamicProvider
+func (s *MockDynamicProvider) Name() string {
+	return "MockDynamicProvider"
+}
+
+// Get returns a value in the map.
+func (s *MockDynamicProvider) Get(key string) Value {
+	s.RLock()
+	defer s.RUnlock()
+
+	val, found := s.data[key]
+	return NewValue(s, key, val, found, GetType(val), nil)
+}
+
+// Set value to specific key and then calls a corresponding callback.
+func (s *MockDynamicProvider) Set(key string, value interface{}) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.data == nil {
+		s.data = make(map[string]interface{})
+	}
+
+	s.data[key] = value
+	if cb, ok := s.callBacks[key]; ok {
+		cb(key, s.Name(), value)
+	}
+}
+
+// RegisterChangeCallback registers a callback to be called when a value associated with a key will change.
+func (s *MockDynamicProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.callBacks == nil {
+		s.callBacks = make(map[string]ChangeCallback)
+	}
+
+	if _, ok := s.callBacks[key]; ok {
+		return errors.New("callback already registered for the key: " + key)
+	}
+
+	s.callBacks[key] = callback
+	return nil
+}
+
+// UnregisterChangeCallback removes a callback associated with a token.
+func (s *MockDynamicProvider) UnregisterChangeCallback(token string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.callBacks == nil {
+		s.callBacks = make(map[string]ChangeCallback)
+	}
+
+	if _, ok := s.callBacks[token]; !ok {
+		return errors.New("there is no registered callback for token: " + token)
+	}
+
+	delete(s.callBacks, token)
+	return nil
+}

--- a/config/mock_dynamic_provider.go
+++ b/config/mock_dynamic_provider.go
@@ -21,8 +21,9 @@
 package config
 
 import (
-	"errors"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // MockDynamicProvider is simple implementation of Provider that can be used to test dynamic features.

--- a/config/mock_dynamic_provider_test.go
+++ b/config/mock_dynamic_provider_test.go
@@ -90,14 +90,20 @@ func TestMockDynamicProvider_UnregisterChangeCallback(t *testing.T) {
 	})
 
 	errChan := make(chan error, 1)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
 	unregister := func() {
 		if err := p.UnregisterChangeCallback("goofy"); err != nil {
 			errChan <- err
 		}
+
+		wg.Done()
 	}
 
 	go unregister()
 	go unregister()
 
+	wg.Wait()
 	assert.EqualError(t, <-errChan, "there is no registered callback for token: goofy")
 }

--- a/config/mock_dynamic_provider_test.go
+++ b/config/mock_dynamic_provider_test.go
@@ -22,9 +22,9 @@ package config
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMockDynamicProvider_GetAndSet(t *testing.T) {
@@ -56,7 +56,7 @@ func TestMockDynamicProvider_RegisterChangeCallback(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(4)
-	p.RegisterChangeCallback("goofy", func(key string, provider string, data interface{}){
+	p.RegisterChangeCallback("goofy", func(key string, provider string, data interface{}) {
 		require.Equal(t, "goofy", key)
 		require.Equal(t, p.Name(), provider)
 		assert.NotEqual(t, "empty", data)
@@ -76,7 +76,6 @@ func TestMockDynamicProvider_RegisterChangeCallback(t *testing.T) {
 	wg.Wait()
 }
 
-
 func TestMockDynamicProvider_UnregisterChangeCallback(t *testing.T) {
 	t.Parallel()
 
@@ -86,12 +85,12 @@ func TestMockDynamicProvider_UnregisterChangeCallback(t *testing.T) {
 		p.UnregisterChangeCallback("goofy"),
 		"there is no registered callback for token: goofy")
 
-	p.RegisterChangeCallback("goofy", func(key string, provider string, data interface{}){
+	p.RegisterChangeCallback("goofy", func(key string, provider string, data interface{}) {
 		require.Fail(t, "should not be called")
 	})
 
 	errChan := make(chan error, 1)
-	unregister := func(){
+	unregister := func() {
 		if err := p.UnregisterChangeCallback("goofy"); err != nil {
 			errChan <- err
 		}

--- a/config/mock_dynamic_provider_test.go
+++ b/config/mock_dynamic_provider_test.go
@@ -21,10 +21,11 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockDynamicProvider_GetAndSet(t *testing.T) {
@@ -105,5 +106,7 @@ func TestMockDynamicProvider_UnregisterChangeCallback(t *testing.T) {
 	go unregister()
 
 	wg.Wait()
-	assert.EqualError(t, <-errChan, "there is no registered callback for token: goofy")
+	err := <-errChan
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "there is no registered callback for token: goofy")
 }

--- a/config/mock_dynamic_provider_test.go
+++ b/config/mock_dynamic_provider_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockDynamicProvider_GetAndSet(t *testing.T) {
+	t.Parallel()
+
+	p := NewMockDynamicProvider(map[string]interface{}{"goofy": "empty"})
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		v := p.Get("goofy")
+		assert.True(t, v.HasValue())
+		wg.Done()
+	}()
+
+	go func() {
+		p.Set("goofy", "gopher")
+		v := p.Get("goofy")
+		assert.Equal(t, "gopher", v.Value())
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func TestMockDynamicProvider_RegisterChangeCallback(t *testing.T) {
+	t.Parallel()
+
+	p := NewMockDynamicProvider(map[string]interface{}{"goofy": "empty"})
+
+	wg := sync.WaitGroup{}
+	wg.Add(4)
+	p.RegisterChangeCallback("goofy", func(key string, provider string, data interface{}){
+		require.Equal(t, "goofy", key)
+		require.Equal(t, p.Name(), provider)
+		assert.NotEqual(t, "empty", data)
+		wg.Done()
+	})
+
+	go func() {
+		p.Set("goofy", "gopher")
+		wg.Done()
+	}()
+
+	go func() {
+		p.Set("goofy", "gofer")
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+
+func TestMockDynamicProvider_UnregisterChangeCallback(t *testing.T) {
+	t.Parallel()
+
+	p := NewMockDynamicProvider(map[string]interface{}{"goofy": ""})
+
+	require.EqualError(t,
+		p.UnregisterChangeCallback("goofy"),
+		"there is no registered callback for token: goofy")
+
+	p.RegisterChangeCallback("goofy", func(key string, provider string, data interface{}){
+		require.Fail(t, "should not be called")
+	})
+
+	errChan := make(chan error, 1)
+	unregister := func(){
+		if err := p.UnregisterChangeCallback("goofy"); err != nil {
+			errChan <- err
+		}
+	}
+
+	go unregister()
+	go unregister()
+
+	assert.EqualError(t, <-errChan, "there is no registered callback for token: goofy")
+}

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -21,7 +21,6 @@
 package config
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,17 +48,17 @@ func TestCallbacks_WithDynamicProvider(t *testing.T) {
 	t.Parallel()
 	data := map[string]interface{}{"hello.world": 42}
 	mock := NewProviderGroup("with-dynamic", NewStaticProvider(data))
-	mock = mock.(providerGroup).WithProvider(newMockDynamicProvider(data))
+	mock = mock.(providerGroup).WithProvider(NewMockDynamicProvider(data))
 	assert.Equal(t, "with-dynamic", mock.Name())
 
 	require.NoError(t, mock.RegisterChangeCallback("mockcall", nil))
 	assert.EqualError(t,
 		mock.RegisterChangeCallback("mockcall", nil),
-		"Callback already registered for the key: mockcall")
+		"callback already registered for the key: mockcall")
 
 	assert.EqualError(t,
 		mock.UnregisterChangeCallback("mock"),
-		"There is no registered callback for token: mock")
+		"there is no registered callback for token: mock")
 }
 
 func TestCallbacks_WithoutDynamicProvider(t *testing.T) {
@@ -74,7 +73,7 @@ func TestCallbacks_WithoutDynamicProvider(t *testing.T) {
 
 func TestCallbacks_WithScopedProvider(t *testing.T) {
 	t.Parallel()
-	mock := &mockDynamicProvider{}
+	mock := &MockDynamicProvider{}
 	mock.Set("uber.fx", "go-lang")
 	scope := NewScopedProvider("uber", mock)
 
@@ -100,7 +99,7 @@ func TestCallbacks_WithScopedProvider(t *testing.T) {
 
 func TestScope_WithGetFromValue(t *testing.T) {
 	t.Parallel()
-	mock := &mockDynamicProvider{}
+	mock := &MockDynamicProvider{}
 	mock.Set("uber.fx", "go-lang")
 	scope := NewScopedProvider("", mock)
 	require.Equal(t, "go-lang", scope.Get("uber.fx").AsString())
@@ -130,62 +129,4 @@ logging:
 `)
 	pg := NewProviderGroup("group", NewYAMLProviderFromBytes(snd), NewYAMLProviderFromBytes(fst))
 	assert.True(t, pg.Get("logging").Get("enabled").AsBool())
-}
-
-type mockDynamicProvider struct {
-	data      map[string]interface{}
-	callBacks map[string]ChangeCallback
-}
-
-// StaticProvider should only be used in tests to isolate config from your environment
-func newMockDynamicProvider(data map[string]interface{}) Provider {
-	return &mockDynamicProvider{
-		data: data,
-	}
-}
-
-func (*mockDynamicProvider) Name() string {
-	return "mock"
-}
-
-func (s *mockDynamicProvider) Get(key string) Value {
-	val, found := s.data[key]
-	return NewValue(s, key, val, found, GetType(val), nil)
-}
-
-func (s *mockDynamicProvider) Set(key string, value interface{}) {
-	if s.data == nil {
-		s.data = make(map[string]interface{})
-	}
-
-	s.data[key] = value
-	if cb, ok := s.callBacks[key]; ok {
-		cb(key, s.Name(), "randomConfig")
-	}
-}
-
-func (s *mockDynamicProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
-	if s.callBacks == nil {
-		s.callBacks = make(map[string]ChangeCallback)
-	}
-
-	if _, ok := s.callBacks[key]; ok {
-		return errors.New("Callback already registered for the key: " + key)
-	}
-
-	s.callBacks[key] = callback
-	return nil
-}
-
-func (s *mockDynamicProvider) UnregisterChangeCallback(token string) error {
-	if s.callBacks == nil {
-		s.callBacks = make(map[string]ChangeCallback)
-	}
-
-	if _, ok := s.callBacks[token]; !ok {
-		return errors.New("There is no registered callback for token: " + token)
-	}
-
-	delete(s.callBacks, token)
-	return nil
 }


### PR DESCRIPTION
We have a mocked dynamic provider, which we use internally to test ProviderGroup. @jborlum opened a [PR](https://github.com/uber-go/fx/pull/406) that , probably would have a similar functionality, but is empty now.