### PR TITLE
Report file name for invalid yamls

### DIFF
--- a/config/yaml.go
+++ b/config/yaml.go
@@ -49,7 +49,7 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 		var curr interface{}
 		if err := unmarshalYAMLValue(v, &curr); err != nil {
 			if file, ok := v.(*os.File); ok {
-				panic(errors.Wrap(err, fmt.Sprintf("in file: %q", file.Name())))
+				panic(errors.Wrapf(err, "in file: %q", file.Name()))
 			}
 
 			panic(err)

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -48,6 +48,10 @@ func newYAMLProviderCore(files ...io.ReadCloser) Provider {
 	for _, v := range files {
 		var curr interface{}
 		if err := unmarshalYAMLValue(v, &curr); err != nil {
+			if file, ok := v.(*os.File); ok {
+				panic(errors.Wrap(err, fmt.Sprintf("in file: %q", file.Name())))
+			}
+
 			panic(err)
 		}
 

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -821,3 +821,23 @@ F: error
 		t.Run(k, func(*testing.T) { v() })
 	}
 }
+
+func TestFileNameInPanic(t *testing.T) {
+	t.Parallel()
+	f, err := ioutil.TempFile("", "testYaml")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	f.Write([]byte("\t"))
+	require.NoError(t, f.Close())
+
+	defer func() {
+		e := recover()
+		require.NotNil(t, e)
+		err, ok := e.(error)
+		require.True(t, ok)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), f.Name())
+	}()
+
+	NewYAMLProviderFromFiles(true, NewRelativeResolver(), f.Name())
+}


### PR DESCRIPTION
Right now we panic on invalid file with a line number only.
We can do better and  do a simple type check on a reader
to report a file name too.
