### PR TITLE
Add dotted keys support to yaml provider

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -137,7 +137,6 @@ list:
     born: 1770
 
 list.composer:
-  name: Mozart
   born: 1756
  ```
 
@@ -145,7 +144,7 @@ list.composer:
 var composer struct{Name, Born string}
 p.Get("list.composer").Populate(&composer)
 fmt.Println(composer)
-// Output: {Mozart 1756}
+// Output: {Beethoven 1756}
 ```
 
 * Populate a struct (`Populate(&myStruct)`)

--- a/config/README.md
+++ b/config/README.md
@@ -131,17 +131,19 @@ if there are 2 values that correspond to the same path, i.e. the longest matchin
 prefix will be chosen first to continue search in child nodes. For example:
 
  ```yaml
-composer:
+list:
+  composer:
     name: Beethoven
     born: 1770
 
-composer.name: Mozart
-composer.born: 1756
+list.composer:
+  name: Mozart
+  born: 1756
  ```
 
 ```go
 var composer struct{Name, Born string}
-p.Get("composer").Populate(&composer)
+p.Get("list.composer").Populate(&composer)
 fmt.Println(composer)
 // Output: {Mozart 1756}
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -126,6 +126,26 @@ fmt.Println(root)
 // Output: map[one:map[two:hello]]
 ```
 
+A provider will choose a value with the most specific path,
+if there are 2 values that correspond to the same path, i.e. the longest matching
+prefix will be chosen first to continue search in child nodes. For example:
+
+ ```yaml
+composer:
+    name: Beethoven
+    born: 1770
+
+composer.name: Mozart
+composer.born: 1756
+ ```
+
+```go
+var composer struct{Name, Born string}
+p.Get("composer").Populate(&composer)
+fmt.Println(composer)
+// Output: {Mozart 1756}
+```
+
 * Populate a struct (`Populate(&myStruct)`)
 
 The `As*` method has two variants: `TryAs*` and `As*`. The former is a

--- a/config/doc.go
+++ b/config/doc.go
@@ -147,6 +147,23 @@
 //   fmt.Println(root)
 //   // Output: map[one:map[two:hello]]
 //
+// A provider will choose a value with the most specific path,
+// if there are 2 values that correspond to the same path, i.e. the longest matching
+// prefix will be chosen first to continue search in child nodes. For example:
+//
+//
+//   composer:
+//       name: Beethoven
+//       born: 1770
+//
+//   composer.name: Mozart
+//   composer.born: 1756
+//
+//   var composer struct{Name, Born string}
+//   p.Get("composer").Populate(&composer)
+//   fmt.Println(composer)
+//   // Output: {Mozart 1756}
+//
 // • Populate a struct (Populate(&myStruct))
 //
 // The As* method has two variants: TryAs* and As*. The former is a
@@ -312,7 +329,7 @@
 //     }
 //   }
 //
-// Don't forget to test the error path::
+// Don't forget to test the error path:
 //
 //   func TestCalculator_Errors(t *testing.T) {
 //     t.Parallel()
@@ -322,7 +339,7 @@
 //     }))
 //
 //     require.Error(t, err)
-//     assert.Contains(t, err.Error(), `unknown operation "*"`)
+//     assert.Contains(t, err.Error(), "unknown operation")
 //   }
 //
 // For integration/E2E testing you can customize Loader to load the

--- a/config/doc.go
+++ b/config/doc.go
@@ -152,15 +152,17 @@
 // prefix will be chosen first to continue search in child nodes. For example:
 //
 //
-//   composer:
+//   list:
+//     composer:
 //       name: Beethoven
 //       born: 1770
 //
-//   composer.name: Mozart
-//   composer.born: 1756
+//   list.composer:
+//     name: Mozart
+//     born: 1756
 //
 //   var composer struct{Name, Born string}
-//   p.Get("composer").Populate(&composer)
+//   p.Get("list.composer").Populate(&composer)
 //   fmt.Println(composer)
 //   // Output: {Mozart 1756}
 //

