### PR TITLE
Fix uhttp module port for simple example

### DIFF
--- a/examples/simple/config/base.yaml
+++ b/examples/simple/config/base.yaml
@@ -3,7 +3,7 @@ description: A simple example service
 owner: owner@service.com
 
 modules:
-  http:
+  uhttp:
     roles:
       - worker
       - web


### PR DESCRIPTION
Haven't I done this already? Strange deja vu

Was defaulting to 3001, rather than 8080 from config.

```
{"level":"info","ts":1490388666.585783,"caller":"uhttp/http.go:147","msg":"Server listening on port","trace":{},"module":"uhttp","port":3001}
```