### PR TITLE
Do not interpolate secrets.yaml

### DIFF
--- a/config/testdata/secrets.yaml
+++ b/config/testdata/secrets.yaml
@@ -1,1 +1,1 @@
-secret: my_secret
+secret: my_${secret}

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -291,7 +291,7 @@ func unmarshalYAMLValue(reader io.ReadCloser, value interface{}, lookUp lookUpFu
 	var data []byte
 	skipInterpolate := false
 	if f, ok := reader.(*os.File); ok {
-		if strings.Contains(f.Name(), "secrets.yaml") {
+		if strings.Contains(f.Name(), _secretsFile) {
 			skipInterpolate = true
 			data = raw
 		}

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -166,7 +166,7 @@ func TestExtends(t *testing.T) {
 	assert.Equal(t, "dev_setting", devValue)
 
 	secretValue := provider.Get("secret").AsString()
-	assert.Equal(t, "my_secret", secretValue)
+	assert.Equal(t, "my_${secret}", secretValue)
 }
 
 func TestAppRoot(t *testing.T) {
@@ -181,7 +181,7 @@ func TestAppRoot(t *testing.T) {
 	assert.Equal(t, "dev_setting", devValue)
 
 	secretValue := provider.Get("secret").AsString()
-	assert.Equal(t, "my_secret", secretValue)
+	assert.Equal(t, "my_${secret}", secretValue)
 }
 
 func TestNewYAMLProviderFromReader(t *testing.T) {


### PR DESCRIPTION
Secrets often contain auto-generated passwords and things of that nature, which can contain combinations that look very much like an environment interpolation syntax.

This still doesn't resolve the need to give user control should they actually want literal `${}` in their config.