### PR TITLE
Propagate tracing context through cherami backend

### DIFF
--- a/modules/task/cherami/cherami.go
+++ b/modules/task/cherami/cherami.go
@@ -299,10 +299,11 @@ func (b *Backend) withContext(delivery cherami.Delivery, f func(context.Context)
 			if err := delivery.Nack(); err != nil {
 				ulog.Logger(ctx).Error("Delivery Nack failed", zap.Error(err))
 			}
+		} else {
+			span = b.tracer.StartSpan(_operationName, ext.RPCServerOption(spanCtx))
+			defer span.Finish()
+			ctx = opentracing.ContextWithSpan(ctx, span)
 		}
-		span = b.tracer.StartSpan(_operationName, ext.RPCServerOption(spanCtx))
-		defer span.Finish()
-		ctx = opentracing.ContextWithSpan(ctx, span)
 	}
 	f(ctx)
 }

--- a/modules/task/cherami/cherami.go
+++ b/modules/task/cherami/cherami.go
@@ -302,8 +302,10 @@ func (b *Backend) withContext(delivery cherami.Delivery, f func(context.Context)
 			var span opentracing.Span
 			span = b.tracer.StartSpan(_operationName, ext.RPCServerOption(spanCtx))
 			defer span.Finish()
-			ctx = opentracing.ContextWithSpan(ctx, span)
+			f(opentracing.ContextWithSpan(ctx, span))
 		}
+
+		return
 	}
 
 	f(ctx)

--- a/modules/task/cherami/cherami_test.go
+++ b/modules/task/cherami/cherami_test.go
@@ -286,7 +286,7 @@ func TestEncodingErrors(t *testing.T) {
 		{errors.New("nack error"), map[string]int{"extract error": 1, "nack error": 1}},
 	}
 	for _, testArg := range testArgs {
-		tracer := &errTracer{opentracing.NoopTracer{}}
+		tracer := &tracing.ErrorTracer{Tracer: opentracing.NoopTracer{}}
 		zapLogger, buf := testutils.GetLockedInMemoryLogger()
 		defer ulog.SetLogger(zapLogger)()
 		host := service.NopHostConfigured(auth.NopClient, zapLogger, tracer)
@@ -330,26 +330,6 @@ func findInLogs(t *testing.T, logs []string, expectedLinesWithCt map[string]int)
 			"Expected msg: %s to occur %d times but found %d", k, v, actualLinesWithCt[k],
 		)
 	}
-}
-
-// errTracer is used to test error scenarios from context encoding
-type errTracer struct {
-	opentracing.Tracer
-}
-
-func (e *errTracer) Inject(
-	sm opentracing.SpanContext,
-	format interface{},
-	carrier interface{},
-) error {
-	return errors.New("inject error")
-}
-
-func (e *errTracer) Extract(
-	format interface{},
-	carrier interface{},
-) (opentracing.SpanContext, error) {
-	return nil, errors.New("extract error")
 }
 
 type cheramiMock struct {

--- a/modules/task/cherami/cherami_test.go
+++ b/modules/task/cherami/cherami_test.go
@@ -114,12 +114,6 @@ func TestBackendWorkflowWorkerPanic(t *testing.T) {
 	)
 }
 
