### PR TITLE
Introduce a command line provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - **[Breaking]** Introduce a config loader, this will allow to override config loading
   and use custom dirs to load from. In order to load configs calls to `config.Load()`
   should be replaced with `config.NewLoader().Load()`.
-- Added `metrics.NopScope` for tests on service.NopHost with tagging capabilities turned
-  on by default
+- Added `metrics.NopScope` for tests on service.NopHost with tagging capabilities
+  turned on by default
+- Added a command line provider `config.NewCommandLineProvider()`, which can be used
+  to pass configuration parameters through command line.
 
 ## v1.0.0-beta3 (28 Mar 2017)
 

--- a/config/cache_provider.go
+++ b/config/cache_provider.go
@@ -29,8 +29,7 @@ type cachedProvider struct {
 	sync.RWMutex
 	cache map[string]Value
 
-	p Provider
-	NopProvider
+	Provider
 }
 
 // NewCachedProvider returns a provider, that caches values of the underlying Provider p.
@@ -43,13 +42,13 @@ func NewCachedProvider(p Provider) Provider {
 	}
 
 	return &cachedProvider{
-		p:     p,
-		cache: make(map[string]Value),
+		Provider: p,
+		cache:    make(map[string]Value),
 	}
 }
 
 func (p *cachedProvider) Name() string {
-	return fmt.Sprintf("cached %q", p.p.Name())
+	return fmt.Sprintf("cached %q", p.Provider.Name())
 }
 
 // Retrieves a Value, caches it internally and subscribe to changes via RegisterCallback.
@@ -62,7 +61,7 @@ func (p *cachedProvider) Get(key string) Value {
 	}
 
 	p.RUnlock()
