### PR TITLE
Update glide lock for the correct YARPC version

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 275e1020ca1e7f8314c2a94ea6cc3964515561dab40e35d0847e08e99842c5de
-updated: 2017-03-22T19:35:19.914547464-07:00
+updated: 2017-03-23T12:57:56.325940899-07:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -63,7 +63,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 34be4a565ce6286a0ba91a54a81be3f6181ca2e2
 - name: github.com/uber/cherami-client-go
-  version: f6da4234a00f2494cacf22e364b92c3972e2050a
+  version: 1cdcfc4a204fe42013f4cf7196fab208d3b98085
   subpackages:
   - client/cherami
   - common
@@ -76,7 +76,7 @@ imports:
   subpackages:
   - .generated/go/cherami
 - name: github.com/uber/jaeger-client-go
-  version: cbd3b6fe50f6d077951da8aabb06374f0ccf3181
+  version: 153cc21d199f5a4b65d0d7219c1f423ea58cfab5
   subpackages:
   - config
   - internal/spanlog
@@ -109,11 +109,12 @@ imports:
 - name: go.uber.org/atomic
   version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: go.uber.org/dig
-  version: bbd35793b6915659f563f30533c7be4f43bc71a8
+  version: 869ade8e3afd0b6dee05418a8e165cdcb487070a
 - name: go.uber.org/thriftrw
-  version: c98a13058faa5dd41584a77221a268d2c72d832d
+  version: 05f870b3c56597d180af568a6392209cc33269e2
   subpackages:
   - envelope
+  - internal
   - internal/envelope
   - internal/envelope/exception
   - internal/frame
@@ -128,7 +129,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 3860420a469b82f1708886e4e03ea75a2314f237
+  version: 6ad92c34d7e982d4bb7299f20e6a27652116cf5d
   subpackages:
   - api/encoding
   - api/middleware


### PR DESCRIPTION
[ERROR]	Failed to set version on go.uber.org/yarpc to 3860420a469b82f1708886e4e03ea75a2314f237: Unable to update checked out version
[ERROR]	Failed to set references: Unable to update checked out version (Skip to cleanup)