### PR TITLE
Cached Provider value should point to cached provider

### DIFF
--- a/config/cache_provider.go
+++ b/config/cache_provider.go
@@ -72,6 +72,7 @@ func (p *cachedProvider) Get(key string) Value {
 	}
 
 	v := p.Provider.Get(key)
+	v.provider = p
 	p.Lock()
 	p.cache[key] = v
 	p.Unlock()

--- a/config/cache_provider_test.go
+++ b/config/cache_provider_test.go
@@ -21,11 +21,11 @@
 package config
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sync"
 )
 
 func TestCacheProviderName(t *testing.T) {
@@ -58,6 +58,8 @@ func TestCachedProvider_GetNewValues(t *testing.T) {
 	ts := v.LastUpdated()
 	m.Set("cartoon", "Futurama")
 	assert.True(t, ts.Before(v.Get(Root).LastUpdated()))
+
+	assert.Equal(t, p, v.provider)
 }
 
 func TestCachedProvider_ErrorToSetCallback(t *testing.T) {


### PR DESCRIPTION
We need to set the cached value provider to the cached provider. If we don't do this, then we won't get the cached value on future `Get` calls from `value`.