### PR TITLE
DIG: Add the ability to register and resolve interfaces

### DIFF
--- a/dig/dig.go
+++ b/dig/dig.go
@@ -133,9 +133,6 @@ func (g *Graph) Resolve(obj interface{}) (err error) {
 	}
 
 	// set the pointer value of the provided object to the instance pointer
-	if objElemType.Kind() == reflect.Interface {
-		v = v.Elem()
-	}
 	objVal.Elem().Set(v)
 
 	return nil

--- a/dig/dig.go
+++ b/dig/dig.go
@@ -82,9 +82,6 @@ func (g *Graph) Register(c interface{}) error {
 		}
 		return g.registerConstructor(c)
 	case reflect.Ptr:
-		if ctype.Elem().Kind() == reflect.Interface {
-			ctype = ctype.Elem()
-		}
 		return g.registerObject(c, ctype)
 	default:
 		return errParamType
@@ -200,11 +197,16 @@ func (g *Graph) String() string {
 }
 
 func (g *Graph) registerObject(o interface{}, otype reflect.Type) error {
+	v := reflect.ValueOf(o)
+	if otype.Elem().Kind() == reflect.Interface {
+		otype = otype.Elem()
+		v = v.Elem()
+	}
 	n := objNode{
-		obj: o,
 		node: node{
-			objType: otype,
-			cached:  true,
+			objType:     otype,
+			cached:      true,
+			cachedValue: v,
 		},
 	}
 

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -153,6 +153,21 @@ func TestBasicRegisterResolve(t *testing.T) {
 	require.True(t, first == second, "Must point to the same object")
 }
 
+func TestInterfaceRegisterResolve(t *testing.T) {
+	t.Parallel()
+	g := New()
+
+	var gc GrandchildInt1 = NewGrandchild1()
+	err := g.Register(&gc)
+	require.NoError(t, err)
+
+	var registered GrandchildInt1
+	require.NoError(t, g.Resolve(&registered), "No error expected during Resolve")
+
+	require.NotNil(t, registered, "GrandchildInt1 must have been registered")
+	require.True(t, gc == registered, "Must point to the same object")
+}
+
 func TestConstructorErrors(t *testing.T) {
 	tests := []struct {
 		desc      string

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -157,15 +157,35 @@ func TestInterfaceRegisterResolve(t *testing.T) {
 	t.Parallel()
 	g := New()
 
-	var gc GrandchildInt1 = NewGrandchild1()
-	err := g.Register(&gc)
+	var gc1 GrandchildInt1 = NewGrandchild1()
+	err := g.Register(&gc1)
 	require.NoError(t, err)
 
-	var registered GrandchildInt1
-	require.NoError(t, g.Resolve(&registered), "No error expected during Resolve")
+	var registered1 GrandchildInt1
+	require.NoError(t, g.Resolve(&registered1), "No error expected during Resolve")
 
-	require.NotNil(t, registered, "GrandchildInt1 must have been registered")
-	require.True(t, gc == registered, "Must point to the same object")
+	require.NotNil(t, registered1, "GrandchildInt1 must have been registered")
+	require.True(t, gc1 == registered1, "Must point to the same object")
+
+	var gc2 GrandchildInt2 = &Grandchild2{}
+	err = g.Register(&gc2)
+	require.NoError(t, err)
+
+	var registered2 GrandchildInt2
+	require.NoError(t, g.Resolve(&registered2), "No error expected during Resolve")
+
+	require.NotNil(t, registered2, "GrandchildInt2 must have been registered")
+	require.True(t, gc2 == registered2, "Must point to the same object")
+
+	err = g.Register(NewChild3)
+	require.NoError(t, err)
+
+	var c3 *Child3
+	require.NoError(t, g.Resolve(&c3), "No error expected during Resolve")
+
+	require.NotNil(t, c3, "NewChild3 must have been registered")
+	require.True(t, gc1 == c3.gci1, "Child grand childeren point to the same object")
+	require.True(t, gc2 == c3.gci2, "Child grand childeren point to the same object")
 }
 
 func TestConstructorErrors(t *testing.T) {

--- a/dig/node.go
+++ b/dig/node.go
@@ -60,17 +60,11 @@ func (n node) id() string {
 
 type objNode struct {
 	node
-
-	obj interface{}
 }
 
 // Return the earlier provided instance
 func (n *objNode) value(g *Graph) (reflect.Value, error) {
-	v := reflect.ValueOf(n.obj)
-	if n.objType.Kind() == reflect.Interface {
-		v = v.Elem()
-	}
-	return v, nil
+	return n.cachedValue, nil
 }
 
 func (n objNode) dependencies() []interface{} {

--- a/dig/node.go
+++ b/dig/node.go
@@ -66,7 +66,11 @@ type objNode struct {
 
 // Return the earlier provided instance
 func (n *objNode) value(g *Graph) (reflect.Value, error) {
-	return reflect.ValueOf(n.obj), nil
+	v := reflect.ValueOf(n.obj)
+	if n.objType.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	return v, nil
 }
 
 func (n objNode) dependencies() []interface{} {


### PR DESCRIPTION
We ran into some issues when we tried to register and resolve `service.Host`. We were able to get it working if we did something like the following:

```
var h service.Host = // some valid host
g.Register(&h)

var registered *Host
g.Resolve(&registered)
```

Unfortunately, this approach won't work with constructors unless your constructors ask for a `*service.Host`. This is obviously awkward. This PR fixes the problem. Here's the new usage:

```
var h service.Host = // some valid host
g.Register(&h)

var registered Host
g.Resolve(&registered)
```