### PR TITLE
Remove x/net/context from task tests

### DIFF
--- a/modules/task/encoding_test.go
+++ b/modules/task/encoding_test.go
@@ -21,10 +21,9 @@
 package task
 
 import (
+	"context"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"go.uber.org/fx/testutils/tracing"
 	"go.uber.org/zap"


### PR DESCRIPTION
We should stick to a standard context everywhere