### PR TITLE
Introduce a cached provider

### DIFF
--- a/config/cache_provider.go
+++ b/config/cache_provider.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"fmt"
+	"sync"
+)
+
+type cachedProvider struct {
+	sync.RWMutex
+	cache map[string]Value
+
+	Provider
+}
+
+// NewCachedProvider returns a provider, that caches values of the underlying Provider p.
+// It also subscribes for changes for all keys that ever retrieved from the provider.
+// If the underlying provider fails to register callback for a particular value, it will
+// return the underlying error wrapped in Value.
+func NewCachedProvider(p Provider) Provider {
+	return &cachedProvider{
+		Provider: p,
+		cache:    make(map[string]Value),
+	}
+}
+
+func (p *cachedProvider) Name() string {
+	return fmt.Sprintf("cached %q", p.Provider.Name())
+}
+
+// Retrieves a Value, caches it internally and subscribe to changes via RegisterCallback.
+// The value is cached only if it is found.
+func (p *cachedProvider) Get(key string) Value {
+	p.RLock()
+	if v, ok := p.cache[key]; ok {
+		p.RUnlock()
+		return v
+	}
+
+	p.RUnlock()
+	err := p.Provider.RegisterChangeCallback(key, func(key string, provider string, data interface{}) {
+		p.Lock()
+		p.cache[key] = NewValue(p, key, data, true, GetType(data), nil)
+		p.Unlock()
+	})
+
+	if err != nil {
+		return NewValue(p, key, err, true, GetType(err), nil)
+	}
+
+	v := p.Provider.Get(key)
+	if v.found {
+		p.Lock()
+		p.cache[key] = v
+		p.Unlock()
+	}
+
+	return v
+}
+
+// No need to register a callback, all the values are fresh.
+func (p *cachedProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
+	return nil
+}
+
+// No need to unregister a callback, because nothing was registered.
+func (p *cachedProvider) UnregisterChangeCallback(token string) error {
+	return nil
+}