-func TestBackendWorkflowWithTask(t *testing.T) {
-	m := newMock()
-	defer m.AssertExpectations(t)
-	//bknd := createNewBackend(t, m, _host)
-}
-
 func TestBackendWorkflowStateLocks(t *testing.T) {
 	m := newMock()
 	defer m.AssertExpectations(t)

--- a/modules/task/cherami/cherami_test.go
+++ b/modules/task/cherami/cherami_test.go
@@ -101,7 +101,7 @@ func TestBackendWorkflowWorkerPanic(t *testing.T) {
 	}
 	// Publish valid message
 	publish(t, m, bknd, deliveryCh, nil, nil)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.True(t, bknd.(*Backend).isRunning())
 	stopBackend(t, m, bknd)
 	// Nack panics are sent for a count of _numWorkers and 1 valid publish. Make sure they are

--- a/modules/task/encoding.go
+++ b/modules/task/encoding.go
@@ -95,12 +95,14 @@ func (c *ContextEncoding) Marshal(ctx context.Context) ([]byte, error) {
 	if span == nil {
 		return nil, nil
 	}
+
 	spanCtx := span.Context()
 	if spanCtx == nil {
 		return nil, nil
 	}
-	carrier := bytes.NewBuffer([]byte{})
-	err := c.Tracer.Inject(spanCtx, opentracing.Binary, carrier)
+
+	var carrier bytes.Buffer
+	err := c.Tracer.Inject(spanCtx, opentracing.Binary, &carrier)
 	return carrier.Bytes(), err
 }
 
@@ -110,9 +112,11 @@ func (c *ContextEncoding) Marshal(ctx context.Context) ([]byte, error) {
 func (c *ContextEncoding) Unmarshal(data []byte) (opentracing.SpanContext, error) {
 	carrier := bytes.NewBuffer(data)
 	spanContext, err := c.Tracer.Extract(opentracing.Binary, carrier)
+
 	// If no SpanContext was given, we return nil instead of erroring
 	if err == opentracing.ErrSpanContextNotFound {
 		return nil, nil
 	}
+
 	return spanContext, err
 }

--- a/modules/task/encoding.go
+++ b/modules/task/encoding.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
-	"fmt"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -97,13 +96,11 @@ func (c *ContextEncoding) Marshal(ctx context.Context) ([]byte, error) {
 		return nil, nil
 	}
 	spanCtx := span.Context()
-	fmt.Println("SpanCtx", spanCtx)
 	if spanCtx == nil {
 		return nil, nil
 	}
 	carrier := bytes.NewBuffer([]byte{})
 	err := c.Tracer.Inject(spanCtx, opentracing.Binary, carrier)
-	fmt.Println("Carrier", carrier)
 	return carrier.Bytes(), err
 }
 

--- a/modules/task/encoding_test.go
+++ b/modules/task/encoding_test.go
@@ -75,3 +75,13 @@ func TestContextEncoding(t *testing.T) {
 		})
 	})
 }
+
+func TestContextEncodingWithNoSpan(t *testing.T) {
+	encoding := ContextEncoding{Tracer: opentracing.NoopTracer{}}
+	msg, err := encoding.Marshal(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, msg)
+	spanCtx, err := encoding.Unmarshal(msg)
+	require.NoError(t, err)
+	assert.Nil(t, spanCtx)
+}

--- a/testutils/tracing/tracer.go
+++ b/testutils/tracing/tracer.go
@@ -31,14 +31,21 @@ import (
 	"go.uber.org/zap"
 )
 
-// WithSpan is used for generating a span to be used in testing
-func WithSpan(t *testing.T, log *zap.Logger, f func(opentracing.Span)) {
-	tracer, closer, err := tracing.CreateTracer(nil, "serviceName", log, tally.NoopScope)
+// WithTracer is used for generating a tracer to be used in testing
+func WithTracer(t *testing.T, log *zap.Logger, f func(opentracing.Tracer)) {
+	tracer, closer, err := tracing.CreateTracer(nil, "dummy", log, tally.NoopScope)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, closer.Close())
 	}()
-	span := tracer.StartSpan("test")
-	defer span.Finish()
-	f(span)
+	f(tracer)
+}
+
+// WithSpan is used for generating a span to be used in testing
+func WithSpan(t *testing.T, log *zap.Logger, f func(opentracing.Span)) {
+	WithTracer(t, log, func(tracer opentracing.Tracer) {
+		span := tracer.StartSpan("test")
+		defer span.Finish()
+		f(span)
+	})
 }

--- a/testutils/tracing/tracer.go
+++ b/testutils/tracing/tracer.go
@@ -21,6 +21,7 @@
 package tracing
 
 import (
+	"errors"
 	"testing"
 
 	"go.uber.org/fx/tracing"
@@ -48,4 +49,26 @@ func WithSpan(t *testing.T, log *zap.Logger, f func(opentracing.Span)) {
 		defer span.Finish()
 		f(span)
 	})
+}
+
+// ErrorTracer is used to test error scenarios from context encoding
+type ErrorTracer struct {
+	opentracing.Tracer
+}
+
+// Inject implements opentracing.Tracer
+func (e *ErrorTracer) Inject(
+	sm opentracing.SpanContext,
+	format interface{},
+	carrier interface{},
+) error {
+	return errors.New("inject error")
+}
+
+// Extract implements opentracing.Tracer
+func (e *ErrorTracer) Extract(
+	format interface{},
+	carrier interface{},
+) (opentracing.SpanContext, error) {
+	return nil, errors.New("extract error")
 }


### PR DESCRIPTION
When a task is enqueued, the context is dropped on the floor. This change is to extract values (SpanContext) from the context and pass this on to the cherami. When the cherami message is consumed, the context values is retrieved, decoded and passed on to the function execution,