-	err := p.p.RegisterChangeCallback(key, func(key string, provider string, data interface{}) {
+	err := p.Provider.RegisterChangeCallback(key, func(key string, provider string, data interface{}) {
 		p.Lock()
 		p.cache[key] = NewValue(p, key, data, true, GetType(data), nil)
 		p.Unlock()
@@ -72,7 +71,7 @@ func (p *cachedProvider) Get(key string) Value {
 		return NewValue(p, key, err, false, GetType(err), nil)
 	}
 
-	v := p.p.Get(key)
+	v := p.Provider.Get(key)
 	v.provider = p
 	p.Lock()
 	p.cache[key] = v

--- a/config/cache_provider.go
+++ b/config/cache_provider.go
@@ -79,3 +79,13 @@ func (p *cachedProvider) Get(key string) Value {
 
 	return v
 }
+
+// No need to register a callback, all the values are fresh.
+func (p *cachedProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
+	return nil
+}
+
+// No need to unregister a callback, because nothing was registered.
+func (p *cachedProvider) UnregisterChangeCallback(token string) error {
+	return nil
+}

--- a/config/command_line_provider.go
+++ b/config/command_line_provider.go
@@ -70,7 +70,7 @@ func NewCommandLineProvider(flags *flag.FlagSet, args []string) Provider {
 func assignValues(m map[string]interface{}, key string, value flag.Value) {
 	if ss, ok := value.(*StringSlice); ok {
 		slice := []string(*ss)
-		tmp := map[string]interface{}{}
+		tmp := make(map[string]interface{}, len(slice))
 		m[key] = tmp
 		for i, str := range slice {
 			tmp[fmt.Sprint(i)] = str
@@ -95,6 +95,8 @@ func traversePath(m map[string]interface{}, f *flag.Flag) (prev map[string]inter
 		if tmp, ok := curr[item].(map[string]interface{}); ok {
 			curr = tmp
 		} else {
+			// This should never happen, because pflag/flag sort flags before calling a visitor,
+			// but it is better to be safe then sorry.
 			curr = map[string]interface{}{}
 		}
 	}

--- a/config/command_line_provider.go
+++ b/config/command_line_provider.go
@@ -83,7 +83,7 @@ func assignValues(m map[string]interface{}, key string, value flag.Value) {
 }
 
 // Traverse map with the flag name used as path.
-func traversePath(m map[string]interface{}, f *flag.Flag) (prev map[string]interface{}, last string) {
+func traversePath(m map[string]interface{}, f *flag.Flag) (map[string]interface{}, string) {
 	curr, prev := m, m
 	path := strings.Split(f.Name, _separator)
 	for _, item := range path {

--- a/config/command_line_provider.go
+++ b/config/command_line_provider.go
@@ -32,18 +32,19 @@ type StringSlice []string
 
 var _ flag.Value = (*StringSlice)(nil)
 
+// String returns slice elements separated by comma.
 func (s *StringSlice) String() string {
 	return strings.Join(*s, ",")
 }
 
+// Set splits val using comma as separators.
 func (s *StringSlice) Set(val string) error {
 	*s = StringSlice(strings.Split(val, ","))
 	return nil
 }
 
 type commandLineProvider struct {
-	p Provider
-	NopProvider
+	Provider
 }
 
 // NewCommandLineProvider returns a Provider that is using command line parameters as config values.
@@ -60,7 +61,7 @@ func NewCommandLineProvider(flags *flag.FlagSet, args []string) Provider {
 		assignValues(prev, last, f.Value)
 	})
 
-	return &commandLineProvider{p: NewStaticProvider(m)}
+	return commandLineProvider{Provider: NewStaticProvider(m)}
 }
 
 // Assign values to a map element based on value type.
@@ -101,10 +102,6 @@ func traversePath(m map[string]interface{}, f *flag.Flag) (prev map[string]inter
 	return prev, path[len(path)-1]
 }
 
-func (c *commandLineProvider) Name() string {
+func (commandLineProvider) Name() string {
 	return "cmd"
-}
-
-func (c *commandLineProvider) Get(key string) Value {
-	return c.p.Get(key)
 }

--- a/config/command_line_provider.go
+++ b/config/command_line_provider.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	flag "github.com/ogier/pflag"
+)
+
+type stringSlice []string
+
+func (s *stringSlice) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *stringSlice) Set(val string) error {
+	*s = stringSlice(strings.Split(val, ","))
+	return nil
+}
+
+type commandLineProvider struct {
+	Provider
+}
+
+// NewCommandLineProvider returns a Provider that is using command line parameters as config values.
+func NewCommandLineProvider(flags *flag.FlagSet, args []string) Provider {
+	if err := flags.Parse(args); err != nil {
+		panic(err)
+	}
+
+	m := make(map[string]interface{})
+	flags.VisitAll(func(f *flag.Flag) {
+		val := f.Value
+		if ss, ok := val.(*stringSlice); ok {
+			slice := []string(*ss)
+			m[f.Name] = slice
+			for i, str := range slice {
+				m[fmt.Sprintf("%s.%d", f.Name, i)] = str
+			}
+
+			return
+		}
+
+		m[f.Name] = f.Value.String()
+	})
+
+	return commandLineProvider{Provider: NewStaticProvider(m)}
+}
+
+func (c commandLineProvider) Name() string {
+	return "cmd"
+}

--- a/config/command_line_provider.go
+++ b/config/command_line_provider.go
@@ -39,7 +39,8 @@ func (s *stringSlice) Set(val string) error {
 }
 
 type commandLineProvider struct {
-	Provider
+	p Provider
+	NopProvider
 }
 
 // NewCommandLineProvider returns a Provider that is using command line parameters as config values.
@@ -64,9 +65,14 @@ func NewCommandLineProvider(flags *flag.FlagSet, args []string) Provider {
 		m[f.Name] = f.Value.String()
 	})
 
-	return commandLineProvider{Provider: NewStaticProvider(m)}
+	m[""] = ""
+	return &commandLineProvider{p: NewStaticProvider(m)}
 }
 
-func (c commandLineProvider) Name() string {
+func (c *commandLineProvider) Name() string {
 	return "cmd"
+}
+
+func (c *commandLineProvider) Get(key string) Value {
+	return c.p.Get(key)
 }

--- a/config/command_line_provider.go
+++ b/config/command_line_provider.go
@@ -68,6 +68,7 @@ func NewCommandLineProvider(flags *flag.FlagSet, args []string) Provider {
 			}
 		}
 
+		// Assign values
 		last := path[len(path)-1]
 		if ss, ok := f.Value.(*stringSlice); ok {
 			slice := []string(*ss)

--- a/config/command_line_provider_test.go
+++ b/config/command_line_provider_test.go
@@ -97,20 +97,24 @@ func TestCommandLineProvider_NestedValues(t *testing.T) {
 	t.Parallel()
 
 	f := flag.NewFlagSet("", flag.PanicOnError)
-	f.String("Name.Source", "default", "")
-	f.String("Name", "wonka", "")
+	f.String("Name.Source", "default", "Data provider source")
+	f.Var(&stringSlice{}, "Name.Array", "Example of a nested array")
 
-	c := NewCommandLineProvider(f, []string{"--Name.Source=chocolateFactory", "--Name=wonka"})
+	c := NewCommandLineProvider(f, []string{"--Name.Source=chocolateFactory", "--Name.Array=one, two,three"})
 	type Wonka struct {
 		Source string
+		Array  []string
 	}
 
 	type Willy struct {
 		Name Wonka
 	}
 
-	//g := NewProviderGroup("group", c, NewStaticProvider(Willy{Name: Wonka{Source: "staticProvider"}}))
+	g := NewProviderGroup("group", NewStaticProvider(Willy{Name: Wonka{Source: "staticProvider"}}), c)
 	var v Willy
-	require.NoError(t, c.Get("").Populate(&v))
-	assert.Equal(t, Willy{Name: Wonka{Source: "chocolateFactory"}}, v)
+	require.NoError(t, g.Get(Root).Populate(&v))
+	assert.Equal(t, Willy{Name: Wonka{
+		Source: "chocolateFactory",
+		Array:  []string{"one", " two", "three"},
+	}}, v)
 }

--- a/config/command_line_provider_test.go
+++ b/config/command_line_provider_test.go
@@ -126,7 +126,7 @@ func TestCommandLineProvider_OverlappingFlags(t *testing.T) {
 	f.String("Sushi.Tools.1", "Saibashi", "Chopsticks are extremely helpful!")
 	f.Var(&StringSlice{}, "Sushi.Tools", "yolo")
 
-	c := NewCommandLineProvider(f, []string{"--Sushi.Tools.1=Fork", "--Sushi.Tools=Fukin, Hashi"})
+	c := NewCommandLineProvider(f, []string{"--Sushi.Tools.1=Fork", "--Sushi.Tools=Hocho, Hashi"})
 	type Sushi struct {
 		Tools []string
 	}
@@ -134,6 +134,6 @@ func TestCommandLineProvider_OverlappingFlags(t *testing.T) {
 	var v Sushi
 	require.NoError(t, c.Get("Sushi").Populate(&v))
 	assert.Equal(t, Sushi{
-		Tools: []string{"Fukin", "Fork"},
+		Tools: []string{"Hocho", "Fork"},
 	}, v)
 }

--- a/config/command_line_provider_test.go
+++ b/config/command_line_provider_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/ogier/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandLineProvider_Roles(t *testing.T) {
+	t.Parallel()
+
+	f := pflag.NewFlagSet("", pflag.PanicOnError)
+	var s stringSlice
+	f.Var(&s, "roles", "")
+
+	c := NewCommandLineProvider(f, []string{`--roles=a,b,c"d"`})
+	v := c.Get("roles")
+	require.True(t, v.HasValue())
+	var roles []string
+	require.NoError(t, v.Populate(&roles))
+	assert.Equal(t, []string{"a", "b", `c"d"`}, roles)
+}
+
+func TestCommandLineProvider_Default(t *testing.T) {
+	t.Parallel()
+
+	f := pflag.NewFlagSet("", pflag.PanicOnError)
+	f.String("killerFeature", "minesweeper", "Start->Games->Minesweeper")
+
+	c := NewCommandLineProvider(f, nil)
+	v := c.Get("killerFeature")
+	require.True(t, v.HasValue())
+	assert.Equal(t, "minesweeper", v.AsString())
+}
+
+func TestCommandLineProvider_Conversion(t *testing.T) {
+	t.Parallel()
+
+	f := pflag.NewFlagSet("", pflag.PanicOnError)
+	f.String("dozen", "14", " that number of rolls being allowed to the purchaser of a dozen")
+
+	c := NewCommandLineProvider(f, []string{"--dozen=13"})
+	v := c.Get("dozen")
+	require.True(t, v.HasValue())
+	assert.Equal(t, 13, v.AsInt())
+}
+
+func TestCommandLineProvider_PanicOnUnknownFlags(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		NewCommandLineProvider(pflag.NewFlagSet("", pflag.ContinueOnError), []string{"--boom"})
+	})
+}
+
+func TestCommandLineProvider_Name(t *testing.T) {
+	t.Parallel()
+	p := NewCommandLineProvider(pflag.NewFlagSet("", pflag.PanicOnError), nil)
+	assert.Equal(t, "cmd", p.Name())
+}
+
+func TestCommandLineProvider_RepeatingArguments(t *testing.T) {
+	t.Parallel()
+
+	f := pflag.NewFlagSet("", pflag.PanicOnError)
+	f.Int("count", 1, "If I had a million dollars")
+
+	c := NewCommandLineProvider(f, []string{"--count=2", "--count=3"})
+	v := c.Get("count")
+	require.True(t, v.HasValue())
+	assert.Equal(t, "3", v.AsString())
+}

--- a/config/command_line_provider_test.go
+++ b/config/command_line_provider_test.go
@@ -32,7 +32,7 @@ func TestCommandLineProvider_Roles(t *testing.T) {
 	t.Parallel()
 
 	f := flag.NewFlagSet("", flag.PanicOnError)
-	var s stringSlice
+	var s StringSlice
 	f.Var(&s, "roles", "")
 
 	c := NewCommandLineProvider(f, []string{`--roles=a,b,c"d"`})
@@ -98,7 +98,7 @@ func TestCommandLineProvider_NestedValues(t *testing.T) {
 
 	f := flag.NewFlagSet("", flag.PanicOnError)
 	f.String("Name.Source", "default", "Data provider source")
-	f.Var(&stringSlice{}, "Name.Array", "Example of a nested array")
+	f.Var(&StringSlice{}, "Name.Array", "Example of a nested array")
 
 	c := NewCommandLineProvider(f, []string{"--Name.Source=chocolateFactory", "--Name.Array=one, two,three"})
 	type Wonka struct {

--- a/config/config.go
+++ b/config/config.go
@@ -293,7 +293,7 @@ func (l *Loader) SetLookupFn(fn func(string) (string, bool)) {
 }
 
 func commandLineProviderFunc() (Provider, error) {
-	var s stringSlice
+	var s StringSlice
 	flag.CommandLine.Var(&s, "roles", "")
 	return NewCommandLineProvider(flag.CommandLine, os.Args[1:]), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,11 +22,12 @@ package config
 
 import (
 	"fmt"
-	"github.com/ogier/pflag"
 	"os"
 	"path"
 	"path/filepath"
 	"sync"
+
+	flag "github.com/ogier/pflag"
 )
 
 const (
@@ -69,10 +70,6 @@ type Loader struct {
 
 	// Where to look for environment variables.
 	lookUp lookUpFunc
-}
-
-func commandLineProviderFunc() (Provider, error) {
-	return NewCommandLineProvider(pflag.CommandLine, os.Args[1:]), nil
 }
 
 // DefaultLoader is going to be used by a service if config is not specified.
@@ -293,4 +290,10 @@ func (l *Loader) SetLookupFn(fn func(string) (string, bool)) {
 	defer l.lock.Unlock()
 
 	l.lookUp = fn
+}
+
+func commandLineProviderFunc() (Provider, error) {
+	var s stringSlice
+	flag.CommandLine.Var(&s, "roles", "")
+	return NewCommandLineProvider(flag.CommandLine, os.Args[1:]), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -86,7 +86,7 @@ func NewLoader(providers ...ProviderFunc) *Loader {
 	}
 
 	l.configFiles = l.baseFiles()
-	// Order is important: we want users to be able to override
+	// Order is important: we want users to be able to override static provider
 	l.RegisterProviders(l.YamlProvider())
 	l.RegisterProviders(providers...)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -621,3 +621,18 @@ func TestZeroInitializeLoader(t *testing.T) {
 	var l Loader
 	assert.NotPanics(t, func() { l.Load() })
 }
+
+func TestLoader_StaticProviderOrder(t *testing.T) {
+	t.Parallel()
+	f := func(dir string) {
+		l := NewLoader(func() (Provider, error) {
+			return NewStaticProvider(map[string]string{"value": "correct"}), nil
+		})
+
+		l.SetDirs(dir)
+		p := l.Load()
+		assert.Equal(t, "correct", p.Get("value").AsString())
+	}
+
+	withBase(t, f, "value: wrong")
+}

--- a/config/static_provider.go
+++ b/config/static_provider.go
@@ -23,7 +23,8 @@ package config
 import "gopkg.in/yaml.v2"
 
 type staticProvider struct {
-	Provider
+	p Provider
+	NopProvider
 }
 
 // NewStaticProvider should only be used in tests to isolate config from your environment
@@ -34,7 +35,7 @@ func NewStaticProvider(data interface{}) Provider {
 		panic(err)
 	}
 
-	return staticProvider{NewYAMLProviderFromBytes(b)}
+	return staticProvider{p: NewYAMLProviderFromBytes(b)}
 }
 
 // StaticProvider returns function to create StaticProvider during configuration initialization
@@ -44,8 +45,12 @@ func StaticProvider(data interface{}) ProviderFunc {
 	}
 }
 
-func (staticProvider) Name() string {
+func (s staticProvider) Name() string {
 	return "static"
+}
+
+func (s staticProvider) Get(key string) Value {
+	return s.p.Get(key)
 }
 
 var _ Provider = &staticProvider{}

--- a/config/static_provider.go
+++ b/config/static_provider.go
@@ -23,8 +23,7 @@ package config
 import "gopkg.in/yaml.v2"
 
 type staticProvider struct {
-	p Provider
-	NopProvider
+	Provider
 }
 
 // NewStaticProvider should only be used in tests to isolate config from your environment
@@ -35,7 +34,7 @@ func NewStaticProvider(data interface{}) Provider {
 		panic(err)
 	}
 
-	return staticProvider{p: NewYAMLProviderFromBytes(b)}
+	return staticProvider{Provider: NewYAMLProviderFromBytes(b)}
 }
 
 // StaticProvider returns function to create StaticProvider during configuration initialization
@@ -45,12 +44,6 @@ func StaticProvider(data interface{}) ProviderFunc {
 	}
 }
 
-func (s staticProvider) Name() string {
+func (staticProvider) Name() string {
 	return "static"
 }
-
-func (s staticProvider) Get(key string) Value {
-	return s.p.Get(key)
-}
-
-var _ Provider = &staticProvider{}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8e8224a2ba8f61089673297868bb05b4154c3beeea1db92045df954c471c4d86
-updated: 2017-04-11T11:49:16.007397633-07:00
+hash: 0c3a9321d883b41d0d74669a604f6d76e9be838fa2d4f45922419346c558359f
+updated: 2017-04-11T12:59:07.851765717-07:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -210,6 +210,8 @@ testImports:
   version: 22c51662ff476dfd97944f74db1b263ed920ee83
   subpackages:
   - cmd/interfacer
+- name: github.com/mvdan/lint
+  version: c9cbe299b369cbfea16318baaa037b19a69e45d2
 - name: github.com/russross/blackfriday
   version: 5ebfae50aacdef0dacd1a1acc469c2c1c7a7d4d8
 - name: github.com/sectioneight/md-to-godoc

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 8e8224a2ba8f61089673297868bb05b4154c3beeea1db92045df954c471c4d86
-updated: 2017-04-10T16:08:40.885758964-07:00
+updated: 2017-04-11T11:49:16.007397633-07:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -12,9 +12,9 @@ imports:
 - name: github.com/certifi/gocertifi
   version: 03be5e6bb9874570ea7fb0961225d193cbc374c5
 - name: github.com/codahale/hdrhistogram
-  version: f8ad88b59a584afeee9d334eff879b104439117b
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -32,7 +32,7 @@ imports:
 - name: github.com/gorilla/mux
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/gorilla/websocket
-  version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
+  version: a91eba7f97777409bc2c443f5534d41dd20c5720
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opentracing/opentracing-go
@@ -41,7 +41,7 @@ imports:
   - ext
   - log
 - name: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
+  version: 1b00554d822231195d1babd97ff4a781231955c9
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
@@ -49,7 +49,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/Sirupsen/logrus
-  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
+  version: 10f801ebc38b33738c9d17d50860f484a0988ff5
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
@@ -59,7 +59,7 @@ imports:
   - mock
   - require
 - name: github.com/uber-common/bark
-  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
+  version: 148dd9dfbd0feb293fc81593a8c10c99877f81bc
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
@@ -74,7 +74,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: b745766cbb5398b92f532daf4ac8f7c0fa9555ac
+  version: 491bc3af350b3cdc0780c6f99ca9fd0a82aeb850
   subpackages:
   - .generated/go/cherami
 - name: github.com/uber/jaeger-client-go
@@ -172,11 +172,11 @@ imports:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  version: f3918c30c5c2cb527c0b071a27c35120a6c0719a
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: ef3dcd5937c94da5c25df3f3a5d8356d778af8e4
+  version: 7ee420f17d7525d013c72c05ed371361a29895d3
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/yaml.v2

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 03dda616164575043fff9196cb586410a53906cceb2aa0a9105eb17b7a4a2e1f
-updated: 2017-03-28T11:36:43.637865373-07:00
+hash: 8e8224a2ba8f61089673297868bb05b4154c3beeea1db92045df954c471c4d86
+updated: 2017-04-10T16:08:40.885758964-07:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -14,7 +14,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -33,6 +33,8 @@ imports:
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/gorilla/websocket
   version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
+- name: github.com/ogier/pflag
+  version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
@@ -43,13 +45,13 @@ imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/Sirupsen/logrus
   version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
   version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
@@ -72,7 +74,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 09ed2ceaeab9e52820a81caece0dee9914c31f5d
+  version: b745766cbb5398b92f532daf4ac8f7c0fa9555ac
   subpackages:
   - .generated/go/cherami
 - name: github.com/uber/jaeger-client-go
@@ -90,7 +92,7 @@ imports:
   - transport/udp
   - utils
 - name: github.com/uber/jaeger-lib
-  version: 9dd8526f119f8cd8379427bfefdc406e81bc3b2f
+  version: ffca3143c929e9b97325e6bebcc380e8c6e5fa0d
   subpackages:
   - metrics
   - metrics/tally
@@ -130,7 +132,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 6ad92c34d7e982d4bb7299f20e6a27652116cf5d
+  version: 6ae533f0810337028ef055b690360e050aa13219
   subpackages:
   - api/encoding
   - api/middleware
@@ -139,7 +141,6 @@ imports:
   - encoding/thrift
   - encoding/thrift/internal
   - internal
-  - internal/buffer
   - internal/clientconfig
   - internal/encoding
   - internal/errors
@@ -156,7 +157,7 @@ imports:
   - transport/tchannel
   - transport/tchannel/internal
 - name: go.uber.org/zap
-  version: 4257c7cf05477d92ec25c31cfd3d60e89575f18a
+  version: a2773be06b9ac7c318a3a105b5c310af5730c6b4
   subpackages:
   - buffer
   - internal/bufferpool
@@ -166,7 +167,7 @@ imports:
   - zapcore
   - zaptest
 - name: golang.org/x/net
-  version: a6577fac2d73be281a500b310739095313165611
+  version: d1e1b351919c6738fdeb9893d5c998b161464f0c
   subpackages:
   - context
   - context/ctxhttp
@@ -175,16 +176,16 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 2946dd1f77e693e136d9ed202ba093bb4a3ea761
+  version: ef3dcd5937c94da5c25df3f3a5d8356d778af8e4
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
 - name: github.com/axw/gocov
-  version: c77561ca0c0cb1ed5d4ce4a912a75f5532566422
+  version: 3a69a0d2a4ef1f263e2d92b041a69593d6964fe8
   subpackages:
   - gocov
 - name: github.com/go-playground/overalls
@@ -202,11 +203,11 @@ testImports:
 - name: github.com/kisielk/gotool
   version: 0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220
 - name: github.com/kyoh86/richgo
-  version: 35d295f8d8df6dc5159273293c5d294cb6fb6b84
+  version: 572c50cd0bf65706adb400fac28583219615712b
 - name: github.com/mattn/goveralls
   version: a99c5ee06aeeca2a2befc7e90b99061b1180850c
 - name: github.com/mvdan/interfacer
-  version: 049d0176189d83d4e2535611f0253b6f1db487ad
+  version: 22c51662ff476dfd97944f74db1b263ed920ee83
   subpackages:
   - cmd/interfacer
 - name: github.com/russross/blackfriday
@@ -218,6 +219,6 @@ testImports:
 - name: github.com/yookoala/realpath
   version: c416d99ab5ed256fa30c1f3bab73152deb59bb69
 - name: go.uber.org/tools
-  version: fb05033aaa266ee0674167682d3da91bef95d02a
+  version: 5908733c544153a245dddd039959386356fbc082
   subpackages:
   - update-license

--- a/glide.yaml
+++ b/glide.yaml
@@ -68,6 +68,7 @@ testImport:
   version: 2
 - package: github.com/shurcooL/sanitized_anchor_name
 - package: github.com/mvdan/interfacer/cmd/interfacer
+- package: github.com/mvdan/lint
 - package: github.com/kyoh86/richgo
 - package: go.uber.org/tools
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,6 +35,7 @@ import:
 - package: github.com/uber/cherami-thrift
   subpackages:
   - .generated/go/cherami
+- package: github.com/ogier/pflag
 testImport:
 - package: golang.org/x/tools
   subpackages:

--- a/service/README.md
+++ b/service/README.md
@@ -65,14 +65,10 @@ func main() {
 }
 ```
 
-Which then allows us to set the roles either via a command line variable:
+Which then allows us to set the roles either via a command line flags:
 
-`export CONFIG__roles__0=worker`
-
-Or via the service parameters, we would activate in the following ways:
-
-* `./myservice` or `./myservice --roles "service,worker"`: Runs all modules
-* `./myservice --roles "worker"`: Runs only the **Kakfa** module
+* `./myservice` or `./myservice --roles=service,worker`: Runs all modules
+* `./myservice --roles=worker`: Runs only the **Kafka** module
 * Etc...
 
 ## Options

--- a/service/doc.go
+++ b/service/doc.go
@@ -86,15 +86,11 @@
 //     svc.Start()
 //   }
 //
-// Which then allows us to set the roles either via a command line variable:
+// Which then allows us to set the roles either via a command line flags:
 //
-// export CONFIG__roles__0=worker
+// • ./myservice or ./myservice --roles=service,worker: Runs all modules
 //
-// Or via the service parameters, we would activate in the following ways:
-//
-// • ./myservice or ./myservice --roles "service,worker": Runs all modules
-//
-// • ./myservice --roles "worker": Runs only the **Kakfa** module
+// • ./myservice --roles=worker: Runs only the **Kakfa** module
 //
 // • Etc...
 //

--- a/service/doc.go
+++ b/service/doc.go
@@ -90,7 +90,7 @@
 //
 // • ./myservice or ./myservice --roles=service,worker: Runs all modules
 //
-// • ./myservice --roles=worker: Runs only the **Kakfa** module
+// • ./myservice --roles=worker: Runs only the **Kafka** module
 //
 // • Etc...
 //

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -43,13 +43,17 @@ func TestNewOwner_ModulesErr(t *testing.T) {
 
 func TestNewOwner_WithMetricsOK(t *testing.T) {
 	assert.NotPanics(t, func() {
-		newManager(WithModule(nopModuleProvider).WithOptions(WithMetrics(tally.NoopScope, metrics.NopCachedStatsReporter)))
+		newManager(WithModule(nopModuleProvider).WithOptions(
+			withConfig(validServiceConfig),
+			WithMetrics(tally.NoopScope, metrics.NopCachedStatsReporter)))
 	})
 }
 
 func TestNewOwner_WithTracingOK(t *testing.T) {
 	tracer := &opentracing.NoopTracer{}
 	assert.NotPanics(t, func() {
-		newManager(WithModule(nopModuleProvider).WithOptions(WithTracer(tracer)))
+		newManager(WithModule(nopModuleProvider).WithOptions(
+			withConfig(validServiceConfig),
+			WithTracer(tracer)))
 	})
 }


### PR DESCRIPTION
Our documentation states that service roles can be overridden from command line,
but we never actually had a config provider that takes data from arguments
passed to a program.

We use "github.com/ogier/pflag" package to read command line flags, because
the standard one isn't POSIX compatible(it can be easily replaced with the standard
though by replacing import to "flag", function signatures are exactly the same).

By default flags don't have a support for list values, so we assume list elements
are comma separated. If users want to have different separators, the can create
their own type and set flags via [Var](https://godoc.org/github.com/ogier/pflag#FlagSet.Var)

If users want to introduce their own command line parameters, they can use the default pflag
[CommandLine](https://godoc.org/github.com/ogier/pflag#pkg-variables) variable and
extend the provider.

Documentation update is coming in the following PRs.