### PR TITLE
Remove authClient from host and cleanup CreateAuthInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   As part of refactor, RouteHandler is removed from the module registration.
 - `Loader.Path() string` is now `Loader.Paths() []string`, to better reflect that
   configuration is loaded from multiple directories.
+- **[Breaking]** Removed `CreateAuthInfo` interface from auth package. package auth
+  RegisterFunc now accepts `config.Provider` and `tally.Scope` for initialization.
+- **[Breaking]** Removed `auth.Client` access from `service.Host`. `auth.Client` can
+  now be accessed via `auth.Load()` call.
 
 ## v1.0.0-beta3 (28 Mar 2017)
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -36,7 +36,7 @@ type userAuthClient struct {
   // embed backend security service client here
 }
 
-func userAuthClient(info CreateAuthInfo) auth.Client {
+func userAuthClient(config config.Provider, scope tally.Scope) auth.Client {
 	return &userAuthClient{}
 }
 

--- a/auth/auth_failure_client.go
+++ b/auth/auth_failure_client.go
@@ -24,8 +24,9 @@ import (
 	"context"
 	"errors"
 
-	"github.com/uber-go/tally"
 	"go.uber.org/fx/config"
+
+	"github.com/uber-go/tally"
 )
 
 // FailureClient is used for auth failure testing

--- a/auth/auth_failure_client.go
+++ b/auth/auth_failure_client.go
@@ -23,13 +23,18 @@ package auth
 import (
 	"context"
 	"errors"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/fx/config"
 )
 
-type failureClient struct {
-}
+// FailureClient is used for auth failure testing
+var FailureClient = FakeFailureClient(nil, tally.NoopScope)
+
+type failureClient struct{}
 
 // FakeFailureClient fails all auth request and must only be used for testing
-func FakeFailureClient(info CreateAuthInfo) Client {
+func FakeFailureClient(config config.Provider, scope tally.Scope) Client {
 	return &failureClient{}
 }
 

--- a/auth/auth_stub.go
+++ b/auth/auth_stub.go
@@ -20,11 +20,16 @@
 
 package auth
 
-import "context"
+import (
+	"context"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/fx/config"
+)
 
 var (
 	// NopClient is used for testing and no-op integration
-	NopClient = nopClient(nil)
+	NopClient = nopClient(nil, tally.NoopScope)
 
 	_ Client = &nop{}
 )
@@ -32,7 +37,7 @@ var (
 type nop struct {
 }
 
-func nopClient(info CreateAuthInfo) Client {
+func nopClient(config config.Provider, scope tally.Scope) Client {
 	return &nop{}
 }
 

--- a/auth/auth_stub.go
+++ b/auth/auth_stub.go
@@ -23,8 +23,9 @@ package auth
 import (
 	"context"
 
-	"github.com/uber-go/tally"
 	"go.uber.org/fx/config"
+
+	"github.com/uber-go/tally"
 )
 
 var (

--- a/auth/doc.go
+++ b/auth/doc.go
@@ -66,7 +66,7 @@
 //     // embed backend security service client here
 //   }
 //
-//   func userAuthClient(info CreateAuthInfo) auth.Client {
+//   func userAuthClient(config config.Provider, scope tally.Scope) auth.Client {
 //   	return &userAuthClient{}
 //   }
 //

--- a/auth/localauth.go
+++ b/auth/localauth.go
@@ -20,7 +20,12 @@
 
 package auth
 
-import "context"
+import (
+	"context"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/fx/config"
+)
 
 var _ Client = &defaultClient{}
 
@@ -30,7 +35,7 @@ type defaultClient struct {
 
 // defaultAuth is a placeholder auth client when no auth client is registered
 // TODO(anup): add configurable authentication, whether a service needs one or not
-func defaultAuth(info CreateAuthInfo) Client {
+func defaultAuth(config config.Provider, scope tally.Scope) Client {
 	return &defaultClient{
 		authClient: NopClient,
 	}

--- a/auth/localauth.go
+++ b/auth/localauth.go
@@ -23,8 +23,9 @@ package auth
 import (
 	"context"
 
-	"github.com/uber-go/tally"
 	"go.uber.org/fx/config"
+
+	"github.com/uber-go/tally"
 )
 
 var _ Client = &defaultClient{}

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -44,14 +44,8 @@ var (
 	ErrAuthorization = "Error authorizing the service"
 )
 
-// CreateAuthInfo interface provides necessary data
-type CreateAuthInfo interface {
-	Config() config.Provider
-	Metrics() tally.Scope
-}
-
 // RegisterFunc is used during service init time to register the Auth client
-type RegisterFunc func(info CreateAuthInfo) Client
+type RegisterFunc func(config config.Provider, scope tally.Scope) Client
 
 // RegisterClient sets up the registerFunc for Auth client initialization
 func RegisterClient(registerFunc RegisterFunc) {
@@ -71,11 +65,11 @@ func UnregisterClient() {
 }
 
 // Load returns a Client instance based on registered auth client implementation
-func Load(info CreateAuthInfo) Client {
+func Load(config config.Provider, scope tally.Scope) Client {
 	_setupMu.Lock()
 	defer _setupMu.Unlock()
 	if _registerFunc != nil {
-		return _registerFunc(info)
+		return _registerFunc(config, scope)
 	}
 	return NopClient
 }

--- a/auth/uauth.go
+++ b/auth/uauth.go
@@ -24,8 +24,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/uber-go/tally"
 	"go.uber.org/fx/config"
+
+	"github.com/uber-go/tally"
 )
 
 var (

--- a/modules/task/cherami/cherami_test.go
+++ b/modules/task/cherami/cherami_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 	cherami_mocks "go.uber.org/fx/mocks/modules/task/cherami"
 	"go.uber.org/fx/modules/task"
@@ -47,9 +46,7 @@ import (
 )
 
 var (
-	_host = service.NopHostConfigured(
-		auth.NopClient, ulog.Logger(context.Background()), opentracing.NoopTracer{},
-	)
+	_host       = service.NopHostConfigured(ulog.Logger(context.Background()), opentracing.NoopTracer{})
 	_pathName   = _pathPrefix + _host.Name()
 	_cgName     = _pathPrefix + _host.Name() + "_cg"
 	_publishMsg = []byte("Hello")
@@ -61,7 +58,7 @@ func TestBackendWorkflow(t *testing.T) {
 	zapLogger, buf := testutils.GetLockedInMemoryLogger()
 	defer ulog.SetLogger(zapLogger)()
 	tracing.WithTracer(t, zapLogger, func(tracer opentracing.Tracer) {
-		host := service.NopHostConfigured(auth.NopClient, zapLogger, tracer)
+		host := service.NopHostConfigured(zapLogger, tracer)
 		bknd := createNewBackend(t, m, host)
 		assert.NotNil(t, bknd.Encoder())
 		deliveryCh, err := startBackend(t, m, bknd, nil, nil)
@@ -283,7 +280,7 @@ func TestEncodingErrors(t *testing.T) {
 		tracer := &tracing.ErrorTracer{Tracer: opentracing.NoopTracer{}}
 		zapLogger, buf := testutils.GetLockedInMemoryLogger()
 		defer ulog.SetLogger(zapLogger)()
-		host := service.NopHostConfigured(auth.NopClient, zapLogger, tracer)
+		host := service.NopHostConfigured(zapLogger, tracer)
 
 		bknd := createNewBackend(t, m, host)
 		cBknd := bknd.(*Backend)

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -101,6 +101,7 @@ func newModule(host service.Host, handler http.Handler) (*Module, error) {
 	serveMux := http.NewServeMux()
 	serveMux.Handle(healthPath, healthHandler{})
 
+	// TODO: pass in the auth client as part of module construction
 	authClient := auth.Load(host.Config(), host.Metrics())
 	stats := newStatsClient(host.Metrics())
 

--- a/modules/uhttp/http.go
+++ b/modules/uhttp/http.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/fx/auth"
 	"go.uber.org/fx/service"
 	"go.uber.org/fx/ulog"
 
@@ -100,7 +101,7 @@ func newModule(host service.Host, handler http.Handler) (*Module, error) {
 	serveMux := http.NewServeMux()
 	serveMux.Handle(healthPath, healthHandler{})
 
-	authClient := host.AuthClient()
+	authClient := auth.Load(host.Config(), host.Metrics())
 	stats := newStatsClient(host.Metrics())
 
 	handle :=

--- a/modules/uhttp/middleware_test.go
+++ b/modules/uhttp/middleware_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/fx/auth"
 	"go.uber.org/fx/service"
 	"go.uber.org/fx/testutils"
 	"go.uber.org/fx/tracing"
@@ -89,7 +90,7 @@ func TestDefaultMiddlewareWithNopHostAuthFailure(t *testing.T) {
 	}
 
 	// setup
-	host := service.NopHostAuthFailure()
+	host := service.NopHost()
 
 	t.Run("parallel group", func(t *testing.T) {
 		for _, tt := range tests {
@@ -161,12 +162,12 @@ func testTracingInboundWithLogs(t *testing.T) {
 }
 
 func testInboundTraceInboundAuthChain(t *testing.T, host service.Host) {
-	response := testServeHTTP(authorizationInbound(tracingInbound(getNopHandler()), host.AuthClient(), newStatsClient(host.Metrics())))
+	response := testServeHTTP(authorizationInbound(tracingInbound(getNopHandler()), auth.NopClient, newStatsClient(host.Metrics())))
 	assert.Contains(t, response.Body.String(), "inbound middleware ok")
 }
 
 func testInboundMiddlewareChainAuthFailure(t *testing.T, host service.Host) {
-	response := testServeHTTP(authorizationInbound(tracingInbound(getNopHandler()), host.AuthClient(), newStatsClient(host.Metrics())))
+	response := testServeHTTP(authorizationInbound(tracingInbound(getNopHandler()), auth.FailureClient, newStatsClient(host.Metrics())))
 	assert.Equal(t, response.Body.String(), "Unauthorized access: Error authorizing the service\n")
 	assert.Equal(t, 401, response.Code)
 }

--- a/modules/uhttp/uhttpclient/client.go
+++ b/modules/uhttp/uhttpclient/client.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"time"
 
+	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 
 	"github.com/opentracing/opentracing-go"
@@ -40,7 +41,8 @@ func New(tracer opentracing.Tracer, config config.Provider, scope tally.Scope, m
 		defaultMiddleware = append(defaultMiddleware, tracingOutbound(tracer))
 	}
 	if config.Get("auth").HasValue() {
-		defaultMiddleware = append(defaultMiddleware, authenticationOutbound(config, scope))
+		authClient := auth.Load(config, scope)
+		defaultMiddleware = append(defaultMiddleware, authenticationOutbound(config, authClient))
 	}
 	defaultMiddleware = append(defaultMiddleware, middleware...)
 	return &http.Client{

--- a/modules/uhttp/uhttpclient/client_middleware.go
+++ b/modules/uhttp/uhttpclient/client_middleware.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -86,8 +85,7 @@ func tracingOutbound(tracer opentracing.Tracer) OutboundMiddlewareFunc {
 
 // authenticationOutbound on client side calls authenticate, and gets a claim that client is who they say they are
 // We only authorize with the claim on server side
-func authenticationOutbound(cfg config.Provider, scope tally.Scope) OutboundMiddlewareFunc {
-	authClient := auth.Load(cfg, scope)
+func authenticationOutbound(cfg config.Provider, authClient auth.Client) OutboundMiddlewareFunc {
 	serviceName := cfg.Get(config.ServiceNameKey).AsString()
 	return func(req *http.Request, next Executor) (resp *http.Response, err error) {
 		ctx := req.Context()

--- a/modules/uhttp/uhttpclient/client_middleware.go
+++ b/modules/uhttp/uhttpclient/client_middleware.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -85,9 +86,9 @@ func tracingOutbound(tracer opentracing.Tracer) OutboundMiddlewareFunc {
 
 // authenticationOutbound on client side calls authenticate, and gets a claim that client is who they say they are
 // We only authorize with the claim on server side
-func authenticationOutbound(info auth.CreateAuthInfo) OutboundMiddlewareFunc {
-	authClient := auth.Load(info)
-	serviceName := info.Config().Get(config.ServiceNameKey).AsString()
+func authenticationOutbound(cfg config.Provider, scope tally.Scope) OutboundMiddlewareFunc {
+	authClient := auth.Load(cfg, scope)
+	serviceName := cfg.Get(config.ServiceNameKey).AsString()
 	return func(req *http.Request, next Executor) (resp *http.Response, err error) {
 		ctx := req.Context()
 		// Client needs to know what service it is to authenticate

--- a/modules/uhttp/uhttpclient/client_middleware_benchmark_test.go
+++ b/modules/uhttp/uhttpclient/client_middleware_benchmark_test.go
@@ -48,11 +48,12 @@ func BenchmarkClientMiddleware(b *testing.B) {
 	}
 
 	defer closer.Close()
+	cfg := config.NewYAMLProviderFromBytes(_testYaml)
 	bm := map[string][]OutboundMiddleware{
 		"empty":   {},
 		"tracing": {tracingOutbound(tracer)},
-		"auth":    {authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope)},
-		"default": {tracingOutbound(tracer), authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope)},
+		"auth":    {authenticationOutbound(cfg, auth.Load(cfg, tally.NoopScope))},
+		"default": {tracingOutbound(tracer), authenticationOutbound(cfg, auth.Load(cfg, tally.NoopScope))},
 	}
 
 	for name, middleware := range bm {

--- a/modules/uhttp/uhttpclient/client_middleware_benchmark_test.go
+++ b/modules/uhttp/uhttpclient/client_middleware_benchmark_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"go.uber.org/fx/auth"
+	"go.uber.org/fx/config"
 	"go.uber.org/fx/tracing"
 
 	"github.com/opentracing/opentracing-go"
@@ -50,8 +51,8 @@ func BenchmarkClientMiddleware(b *testing.B) {
 	bm := map[string][]OutboundMiddleware{
 		"empty":   {},
 		"tracing": {tracingOutbound(tracer)},
-		"auth":    {authenticationOutbound(fakeAuthInfo{_testYaml})},
-		"default": {tracingOutbound(tracer), authenticationOutbound(fakeAuthInfo{_testYaml})},
+		"auth":    {authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope)},
+		"default": {tracingOutbound(tracer), authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope)},
 	}
 
 	for name, middleware := range bm {

--- a/modules/uhttp/uhttpclient/client_middleware_test.go
+++ b/modules/uhttp/uhttpclient/client_middleware_test.go
@@ -118,14 +118,14 @@ func TestExecutionChainOutboundMiddleware_AuthContextPropagationFailure(t *testi
 
 func getExecChainWithAuth(t *testing.T) executionChain {
 	return newExecutionChain(
-		[]OutboundMiddleware{authenticationOutbound(fakeAuthInfo{_testYaml})},
+		[]OutboundMiddleware{authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope)},
 		contextPropagationTransport{t},
 	)
 }
 
 func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 	testCases := map[string]OutboundMiddleware{
-		"auth":    authenticationOutbound(fakeAuthInfo{_testYaml}),
+		"auth":    authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope),
 		"tracing": tracingOutbound(opentracing.NoopTracer{}),
 	}
 
@@ -154,22 +154,6 @@ func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) { op() })
 	}
-}
-
-type fakeAuthInfo struct {
-	yaml []byte
-}
-
-func (f fakeAuthInfo) Config() config.Provider {
-	return config.NewYAMLProviderFromBytes(f.yaml)
-}
-
-func (f fakeAuthInfo) Logger() *zap.Logger {
-	return zap.NewNop()
-}
-
-func (f fakeAuthInfo) Metrics() tally.Scope {
-	return tally.NoopScope
 }
 
 type contextPropagationTransport struct {

--- a/modules/uhttp/uhttpclient/client_middleware_test.go
+++ b/modules/uhttp/uhttpclient/client_middleware_test.go
@@ -117,15 +117,17 @@ func TestExecutionChainOutboundMiddleware_AuthContextPropagationFailure(t *testi
 }
 
 func getExecChainWithAuth(t *testing.T) executionChain {
+	cfg := config.NewYAMLProviderFromBytes(_testYaml)
 	return newExecutionChain(
-		[]OutboundMiddleware{authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope)},
+		[]OutboundMiddleware{authenticationOutbound(cfg, auth.Load(cfg, tally.NoopScope))},
 		contextPropagationTransport{t},
 	)
 }
 
 func TestOutboundMiddlewareWithTracerErrors(t *testing.T) {
+	cfg := config.NewYAMLProviderFromBytes(_testYaml)
 	testCases := map[string]OutboundMiddleware{
-		"auth":    authenticationOutbound(config.NewYAMLProviderFromBytes(_testYaml), tally.NoopScope),
+		"auth":    authenticationOutbound(cfg, auth.Load(cfg, tally.NoopScope)),
 		"tracing": tracingOutbound(opentracing.NoopTracer{}),
 	}
 

--- a/modules/yarpc/middleware_test.go
+++ b/modules/yarpc/middleware_test.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"testing"
 
-	"go.uber.org/fx/service"
+	"go.uber.org/fx/auth"
 	"go.uber.org/fx/ulog"
 	"go.uber.org/thriftrw/wire"
 	"go.uber.org/yarpc/api/transport"
@@ -45,31 +45,26 @@ func checkLogForTrace(t *testing.T, buf *zaptest.Buffer) {
 }
 
 func TestInboundMiddleware_auth(t *testing.T) {
-	host := service.NopHost()
-	unary := authInboundMiddleware{host}
+	unary := authInboundMiddleware{auth.NopClient}
 	err := unary.Handle(context.Background(), &transport.Request{}, nil, &fakeUnary{t: t})
 	assert.EqualError(t, err, "handle")
 }
 
 func TestInboundMiddleware_authFailure(t *testing.T) {
-	host := service.NopHostAuthFailure()
-	unary := authInboundMiddleware{host}
+	unary := authInboundMiddleware{auth.FailureClient}
 	err := unary.Handle(context.Background(), &transport.Request{}, nil, &fakeUnary{t: t})
 	assert.EqualError(t, err, "Error authorizing the service")
 
 }
 
 func TestOnewayInboundMiddleware_auth(t *testing.T) {
-	oneway := authOnewayInboundMiddleware{
-		Host: service.NopHost(),
-	}
+	oneway := authOnewayInboundMiddleware{auth.NopClient}
 	err := oneway.HandleOneway(context.Background(), &transport.Request{}, &fakeOneway{t: t})
 	assert.EqualError(t, err, "oneway handle")
 }
 
 func TestOnewayInboundMiddleware_authFailure(t *testing.T) {
-	host := service.NopHostAuthFailure()
-	oneway := authOnewayInboundMiddleware{host}
+	oneway := authOnewayInboundMiddleware{auth.FailureClient}
 	err := oneway.HandleOneway(context.Background(), &transport.Request{}, &fakeOneway{t: t})
 	assert.EqualError(t, err, "Error authorizing the service")
 }

--- a/modules/yarpc/yarpc.go
+++ b/modules/yarpc/yarpc.go
@@ -139,6 +139,7 @@ func newModule(
 		return nil, errs.Wrap(err, "can't read inbounds")
 	}
 
+	// TODO: pass in the auth client as part of module construction
 	module.authClient = auth.Load(host.Config(), host.Metrics())
 
 	// iterate over inbounds

--- a/modules/yarpc/yarpc_test.go
+++ b/modules/yarpc/yarpc_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"testing"
 
+	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 	"go.uber.org/fx/service"
 	"go.uber.org/yarpc"
@@ -101,7 +102,7 @@ func TestDispatcher(t *testing.T) {
 	c := dispatcherController{}
 	host := service.NopHost()
 	c.addConfig(yarpcConfig{transports: transports{inbounds: []transport.Inbound{}}})
-	assert.NoError(t, c.Start(host))
+	assert.NoError(t, c.Start(auth.NopClient, host))
 }
 
 func TestBindToBadPortReturnsError(t *testing.T) {
@@ -114,8 +115,7 @@ func TestBindToBadPortReturnsError(t *testing.T) {
 	}
 
 	c.addConfig(cfg)
-	host := service.NopHost()
-	assert.Error(t, c.Start(host))
+	assert.Error(t, c.Start(auth.NopClient, service.NopHost()))
 }
 
 func TestMergeOfEmptyConfigCollectionReturnsError(t *testing.T) {
@@ -124,7 +124,7 @@ func TestMergeOfEmptyConfigCollectionReturnsError(t *testing.T) {
 	_, err := c.mergeConfig("test")
 	assert.EqualError(t, err, "unable to merge empty configs")
 	host := service.NopHost()
-	assert.EqualError(t, c.Start(host), err.Error())
+	assert.EqualError(t, c.Start(auth.NopClient, host), err.Error())
 }
 
 func TestInboundPrint(t *testing.T) {

--- a/service/host_mock.go
+++ b/service/host_mock.go
@@ -21,7 +21,6 @@
 package service
 
 import (
-	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 	"go.uber.org/fx/metrics"
 
@@ -36,28 +35,19 @@ func NopHost() Host {
 
 // NopHostWithConfig is to be used in tests and allows setting of config.
 func NopHostWithConfig(configProvider config.Provider) Host {
-	return nopHostConfigured(auth.NopClient, zap.NewNop(), opentracing.NoopTracer{}, configProvider)
-}
-
-// NopHostAuthFailure is nop manager with failure auth client
-func NopHostAuthFailure() Host {
-	auth.UnregisterClient()
-	defer auth.UnregisterClient()
-	auth.RegisterClient(auth.FakeFailureClient)
-	return NopHostConfigured(auth.Load(nil), zap.NewNop(), opentracing.NoopTracer{})
+	return nopHostConfigured(zap.NewNop(), opentracing.NoopTracer{}, configProvider)
 }
 
 // NopHostConfigured is a nop manager with set logger and tracer for tests
-func NopHostConfigured(client auth.Client, logger *zap.Logger, tracer opentracing.Tracer) Host {
-	return nopHostConfigured(client, logger, tracer, nil)
+func NopHostConfigured(logger *zap.Logger, tracer opentracing.Tracer) Host {
+	return nopHostConfigured(logger, tracer, nil)
 }
 
-func nopHostConfigured(client auth.Client, logger *zap.Logger, tracer opentracing.Tracer, configProvider config.Provider) Host {
+func nopHostConfigured(logger *zap.Logger, tracer opentracing.Tracer, configProvider config.Provider) Host {
 	if configProvider == nil {
 		configProvider = config.NewStaticProvider(nil)
 	}
 	return &serviceCore{
-		authClient:     client,
 		configProvider: configProvider,
 		standardConfig: serviceConfig{
 			Name:        "dummy",

--- a/service/host_mock_test.go
+++ b/service/host_mock_test.go
@@ -30,9 +30,3 @@ func TestNopHost_OK(t *testing.T) {
 	sh := NopHost()
 	assert.Equal(t, "dummy", sh.Name())
 }
-
-func TestNopHost_AuthFailures(t *testing.T) {
-	sh := NopHostAuthFailure()
-	assert.Equal(t, "dummy", sh.Name())
-	assert.Equal(t, "failure", sh.AuthClient().Name())
-}

--- a/service/manager.go
+++ b/service/manager.go
@@ -96,10 +96,11 @@ func newManager(builder *Builder) (Manager, error) {
 	if err := m.setupLogging(); err != nil {
 		return nil, err
 	}
-	m.setupAuthClient()
+
 	if err := m.setupRuntimeMetricsCollector(); err != nil {
 		return nil, err
 	}
+
 	m.setupVersionMetricsEmitter()
 	if err := m.setupTracer(); err != nil {
 		return nil, err

--- a/service/service.go
+++ b/service/service.go
@@ -21,7 +21,6 @@
 package service
 
 import (
-	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 	"go.uber.org/fx/metrics"
 
@@ -49,7 +48,6 @@ const (
 
 // A Host represents the hosting environment for a service instance
 type Host interface {
-	AuthClient() auth.Client
 	Name() string
 	Description() string
 	Roles() []string

--- a/service/service_core.go
+++ b/service/service_core.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/fx/auth"
 	"go.uber.org/fx/config"
 	"go.uber.org/fx/internal/util"
 	"go.uber.org/fx/metrics"
@@ -221,10 +220,6 @@ func (s *serviceCore) setupObserver() {
 			shc.SetContainer(s)
 		}
 	}
-}
-
-func (s *serviceCore) setupAuthClient() {
-	auth.Load(s.Config(), s.Metrics())
 }
 
 func loadInstanceConfig(cfg config.Provider, key string, instance interface{}) bool {

--- a/service/service_core.go
+++ b/service/service_core.go
@@ -84,7 +84,6 @@ type serviceConfig struct {
 type serviceCore struct {
 	metricsCore
 	tracerCore
-	authClient     auth.Client
 	configProvider config.Provider
 	logConfig      ulog.Configuration
 	observer       Observer
@@ -96,10 +95,6 @@ type serviceCore struct {
 }
 
 var _ Host = &serviceCore{}
-
-func (s *serviceCore) AuthClient() auth.Client {
-	return s.authClient
-}
 
 func (s *serviceCore) Name() string {
 	return s.standardConfig.Name
@@ -229,10 +224,7 @@ func (s *serviceCore) setupObserver() {
 }
 
 func (s *serviceCore) setupAuthClient() {
-	if s.authClient != nil {
-		return
-	}
-	s.authClient = auth.Load(s)
+	auth.Load(s.Config(), s.Metrics())
 }
 
 func loadInstanceConfig(cfg config.Provider, key string, instance interface{}) bool {


### PR DESCRIPTION
There is no need of Host to utilize or initialize authClient, so now modules can load auth client by calling `auth.Load()`. Also removed CreateAuthInfo to simplify initialization.  

In the future, the auth client will be provided to modules via dig as part of module construction.