### PR TITLE
Rename PopulateStruct to Populate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v1.0.0-beta3 (unreleased)
+* [Breaking] Rename `PopulateStruct` method in value to `Populate`. The method can now populate not only structs,
+  but anything slices, maps, builtin types and maps.
 * [Breaking] Simplify Provider interface: remove `Scope` method from the `config.Provider` interface, one can
   use either ScopedProvider and Value.Get() to access sub fields.
 * Add `task.MustRegister` convenience function which fails fast by panicking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.0-beta3 (unreleased)
 * [Breaking] Rename `PopulateStruct` method in value to `Populate`. The method can now populate not only structs,
-  but anything slices, maps, builtin types and maps.
+  but anything: slices, maps, builtin types and maps.
 * [Breaking] Simplify Provider interface: remove `Scope` method from the `config.Provider` interface, one can
   use either ScopedProvider and Value.Get() to access sub fields.
 * Add `task.MustRegister` convenience function which fails fast by panicking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Changelog
 
 ## v1.0.0-beta3 (unreleased)
-* [Breaking] Rename `PopulateStruct` method in value to `Populate`. The method can now populate not only structs,
-  but anything: slices, maps, builtin types and maps.
-* [Breaking] Simplify Provider interface: remove `Scope` method from the `config.Provider` interface, one can
-  use either ScopedProvider and Value.Get() to access sub fields.
+
+* [Breaking] Rename `PopulateStruct` method in value to `Populate`.
+  The method can now populate not only structs, but anything: slices,
+  maps, builtin types and maps.
+* [Breaking] Simplify Provider interface: remove `Scope` method from
+  the `config.Provider` interface, one can use either ScopedProvider and
+  Value.Get() to access sub fields.
 * Add `task.MustRegister` convenience function which fails fast by panicking
   Note that this should only be used during app initialization, and is provided
   to avoid repetetive error checking for services which register many tasks.
-* Expose options on task module to disable execution. This will allow users to enqueue and consume
-  tasks on different clusters.
-* Rename Backend interface `Publish` to `Enqueue`. Created a new `ExecuteAsync` method that will
-  kick off workers to consume tasks and this is subsumed by module Start.
+* Expose options on task module to disable execution. This will allow users
+  to enqueue and consume tasks on different clusters.
+* Rename Backend interface `Publish` to `Enqueue`. Created a new `ExecuteAsync`
+  method that will kick off workers to consume tasks and this is subsumed by
+  module Start.
 
 ## v1.0.0-beta2 (09 Mar 2017)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,7 +173,7 @@ func TestOverrideSimple(t *testing.T) {
 	rpc := &rpcStruct{}
 	v := provider.Get("modules.rpc")
 	assert.True(t, v.HasValue())
-	v.PopulateStruct(rpc)
+	v.Populate(rpc)
 	assert.Equal(t, ":8888", rpc.Bind)
 }
 