--- a/config/cache_provider.go
+++ b/config/cache_provider.go
@@ -37,6 +37,10 @@ type cachedProvider struct {
 // If the underlying provider fails to register callback for a particular value, it will
 // return the underlying error wrapped in Value.
 func NewCachedProvider(p Provider) Provider {
+	if p == nil {
+		panic("Received a nil provider")
+	}
+
 	return &cachedProvider{
 		Provider: p,
 		cache:    make(map[string]Value),
@@ -64,11 +68,11 @@ func (p *cachedProvider) Get(key string) Value {
 	})
 
 	if err != nil {
-		return NewValue(p, key, err, true, GetType(err), nil)
+		return NewValue(p, key, err, false, GetType(err), nil)
 	}
 
 	v := p.Provider.Get(key)
-	if v.found {
+	if v.HasValue() {
 		p.Lock()
 		p.cache[key] = v
 		p.Unlock()

--- a/config/cache_provider.go
+++ b/config/cache_provider.go
@@ -72,11 +72,9 @@ func (p *cachedProvider) Get(key string) Value {
 	}
 
 	v := p.Provider.Get(key)
-	if v.HasValue() {
-		p.Lock()
-		p.cache[key] = v
-		p.Unlock()
-	}
+	p.Lock()
+	p.cache[key] = v
+	p.Unlock()
 
 	return v
 }

--- a/config/cache_provider_test.go
+++ b/config/cache_provider_test.go
@@ -76,7 +76,7 @@ func TestCachedProvider_ErrorToSetCallback(t *testing.T) {
 	require.False(t, v.HasValue())
 }
 
-func TestCachedProviderConcurrentUse(t *testing.T){
+func TestCachedProviderConcurrentUse(t *testing.T) {
 	t.Parallel()
 
 	wg := sync.WaitGroup{}
@@ -89,13 +89,13 @@ func TestCachedProviderConcurrentUse(t *testing.T){
 
 	m.Set("cartoon", "Simpsons")
 	wg.Add(4)
-	get := func () {
+	get := func() {
 		x := v.Get(Root)
 		require.True(t, x.HasValue())
 		wg.Done()
 	}
 
-	set := func () {
+	set := func() {
 		m.Set("cartoon", "Jetsons")
 		wg.Done()
 	}
@@ -104,7 +104,6 @@ func TestCachedProviderConcurrentUse(t *testing.T){
 	go get()
 	go set()
 	go get()
-
 
 	wg.Wait()
 }

--- a/config/cache_provider_test.go
+++ b/config/cache_provider_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sync"
+)
+
+func TestCacheProviderName(t *testing.T) {
+	t.Parallel()
+
+	c := NewCachedProvider(&MockDynamicProvider{})
+	assert.Equal(t, `cached "MockDynamicProvider"`, c.Name())
+}
+
+func TestCachedProvider_ConstructorPanicsOnNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { NewCachedProvider(nil) })
+}
+
+func TestCachedProvider_GetNewValues(t *testing.T) {
+	t.Parallel()
+
+	m := &MockDynamicProvider{}
+	p := NewCachedProvider(m)
+
+	v := p.Get("cartoon")
+	assert.False(t, v.HasValue())
+
+	m.Set("cartoon", "Simpsons")
+	v = v.Get(Root)
+	require.True(t, v.HasValue())
+	assert.Equal(t, "Simpsons", v.Value())
+
+	ts := v.LastUpdated()
+	m.Set("cartoon", "Futurama")
+	assert.True(t, ts.Before(v.Get(Root).LastUpdated()))
+}
+
+func TestCachedProvider_ErrorToSetCallback(t *testing.T) {
+	t.Parallel()
+
+	m := &MockDynamicProvider{}
+	p := NewCachedProvider(m)
+
+	m.RegisterChangeCallback("cartoon", func(key, provider string, data interface{}) {})
+
+	v := p.Get("cartoon")
+	assert.False(t, v.HasValue())
+
+	m.Set("cartoon", "Simpsons")
+	v = v.Get(Root)
+	require.False(t, v.HasValue())
+}
+
+func TestCachedProviderConcurrentUse(t *testing.T){
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+
+	m := &MockDynamicProvider{}
+	p := NewCachedProvider(m)
+
+	v := p.Get("cartoon")
+	assert.False(t, v.HasValue())
+
+	m.Set("cartoon", "Simpsons")
+	wg.Add(4)
+	get := func () {
+		x := v.Get(Root)
+		require.True(t, x.HasValue())
+		wg.Done()
+	}
+
+	set := func () {
+		m.Set("cartoon", "Jetsons")
+		wg.Done()
+	}
+
+	go set()
+	go get()
+	go set()
+	go get()
+
+
+	wg.Wait()
+}

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -33,8 +33,7 @@ import (
 )
 
 type yamlConfigProvider struct {
-	root   *yamlNode
-	vCache map[string]Value
+	root *yamlNode
 }
 
 var _ Provider = &yamlConfigProvider{}
@@ -56,7 +55,6 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 			key:      Root,
 			value:    root,
 		},
-		vCache: make(map[string]Value),
 	}
 }
 
@@ -125,13 +123,13 @@ func NewYAMLProviderFromFiles(mustExist bool, resolver FileResolver, files ...st
 		}
 	}
 
-	return newYAMLProviderCore(readers...)
+	return NewCachedProvider(newYAMLProviderCore(readers...))
 }
 
 // NewYAMLProviderFromReader creates a configuration provider from a list of `io.ReadClosers`.
 // As above, all the objects are going to be merged and arrays/values overridden in the order of the files.
 func NewYAMLProviderFromReader(readers ...io.ReadCloser) Provider {
-	return newYAMLProviderCore(readers...)
+	return NewCachedProvider(newYAMLProviderCore(readers...))
 }
 
 // NewYAMLProviderFromBytes creates a config provider from a byte-backed YAML blobs.
@@ -142,7 +140,7 @@ func NewYAMLProviderFromBytes(yamls ...[]byte) Provider {
 		closers[i] = ioutil.NopCloser(bytes.NewReader(yml))
 	}
 
-	return newYAMLProviderCore(closers...)
+	return NewCachedProvider(newYAMLProviderCore(closers...))
 }
 
 func (y yamlConfigProvider) getNode(key string) *yamlNode {
@@ -160,21 +158,12 @@ func (y yamlConfigProvider) Name() string {
 
 // Get returns a configuration value by name
 func (y yamlConfigProvider) Get(key string) Value {
-	// check the cache for the value
-	if node, ok := y.vCache[key]; ok {
-		return node
-	}
-
 	node := y.getNode(key)
 	if node == nil {
 		return NewValue(y, key, nil, false, Invalid, nil)
 	}
 
-	// cache the found value
-	value := NewValue(y, key, node.value, true, GetType(node.value), nil)
-	y.vCache[key] = value
-
-	return value
+	return NewValue(y, key, node.value, true, GetType(node.value), nil)
 }
 
 func (y yamlConfigProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {


### PR DESCRIPTION
We cache values only for yaml config provider(not concurrently safe). We can introduce a simple wrapper, that can be used by any other provider to cache values, even DynamicProviders, that have callbacks by registering a callback for the underlying provider for all values that were ever retrieved.