### PR TITLE
Refactor http module

### DIFF
--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -175,8 +175,8 @@ func makeRequest(m *Module, method, url string, body io.Reader, fn func(r *http.
 		// Yes, panics are OK for programmer errors in test suites
 		panic(err)
 	}
+
 	response, err := _defaultHTTPClient.Do(request)
-	fmt.Println(err)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/uhttp/http_test.go
+++ b/modules/uhttp/http_test.go
@@ -175,8 +175,8 @@ func makeRequest(m *Module, method, url string, body io.Reader, fn func(r *http.
 		// Yes, panics are OK for programmer errors in test suites
 		panic(err)
 	}
-
 	response, err := _defaultHTTPClient.Do(request)
+	fmt.Println(err)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/uhttp/router_test.go
+++ b/modules/uhttp/router_test.go
@@ -44,11 +44,11 @@ func withRouter(t *testing.T, f func(r *Router, l net.Listener)) {
 	r := NewRouter(service.NopHost())
 	l := serve(t, r)
 	defer l.Close()
-	r.Handle("/foo/baz/quokka",
+	r.AddPatternRoute("/foo/baz/quokka",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Write([]byte("hello"))
 		}))
-	r.Handle("/foo/bar/quokka",
+	r.AddPatternRoute("/foo/bar/quokka",
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Write([]byte("world"))
 		}))

--- a/modules/uhttp/routes.go
+++ b/modules/uhttp/routes.go
@@ -26,13 +26,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// FromGorilla turns a gorilla mux route into an UberFx route
-func FromGorilla(r *mux.Route) Route {
-	return Route{
-		r: r,
-	}
-}
-
 // A RouteHandler is an HTTP handler for a single route
 type RouteHandler struct {
 	Path    string
@@ -47,14 +40,14 @@ func NewRouteHandler(path string, handler http.Handler) RouteHandler {
 	}
 }
 
+// NewRoute returns new route
+func NewRoute() Route {
+	return Route{}
+}
+
 // A Route represents a handler for HTTP requests, with restrictions
 type Route struct {
 	r *mux.Route
-}
-
-// GorillaMux returns the underlying mux if you need to use it directly
-func (r Route) GorillaMux() *mux.Route {
-	return r.r
 }
 
 // Headers allows easy enforcement of headers

--- a/modules/uhttp/routes_test.go
+++ b/modules/uhttp/routes_test.go
@@ -29,27 +29,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFromGorilla_OK(t *testing.T) {
-	r := mux.NewRouter()
-	route := r.Headers("foo", "bar")
-	f := FromGorilla(route)
-	assert.Equal(t, f.r, route)
-}
-
 func TestNewRouteHandler(t *testing.T) {
 	rh := NewRouteHandler("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "Hi\n")
 	}))
 
 	assert.Equal(t, rh.Path, "/")
-}
-
-func TestGorillaMux_OK(t *testing.T) {
-	r := mux.NewRouter()
-	route := r.Path("/foo")
-	ours := FromGorilla(route)
-	rounded := ours.GorillaMux()
-	assert.Equal(t, route, rounded)
 }
 
 func TestHeaders_OK(t *testing.T) {


### PR DESCRIPTION
Middlewares are defined on router than the handler. Now they can be defined and build separately from handlers. Following to this change, we want to separate and build middlewares specific to the defined routes. 