--- a/config/doc.go
+++ b/config/doc.go
@@ -158,13 +158,12 @@
 //       born: 1770
 //
 //   list.composer:
-//     name: Mozart
 //     born: 1756
 //
 //   var composer struct{Name, Born string}
 //   p.Get("list.composer").Populate(&composer)
 //   fmt.Println(composer)
-//   // Output: {Mozart 1756}
+//   // Output: {Beethoven 1756}
 //
 // • Populate a struct (Populate(&myStruct))
 //

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -214,33 +214,24 @@ func (n yamlNode) Type() reflect.Type {
 	return reflect.TypeOf(n.value)
 }
 
+// Find the first longest match in child nodes for the dottedPath.
 func (n *yamlNode) Find(dottedPath string) *yamlNode {
-	node := n
-	parts := strings.Split(dottedPath, ".")
+	for curr := dottedPath; len(curr) != 0; {
+		for _, v := range n.Children() {
+			if strings.EqualFold(v.key, curr) {
+				if curr == dottedPath {
+					return v
+				}
 
-	for {
-		if len(parts) == 0 {
-			return node
-		}
-		// does this part exist?
-		children := node.Children()
-		if len(children) == 0 {
-			// not found
-			break
-		}
-
-		part := parts[0]
-		found := false
-		for _, v := range children {
-			if strings.EqualFold(v.key, part) {
-				parts = parts[1:]
-				node = v
-				found = true
-				break
+				if node := v.Find(dottedPath[len(curr)+1:]); node != nil {
+					return node
+				}
 			}
 		}
 
-		if !found {
+		if last := strings.LastIndex(curr, _separator); last > 0 {
+			curr = curr[0:last]
+		} else {
 			break
 		}
 	}

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -230,7 +230,7 @@ func (n *yamlNode) Find(dottedPath string) *yamlNode {
 		}
 
 		if last := strings.LastIndex(curr, _separator); last > 0 {
-			curr = curr[0:last]
+			curr = curr[:last]
 		} else {
 			break
 		}

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -930,7 +930,8 @@ a:
   b:
     s: Mozart
     i: 1756
-a.b.i: 1791
+a.b:
+  i: 1791
 `)
 	var A a
 	provider := NewYAMLProviderFromBytes(bytes)
@@ -984,7 +985,8 @@ a:
 `)
 
 	development := []byte(`
-a.b.s: List
+a.b:
+  s: List
 a.b.i: 1811
 `)
 	var A a
@@ -1007,10 +1009,10 @@ a.b.c.d : e
 	var m map[string]string
 	require.NoError(t, p.Get(Root).Populate(&m))
 	expected := map[string]string{
-		"a": "b",
-		"a.b": "c",
-		"a.b.c": "d",
-		"a.b.c.d" : "e",
+		"a":       "b",
+		"a.b":     "c",
+		"a.b.c":   "d",
+		"a.b.c.d": "e",
 	}
 
 	assert.Equal(t, expected, m)

--- a/config/yaml_test.go
+++ b/config/yaml_test.go
@@ -993,3 +993,25 @@ a.b.i: 1811
 	assert.Equal(t, 1811, A.B.I)
 	assert.Equal(t, "List", A.B.S)
 }
+
+func TestMapsWithDottedKeys(t *testing.T) {
+	t.Parallel()
+
+	p := NewYAMLProviderFromBytes([]byte(`
+a: b
+a.b: c
+a.b.c: d
+a.b.c.d : e
+`))
+
+	var m map[string]string
+	require.NoError(t, p.Get(Root).Populate(&m))
+	expected := map[string]string{
+		"a": "b",
+		"a.b": "c",
+		"a.b.c": "d",
+		"a.b.c.d" : "e",
+	}
+
+	assert.Equal(t, expected, m)
+}


### PR DESCRIPTION
We split the path to a node based on dots, which makes impossible to work with e.g. maps with keys containing dots.

In this change we recursively try to find the longest key that matches dotted path to a node. For example, if we want to find a key `a.b` in a `map["a":map["b":"c"], "a.b":"d"]` we want to return `d` instead of `c`.