@@ -191,7 +191,7 @@ func TestSimpleConfigValues(t *testing.T) {
 	assert.Equal(t, 1.123, provider.Get("float").AsFloat())
 	nested := &nested{}
 	v := provider.Get("nonexisting")
-	assert.NoError(t, v.PopulateStruct(nested))
+	assert.NoError(t, v.Populate(nested))
 }
 
 func TestGetAsIntegerValue(t *testing.T) {
@@ -240,7 +240,7 @@ func TestNestedStructs(t *testing.T) {
 	v := provider.Get(Root)
 
 	assert.True(t, v.HasValue())
-	err := v.PopulateStruct(str)
+	err := v.Populate(str)
 	assert.Nil(t, err)
 
 	assert.Equal(t, 1234, str.ID)
@@ -264,7 +264,7 @@ func TestArrayOfStructs(t *testing.T) {
 	v := provider.Get(Root)
 
 	assert.True(t, v.HasValue())
-	assert.NoError(t, v.PopulateStruct(target))
+	assert.NoError(t, v.Populate(target))
 	assert.Equal(t, 0, target.Things[0].ID1)
 	assert.Equal(t, -2, target.Things[2].ID1)
 }
@@ -278,7 +278,7 @@ func TestDefault(t *testing.T) {
 	target := &nested{}
 	v := provider.Get(Root)
 	assert.True(t, v.HasValue())
-	assert.NoError(t, v.PopulateStruct(target))
+	assert.NoError(t, v.Populate(target))
 	assert.Equal(t, "default_name", target.Name)
 }
 

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -73,6 +73,13 @@ func convertValueFromStruct(value interface{}, targetType reflect.Type, fieldTyp
 	return nil
 }
 
+func addSeparator(key string) string {
+	if key != "" {
+		key += _separator
+	}
+	return key
+}
+
 type decoder struct {
 	*Value
 	m map[interface{}]struct{}
@@ -125,9 +132,7 @@ func (d *decoder) sequence(childKey string, value reflect.Value) error {
 
 	// start looking for child values.
 	elementType := derefType(valueType).Elem()
-	if childKey != "" {
-		childKey += _separator
-	}
+	childKey = addSeparator(childKey)
 
 	for ai := 0; ; ai++ {
 		arrayKey := childKey + strconv.Itoa(ai)
@@ -166,9 +171,7 @@ func (d *decoder) array(childKey string, value reflect.Value) error {
 
 	// start looking for child values.
 	elementType := derefType(valueType).Elem()
-	if childKey != "" {
-		childKey += _separator
-	}
+	childKey = addSeparator(childKey)
 
 	for ai := 0; ai < value.Len(); ai++ {
 		arrayKey := childKey + strconv.Itoa(ai)
@@ -209,9 +212,7 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 	// child yamlNode parsed from yaml file is of type map[interface{}]interface{}
 	// type casting here makes sure that we are iterating over a parsed map.
 	if v, ok := val.(map[interface{}]interface{}); ok {
-		if childKey != "" {
-			childKey += _separator
-		}
+		childKey = addSeparator(childKey)
 
 		for key := range v {
 			mapKey := childKey + fmt.Sprintf("%v", key)

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -215,21 +215,18 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 		childKey = addSeparator(childKey)
 
 		for key := range v {
-			mapKey := childKey + fmt.Sprintf("%v", key)
 
 			// Skip empty keys, because lookups in provider can toggle infinite loops/spill internals.
-			if mapKey == "" {
-				continue
+			if mapKey := childKey + fmt.Sprintf("%v", key); mapKey != "" {
+				itemValue := reflect.New(valueType.Elem()).Elem()
+
+				// Try to unmarshal value and save it in the map.
+				if err := d.unmarshal(mapKey, itemValue, def); err != nil {
+					return err
+				}
+
+				destMap.SetMapIndex(reflect.ValueOf(key), itemValue)
 			}
-
-			itemValue := reflect.New(valueType.Elem()).Elem()
-
-			// Try to unmarshal value and save it in the map.
-			if err := d.unmarshal(mapKey, itemValue, def); err != nil {
-				return err
-			}
-
-			destMap.SetMapIndex(reflect.ValueOf(key), itemValue)
 		}
 
 		value.Set(destMap)

--- a/config/decoder.go
+++ b/config/decoder.go
@@ -125,7 +125,9 @@ func (d *decoder) sequence(childKey string, value reflect.Value) error {
 
 	// start looking for child values.
 	elementType := derefType(valueType).Elem()
-	childKey += _separator
+	if childKey != "" {
+		childKey += _separator
+	}
 
 	for ai := 0; ; ai++ {
 		arrayKey := childKey + strconv.Itoa(ai)
@@ -164,7 +166,9 @@ func (d *decoder) array(childKey string, value reflect.Value) error {
 
 	// start looking for child values.
 	elementType := derefType(valueType).Elem()
-	childKey += _separator
+	if childKey != "" {
+		childKey += _separator
+	}
 
 	for ai := 0; ai < value.Len(); ai++ {
 		arrayKey := childKey + strconv.Itoa(ai)
@@ -205,9 +209,18 @@ func (d *decoder) mapping(childKey string, value reflect.Value, def string) erro
 	// child yamlNode parsed from yaml file is of type map[interface{}]interface{}
 	// type casting here makes sure that we are iterating over a parsed map.
 	if v, ok := val.(map[interface{}]interface{}); ok {
-		childKey += _separator
+		if childKey != "" {
+			childKey += _separator
+		}
+
 		for key := range v {
 			mapKey := childKey + fmt.Sprintf("%v", key)
+
+			// Skip empty keys, because lookups in provider can toggle infinite loops/spill internals.
+			if mapKey == "" {
+				continue
+			}
+
 			itemValue := reflect.New(valueType.Elem()).Elem()
 
 			// Try to unmarshal value and save it in the map.

--- a/config/value.go
+++ b/config/value.go
@@ -325,9 +325,8 @@ func convertValue(value interface{}, targetType reflect.Type) (interface{}, erro
 	return nil, fmt.Errorf("can't convert %v to %v", reflect.TypeOf(value).String(), targetType)
 }
 
-// PopulateStruct fills in a struct from configuration
-// TODO(alsam) now we can populate not only structs. Provide a generic function.
-func (cv Value) PopulateStruct(target interface{}) error {
+// Populate fills in an object from configuration
+func (cv Value) Populate(target interface{}) error {
 	d := decoder{Value: &cv, m: make(map[interface{}]struct{})}
 
 	return d.unmarshal(cv.key, reflect.Indirect(reflect.ValueOf(target)), "")

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -40,9 +40,9 @@ type yamlConfigProvider struct {
 var _ Provider = &yamlConfigProvider{}
 
 func newYAMLProviderCore(files ...io.ReadCloser) Provider {
-	var root interface{} = make(map[interface{}]interface{})
+	var root interface{}
 	for _, v := range files {
-		curr := make(map[interface{}]interface{})
+		var curr interface{}
 		if err := unmarshalYAMLValue(v, &curr); err != nil {
 			panic(err)
 		}
@@ -52,7 +52,7 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 
 	return &yamlConfigProvider{
 		root: &yamlNode{
-			nodeType: objectNode,
+			nodeType: getNodeType(root),
 			key:      Root,
 			value:    root,
 		},
@@ -74,11 +74,11 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 // * in all the remaining cases B will overwrite A.
 func mergeMaps(dst interface{}, src interface{}) interface{} {
 	if dst == nil {
-		panic("Destination node is nil")
+		return src
 	}
 
 	if src == nil {
-		return src
+		return dst
 	}
 
 	switch s := src.(type) {

--- a/config/yaml_benchmark_test.go
+++ b/config/yaml_benchmark_test.go
@@ -84,7 +84,7 @@ func BenchmarkYAMLPopulateStruct(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.Get("api.credentials").PopulateStruct(c)
+		p.Get("api.credentials").Populate(c)
 	}
 }
 
@@ -105,7 +105,7 @@ func BenchmarkYAMLPopulateStructNested(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.Get("api").PopulateStruct(s)
+		p.Get("api").Populate(s)
 	}
 }
 
@@ -128,7 +128,7 @@ func BenchmarkYAMLPopulateStructNestedMultipleFiles(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.Get("api").PopulateStruct(s)
+		p.Get("api").Populate(s)
 	}
 }
 
@@ -146,7 +146,7 @@ func BenchmarkYAMLPopulateNestedTextUnmarshaler(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		p.Get(Root).PopulateStruct(s)
+		p.Get(Root).Populate(s)
 	}
 }
 
@@ -161,7 +161,7 @@ encoderConfig:
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		if err := p.Get(Root).PopulateStruct(cfg); err != nil {
+		if err := p.Get(Root).Populate(cfg); err != nil {
 			b.Error(err)
 		}
 	}

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -69,7 +69,7 @@ func TestYamlStructRoot(t *testing.T) {
 
 	cs := &configStruct{}
 
-	assert.NoError(t, provider.Get(Root).PopulateStruct(cs))
+	assert.NoError(t, provider.Get(Root).Populate(cs))
 
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "owner@service.com", cs.Owner)
@@ -86,7 +86,7 @@ func TestYamlStructChild(t *testing.T) {
 
 	cs := &rpcStruct{}
 
-	assert.NoError(t, provider.Get("modules.rpc").PopulateStruct(cs))
+	assert.NoError(t, provider.Get("modules.rpc").Populate(cs))
 
 	assert.Equal(t, ":28941", cs.Bind)
 }
@@ -128,7 +128,7 @@ func TestNewYAMLProviderFromReader(t *testing.T) {
 	buff := bytes.NewBuffer([]byte(yamlConfig1))
 	provider := NewYAMLProviderFromReader(ioutil.NopCloser(buff))
 	cs := &configStruct{}
-	assert.NoError(t, provider.Get(Root).PopulateStruct(cs))
+	assert.NoError(t, provider.Get(Root).Populate(cs))
 	assert.Equal(t, "keyvalue", cs.AppID)
 	assert.Equal(t, "owner@service.com", cs.Owner)
 }
@@ -168,7 +168,7 @@ func TestMatchEmptyStruct(t *testing.T) {
 	t.Parallel()
 	withYamlBytes([]byte(``), func(provider Provider) {
 		es := emptystruct{}
-		provider.Get("emptystruct").PopulateStruct(&es)
+		provider.Get("emptystruct").Populate(&es)
 		empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
 		assert.True(t, reflect.DeepEqual(empty, es))
 	})
@@ -178,7 +178,7 @@ func TestMatchPopulatedEmptyStruct(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(emptyyaml, func(provider Provider) {
 		es := emptystruct{}
-		provider.Get("emptystruct").PopulateStruct(&es)
+		provider.Get("emptystruct").Populate(&es)
 		empty := reflect.New(reflect.TypeOf(es)).Elem().Interface()
 		assert.True(t, reflect.DeepEqual(empty, es))
 	})
@@ -188,7 +188,7 @@ func TestPopulateStructWithPointers(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(pointerYaml, func(provider Provider) {
 		ps := pointerStruct{}
-		provider.Get("pointerStruct").PopulateStruct(&ps)
+		provider.Get("pointerStruct").Populate(&ps)
 		assert.True(t, *ps.MyTrueBool)
 		assert.False(t, *ps.MyFalseBool)
 		assert.Equal(t, "hello", *ps.MyString)
@@ -199,7 +199,7 @@ func TestNonExistingPopulateStructWithPointers(t *testing.T) {
 	t.Parallel()
 	withYamlBytes([]byte(``), func(provider Provider) {
 		ps := pointerStruct{}
-		provider.Get("pointerStruct").PopulateStruct(&ps)
+		provider.Get("pointerStruct").Populate(&ps)
 		assert.Nil(t, ps.MyTrueBool)
 		assert.Nil(t, ps.MyFalseBool)
 		assert.Nil(t, ps.MyString)
@@ -210,7 +210,7 @@ func TestMapParsing(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(complexMapYaml, func(provider Provider) {
 		ms := mapStruct{}
-		provider.Get("mapStruct").PopulateStruct(&ms)
+		provider.Get("mapStruct").Populate(&ms)
 
 		assert.NotNil(t, ms.MyMap)
 		assert.NotZero(t, len(ms.MyMap))
@@ -231,7 +231,7 @@ func TestMapParsingSimpleMap(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(simpleMapYaml, func(provider Provider) {
 		ms := mapStruct{}
-		provider.Get("mapStruct").PopulateStruct(&ms)
+		provider.Get("mapStruct").Populate(&ms)
 		assert.Equal(t, 1, ms.MyMap["one"])
 		assert.Equal(t, 2, ms.MyMap["two"])
 		assert.Equal(t, 3, ms.MyMap["three"])
@@ -243,7 +243,7 @@ func TestMapParsingMapWithNonStringKeys(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(intKeyMapYaml, func(provider Provider) {
 		ik := intKeyMapStruct{}
-		err := provider.Get("intKeyMapStruct").PopulateStruct(&ik)
+		err := provider.Get("intKeyMapStruct").Populate(&ik)
 		assert.NoError(t, err)
 		assert.Equal(t, "onetwothree", ik.IntKeyMap[123])
 	})
@@ -253,7 +253,7 @@ func TestDurationParsing(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(durationYaml, func(provider Provider) {
 		ds := durationStruct{}
-		err := provider.Get("durationStruct").PopulateStruct(&ds)
+		err := provider.Get("durationStruct").Populate(&ds)
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, ds.Seconds)
 		assert.Equal(t, 20*time.Minute, ds.Minutes)
@@ -265,7 +265,7 @@ func TestParsingUnparsableDuration(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(unparsableDurationYaml, func(provider Provider) {
 		ds := durationStruct{}
-		err := provider.Get("durationStruct").PopulateStruct(&ds)
+		err := provider.Get("durationStruct").Populate(&ds)
 		assert.Error(t, err)
 	})
 }
@@ -274,7 +274,7 @@ func TestTypeOfTypes(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(typeStructYaml, func(provider Provider) {
 		tts := typeStructStruct{}
-		err := provider.Get(Root).PopulateStruct(&tts)
+		err := provider.Get(Root).Populate(&tts)
 		assert.NoError(t, err)
 		assert.Equal(t, userDefinedTypeInt(123), tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), tts.TypeStruct.TestUInt)
@@ -291,7 +291,7 @@ func TestTypeOfTypesPtr(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(typeStructYaml, func(provider Provider) {
 		tts := typeStructStructPtr{}
-		err := provider.Get(Root).PopulateStruct(&tts)
+		err := provider.Get(Root).Populate(&tts)
 		assert.NoError(t, err)
 		assert.Equal(t, userDefinedTypeInt(123), *tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), *tts.TypeStruct.TestUInt)
@@ -308,7 +308,7 @@ func TestTypeOfTypesPtrPtr(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(typeStructYaml, func(provider Provider) {
 		tts := typeStructStructPtrPtr{}
-		err := provider.Get(Root).PopulateStruct(&tts)
+		err := provider.Get(Root).Populate(&tts)
 		assert.NoError(t, err)
 		assert.Equal(t, userDefinedTypeInt(123), *tts.TypeStruct.TestInt)
 		assert.Equal(t, userDefinedTypeUInt(456), *tts.TypeStruct.TestUInt)
@@ -325,7 +325,7 @@ func TestHappyTextUnMarshallerParsing(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(happyTextUnmarshallerYaml, func(provider Provider) {
 		ds := duckTales{}
-		err := provider.Get("duckTales").PopulateStruct(&ds)
+		err := provider.Get("duckTales").Populate(&ds)
 		assert.NoError(t, err)
 		assert.Equal(t, scrooge, ds.Protagonist)
 		assert.Equal(t, launchpadMcQuack, ds.Pilot)
@@ -336,7 +336,7 @@ func TestGrumpyTextUnMarshallerParsing(t *testing.T) {
 	t.Parallel()
 	withYamlBytes(grumpyTextUnmarshallerYaml, func(provider Provider) {
 		ds := duckTales{}
-		err := provider.Get("darkwingDuck").PopulateStruct(&ds)
+		err := provider.Get("darkwingDuck").Populate(&ds)
 		assert.Contains(t, err.Error(), "Unknown character: DarkwingDuck")
 	})
 }
@@ -346,7 +346,7 @@ func TestMergeUnmarshaller(t *testing.T) {
 	provider := NewYAMLProviderFromBytes(complexMapYaml, complexMapYamlV2)
 
 	ms := mapStruct{}
-	assert.NoError(t, provider.Get("mapStruct").PopulateStruct(&ms))
+	assert.NoError(t, provider.Get("mapStruct").Populate(&ms))
 	assert.NotNil(t, ms.MyMap)
 	assert.NotZero(t, len(ms.MyMap))
 
@@ -360,7 +360,7 @@ func TestMergeUnmarshaller(t *testing.T) {
 	s, ok := ms.MyMap["pools"].([]interface{})
 	assert.True(t, ok)
 	assert.Equal(t, []interface{}{"very", "funny"}, s)
-	assert.Equal(t, "", ms.NestedStruct.AdditionalData)
+	assert.Equal(t, "nesteddata", ms.NestedStruct.AdditionalData)
 }
 
 func TestMerge(t *testing.T) {
@@ -370,7 +370,7 @@ func TestMerge(t *testing.T) {
 			prov := NewYAMLProviderFromBytes(v.yaml...)
 			for path, exp := range v.expected {
 				res := reflect.New(reflect.ValueOf(exp).Type()).Interface()
-				assert.NoError(t, prov.Get(path).PopulateStruct(res))
+				assert.NoError(t, prov.Get(path).Populate(res))
 				assert.Equal(t, exp, reflect.ValueOf(res).Elem().Interface(), "For path: %s", path)
 			}
 		})
@@ -419,7 +419,7 @@ func TestArrayTypeNoPanic(t *testing.T) {
 		ID [6]int `yaml:"id"`
 	}{}
 
-	assert.NoError(t, provider.Get(Root).PopulateStruct(&cs))
+	assert.NoError(t, provider.Get(Root).Populate(&cs))
 }
 
 func TestNilYAMLProviderSetDefaultTagValue(t *testing.T) {
@@ -439,7 +439,7 @@ func TestNilYAMLProviderSetDefaultTagValue(t *testing.T) {
 	}{}
 
 	p := NewYAMLProviderFromBytes(nil)
-	p.Get("hello").PopulateStruct(&data)
+	p.Get("hello").Populate(&data)
 
 	assert.Equal(t, 10, data.ID0)
 	assert.Equal(t, "string", data.ID1)
@@ -470,7 +470,7 @@ abc:
 		BoolPtr *bool  `yaml:"bool_ptr"`
 	}{}
 	p := NewYAMLProviderFromBytes(base, prod)
-	p.Get("abc").PopulateStruct(&cfg)
+	p.Get("abc").Populate(&cfg)
 
 	assert.Equal(t, "prod", cfg.Str)
 	assert.Equal(t, 1, cfg.Int)
@@ -502,7 +502,7 @@ m:
 
 	p := NewYAMLProviderFromBytes(b)
 	var r Map
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Equal(t, Bag{S: "one", I: 1, P: nil}, r.M["first"])
 
 	snd := r.M["second"]
@@ -527,7 +527,7 @@ s:
 `)
 	p := NewYAMLProviderFromBytes(b)
 	var r Map
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Equal(t, []time.Duration{time.Second}, r.S["first"])
 	assert.Equal(t, []time.Duration{2 * time.Minute, 3 * time.Hour}, r.S["second"])
 }
@@ -549,7 +549,7 @@ s:
 `)
 	p := NewYAMLProviderFromBytes(b)
 	var r Map
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Equal(t, [2]time.Duration{time.Second, 4 * time.Minute}, r.S["first"])
 	assert.Equal(t, [2]time.Duration{2 * time.Minute, 3 * time.Hour}, r.S["second"])
 }
@@ -578,7 +578,7 @@ func TestLoops(t *testing.T) {
 	require.Equal(t, b, a)
 
 	p := testProvider{}
-	assert.Contains(t, p.Get(Root).PopulateStruct(&b).Error(), "cycles")
+	assert.Contains(t, p.Get(Root).Populate(&b).Error(), "cycles")
 }
 
 func TestInternalFieldsAreNotSet(t *testing.T) {
@@ -592,7 +592,7 @@ internal: set
 `)
 	p := NewYAMLProviderFromBytes(b)
 	var r External
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Equal(t, "", r.internal)
 }
 
@@ -620,7 +620,7 @@ logging:
 `)
 	p := NewYAMLProviderFromBytes(b)
 	var r Config
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Equal(t, "bar", r.Foo)
 }
 
@@ -640,7 +640,7 @@ M:
 `)
 	p := NewYAMLProviderFromBytes(b)
 	var r Foo
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Equal(t, r.M, map[string]Hello{"sayHello": Hello(nil)})
 }
 
@@ -659,7 +659,7 @@ Say:
 `)
 	p := NewYAMLProviderFromBytes(b)
 	var r Foo
-	require.NoError(t, p.Get(Root).PopulateStruct(&r))
+	require.NoError(t, p.Get(Root).Populate(&r))
 	assert.Nil(t, r.Say)
 }
 
@@ -699,7 +699,7 @@ func TestHappyUnmarshallerChannelFunction(t *testing.T) {
 	f := func(src []byte, band, song string) {
 		var r Chart
 		p := NewYAMLProviderFromBytes(src)
-		require.NoError(t, p.Get(Root).PopulateStruct(&r))
+		require.NoError(t, p.Get(Root).Populate(&r))
 		require.Equal(t, band, <-r.Band)
 		assert.EqualError(t, r.Song("Get "), song)
 	}
@@ -729,7 +729,7 @@ func TestGrumpyUnmarshallerChannelFunction(t *testing.T) {
 	f := func(src []byte, message string) {
 		var r S
 		p := NewYAMLProviderFromBytes(src)
-		e := p.Get(Root).PopulateStruct(&r)
+		e := p.Get(Root).Populate(&r)
 		require.EqualError(t, e, message)
 	}
 

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -107,7 +107,7 @@ func newModule(
 		Timeout: defaultTimeout,
 	}
 	log := ulog.Logger(context.Background()).With(zap.String("module", host.ModuleName()))
-	if err := host.Config().Get("modules").Get(host.ModuleName()).PopulateStruct(&cfg); err != nil {
+	if err := host.Config().Get("modules").Get(host.ModuleName()).Populate(&cfg); err != nil {
 		log.Error("Error loading http module configuration", zap.Error(err))
 	}
 	module := &Module{

--- a/modules/yarpc/yarpc.go
+++ b/modules/yarpc/yarpc.go
@@ -135,7 +135,7 @@ func newModule(
 		statsClient: newStatsClient(host.Metrics()),
 		log:         ulog.Logger(context.Background()).With(zap.String("module", host.ModuleName())),
 	}
-	if err := host.Config().Get("modules").Get(host.ModuleName()).PopulateStruct(&module.config); err != nil {
+	if err := host.Config().Get("modules").Get(host.ModuleName()).Populate(&module.config); err != nil {
 		return nil, errs.Wrap(err, "can't read inbounds")
 	}
 

--- a/service/service_core.go
+++ b/service/service_core.go
@@ -158,7 +158,7 @@ func (s *serviceCore) setupLogging() error {
 }
 
 func (s *serviceCore) setupStandardConfig() error {
-	if err := s.configProvider.Get(config.Root).PopulateStruct(&s.standardConfig); err != nil {
+	if err := s.configProvider.Get(config.Root).Populate(&s.standardConfig); err != nil {
 		return errors.Wrap(err, "unable to load standard configuration")
 	}
 
@@ -182,7 +182,7 @@ func (s *serviceCore) setupRuntimeMetricsCollector() error {
 	}
 
 	var runtimeMetricsConfig metrics.RuntimeConfig
-	err := s.configProvider.Get("metrics.runtime").PopulateStruct(&runtimeMetricsConfig)
+	err := s.configProvider.Get("metrics.runtime").Populate(&runtimeMetricsConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to load runtime metrics configuration")
 	}
@@ -201,7 +201,7 @@ func (s *serviceCore) setupTracer() error {
 	if s.Tracer() != nil {
 		return nil
 	}
-	if err := s.configProvider.Get("tracing").PopulateStruct(&s.tracerConfig); err != nil {
+	if err := s.configProvider.Get("tracing").Populate(&s.tracerConfig); err != nil {
 		return errors.Wrap(err, "unable to load tracing configuration")
 	}
 	tracer, closer, err := tracing.InitGlobalTracer(
@@ -242,7 +242,7 @@ func loadInstanceConfig(cfg config.Provider, key string, instance interface{}) b
 		configValue := reflect.New(field.Type())
 
 		// Try to load the service config
-		err := cfg.Get(key).PopulateStruct(configValue.Interface())
+		err := cfg.Get(key).Populate(configValue.Interface())
 		if err != nil {
 			zap.L().Error("Unable to load instance config", zap.Error(err))
 			return false

--- a/ulog/log.go
+++ b/ulog/log.go
@@ -42,7 +42,7 @@ func (c *Configuration) Configure(cfg config.Value) error {
 	// TODO: Fix after GFM-415
 	// Uhhh... this process is not the most elegant.
 	//
-	// Because log.Configuration embeds zap, the PopulateStruct
+	// Because log.Configuration embeds zap, the Populate
 	// does not work properly as it's unable to serialize fields directly
 	// into the embedded struct, so inner struct has to be treated as a
 	// separate object
@@ -51,7 +51,7 @@ func (c *Configuration) Configure(cfg config.Value) error {
 	zapCfg := DefaultConfiguration().Config
 
 	// override the embedded zap.Config stuct from config
-	if err := cfg.PopulateStruct(&zapCfg); err != nil {
+	if err := cfg.Populate(&zapCfg); err != nil {
 		return errors.New("unable to parse logging config")
 	}
 
@@ -59,7 +59,7 @@ func (c *Configuration) Configure(cfg config.Value) error {
 	c.Config = zapCfg
 
 	// override any remaining things fom config, i.e. Sentry
-	if err := cfg.PopulateStruct(&c); err != nil {
+	if err := cfg.Populate(&c); err != nil {
 		return errors.New("unable to parse logging config")
 	}
 


### PR DESCRIPTION
Rename `PopulateStruct` method in Value to `Populate`. The method can now populate not only structs, but anything: slices, maps, builtin types and maps.