### PR TITLE
More efficient group provider initialization

### DIFF
--- a/config/provider_group.go
+++ b/config/provider_group.go
@@ -25,22 +25,18 @@ type providerGroup struct {
 	providers []Provider
 }
 
-// NewProviderGroup creates a configuration provider from a group of backends
+// NewProviderGroup creates a configuration provider from a group of backends.
+// The highest priority provider is the last.
 func NewProviderGroup(name string, providers ...Provider) Provider {
-	group := providerGroup{
-		name: name,
+	l := len(providers)
+	for i := 0; i < l/2; i++ {
+		last := l - i - 1
+		providers[i], providers[last] = providers[last], providers[i]
 	}
-	for _, provider := range providers {
-		group.providers = append([]Provider{provider}, group.providers...)
-	}
-	return group
-}
 
-// WithProvider updates the current Provider
-func (p providerGroup) WithProvider(provider Provider) Provider {
 	return providerGroup{
-		name:      p.name,
-		providers: append([]Provider{provider}, p.providers...),
+		name:      name,
+		providers: providers,
 	}
 }
 

--- a/config/provider_group.go
+++ b/config/provider_group.go
@@ -29,15 +29,16 @@ type providerGroup struct {
 // The highest priority provider is the last.
 func NewProviderGroup(name string, providers ...Provider) Provider {
 	l := len(providers)
-	for i := 0; i < l/2; i++ {
-		last := l - i - 1
-		providers[i], providers[last] = providers[last], providers[i]
+	p := providerGroup{
+		name:      name,
+		providers: make([]Provider, l),
 	}
 
-	return providerGroup{
-		name:      name,
-		providers: providers,
+	for i := 0; i < l; i++ {
+		p.providers[i] = providers[l-i-1]
 	}
+
+	return p
 }
 
 func (p providerGroup) Get(key string) Value {

--- a/config/provider_group_test.go
+++ b/config/provider_group_test.go
@@ -47,8 +47,7 @@ func TestProviderGroupScope(t *testing.T) {
 func TestCallbacks_WithDynamicProvider(t *testing.T) {
 	t.Parallel()
 	data := map[string]interface{}{"hello.world": 42}
-	mock := NewProviderGroup("with-dynamic", NewStaticProvider(data))
-	mock = mock.(providerGroup).WithProvider(NewMockDynamicProvider(data))
+	mock := NewProviderGroup("with-dynamic", NewStaticProvider(data), NewMockDynamicProvider(data))
 	assert.Equal(t, "with-dynamic", mock.Name())
 
 	require.NoError(t, mock.RegisterChangeCallback("mockcall", nil))
@@ -65,7 +64,6 @@ func TestCallbacks_WithoutDynamicProvider(t *testing.T) {
 	t.Parallel()
 	data := map[string]interface{}{"hello.world": 42}
 	mock := NewProviderGroup("with-dynamic", NewStaticProvider(data))
-	mock = mock.(providerGroup).WithProvider(NewStaticProvider(data))
 	assert.Equal(t, "with-dynamic", mock.Name())
 	assert.NoError(t, mock.RegisterChangeCallback("mockcall", nil))
 	assert.NoError(t, mock.UnregisterChangeCallback("mock"))

--- a/modules/task/cherami/cherami_test.go
+++ b/modules/task/cherami/cherami_test.go
@@ -101,7 +101,7 @@ func TestBackendWorkflowWorkerPanic(t *testing.T) {
 	}
 	// Publish valid message
 	publish(t, m, bknd, deliveryCh, nil, nil)
-	time.Sleep(30 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	assert.True(t, bknd.(*Backend).isRunning())
 	stopBackend(t, m, bknd)
 	// Nack panics are sent for a count of _numWorkers and 1 valid publish. Make sure they are


### PR DESCRIPTION
1. We are using a really inefficient way to reverse a slice.
2. WithProvider can't be used outside of the `config` package, because `providerGroup` is private.