### PR TITLE
Make all possible tests in config package to run in parallel

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -115,6 +115,7 @@ func TestGlobalConfig(t *testing.T) {
 }
 
 func TestRootNodeConfig(t *testing.T) {
+	t.Parallel()
 	txt := []byte(`
 one:
   two: hello
@@ -177,7 +178,7 @@ func TestOverrideSimple(t *testing.T) {
 }
 
 func TestSimpleConfigValues(t *testing.T) {
-
+	t.Parallel()
 	provider := NewProviderGroup(
 		"test",
 		NewYAMLProviderFromBytes(yamlConfig3),
@@ -194,6 +195,7 @@ func TestSimpleConfigValues(t *testing.T) {
 }
 
 func TestGetAsIntegerValue(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		value interface{}
 	}{
@@ -210,6 +212,7 @@ func TestGetAsIntegerValue(t *testing.T) {
 }
 
 func TestGetAsFloatValue(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		value interface{}
 	}{
@@ -298,6 +301,7 @@ func TestDefaultValue(t *testing.T) {
 }
 
 func TestInvalidConfigFailures(t *testing.T) {
+	t.Parallel()
 	valueType := []byte(`
 id: xyz
 boolean:

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -29,11 +29,13 @@ import (
 )
 
 func TestStaticProvider_Name(t *testing.T) {
+	t.Parallel()
 	p := NewStaticProvider(nil)
 	assert.Equal(t, "static", p.Name())
 }
 
 func TestNewStaticProvider_NilData(t *testing.T) {
+	t.Parallel()
 	p := NewStaticProvider(nil)
 
 	val := p.Get("something")
@@ -41,6 +43,7 @@ func TestNewStaticProvider_NilData(t *testing.T) {
 }
 
 func TestStaticProvider_WithData(t *testing.T) {
+	t.Parallel()
 	data := map[string]interface{}{
 		"hello": "world",
 	}
@@ -53,6 +56,7 @@ func TestStaticProvider_WithData(t *testing.T) {
 }
 
 func TestStaticProvider_WithGet(t *testing.T) {
+	t.Parallel()
 	data := map[string]interface{}{
 		"hello": map[string]int{"world": 42},
 	}
@@ -68,12 +72,14 @@ func TestStaticProvider_WithGet(t *testing.T) {
 }
 
 func TestStaticProvider_Callbacks(t *testing.T) {
+	t.Parallel()
 	p := NewStaticProvider(nil)
 	assert.NoError(t, p.RegisterChangeCallback("test", nil))
 	assert.NoError(t, p.UnregisterChangeCallback("token"))
 }
 
 func TestStaticProviderFmtPrintOnValueNoPanic(t *testing.T) {
+	t.Parallel()
 	p := NewStaticProvider(nil)
 	val := p.Get("something")
 
@@ -84,6 +90,7 @@ func TestStaticProviderFmtPrintOnValueNoPanic(t *testing.T) {
 }
 
 func TestNilStaticProviderSetDefaultTagValue(t *testing.T) {
+	t.Parallel()
 	type Inner struct {
 		Set bool `yaml:"set" default:"true"`
 	}


### PR DESCRIPTION
The only left are environment config tests and the ones that touch global variables.