### PR TITLE
[WIP] Bring YARPC back

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0dff4fa7a9505a775a11fdc391f7b8d5b106dbef03e7dfdcf5670182d6226590
-updated: 2017-05-02T14:04:55.659040039-07:00
+hash: 29f7f8a09c59c5ca1e770208961c97896d30400f9fcb0aa33b8bf0195a61c0a6
+updated: 2017-05-04T16:35:13.499736997-07:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -18,7 +18,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -32,7 +32,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
+  version: 7cc19b78d562895b13596ddce7aafb59dd789318
   subpackages:
   - proto
 - name: github.com/gorilla/context
@@ -78,7 +78,7 @@ imports:
   subpackages:
   - xfs
 - name: github.com/Sirupsen/logrus
-  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
@@ -168,7 +168,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 6b9245d126758870690c44f27f695cc7e811f913
+  version: 1d24a72942f33a6dd32caaabdc9badf347a4118f
   subpackages:
   - api/encoding
   - api/middleware
@@ -181,8 +181,11 @@ imports:
   - internal/encoding
   - internal/errors
   - internal/inboundmiddleware
+  - internal/interpolate
   - internal/introspection
   - internal/iopool
+  - internal/mapdecode
+  - internal/mapdecode/mapstructure
   - internal/net
   - internal/observability
   - internal/outboundmiddleware
@@ -193,8 +196,7 @@ imports:
   - peer
   - peer/hostport
   - transport/http
-  - transport/tchannel
-  - transport/tchannel/internal
+  - x/config
 - name: go.uber.org/zap
   version: 6a4e056f2cc954cfec3581729e758909604b3f76
   subpackages:
@@ -206,8 +208,7 @@ imports:
   - zapcore
   - zaptest
 - name: golang.org/x/net
-  version: 0819898fb4973868bba6de59b6aaad75beea9a6a
-  repo: https://github.com/golang/net
+  version: feeb485667d1fdabe727840fe00adc22431bc86e
   subpackages:
   - context
 - name: golang.org/x/sys

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
 - package: github.com/gorilla/context
   version: ^1.1.0
 - package: go.uber.org/yarpc
-  version: ^v1.4.0
+  version: config
 - package: go.uber.org/dig
   version: ~0.3
 - package: go.uber.org/thriftrw

--- a/modules/yarpc/yarpc.go
+++ b/modules/yarpc/yarpc.go
@@ -1,0 +1,71 @@
+package yarpc
+
+import (
+	"go.uber.org/fx"
+	"go.uber.org/yarpc"
+	"go.uber.org/zap"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/fx/config"
+	"github.com/uber-go/tally"
+)
+
+type Module struct {
+	l *zap.Logger
+	handlerCtor fx.Component
+	d *yarpc.Dispatcher
+}
+
+type Transports struct {
+	Ts []transport.Procedure
+}
+
+type starter struct{}
+
+func New(handlerCtor fx.Component) *Module {
+	if handlerCtor == nil {
+		panic("Expect a non nil handler constructor")
+	}
+	return &Module{handlerCtor:handlerCtor}
+}
+
+func (m *Module) Name() string {
+	return "yarpc"
+}
+
+func (m *Module) Constructor() []fx.Component {
+	return []fx.Component{
+		func (provider config.Provider, scope tally.Scope, logger *zap.Logger) (*yarpc.Dispatcher, error){
+			m.l = logger.With(zap.String("module", m.Name()))
+			cfg := yarpc.Config{}
+			if err := provider.Get("modules").Get(m.Name()).Populate(cfg); err != nil {
+				m.l.Error("Failed to populate config", zap.Error(err))
+				return nil, err
+			}
+
+			m.d = yarpc.NewDispatcher(cfg)
+			return m.d, nil
+		},
+		m.handlerCtor,
+		func (transports *Transports) (*starter, error) {
+			m.d.Register(transports.Ts)
+			if err := m.d.Start(); err != nil {
+				m.l.Error("Failed to start dispatcher", zap.Error(err))
+				return nil, err
+			}
+
+			m.l.Info("Dispatcher started successfully")
+			return &starter{}, nil
+		},
+	}
+}
+
+func (m *Module) Stop() error {
+	if err := m.d.Stop(); err != nil {
+		m.l.Error("Failed to stop dispatcher", zap.Error(err))
+		return err
+	}
+
+	m.l.Info("Dispatcher stopped")
+	return nil
+}
+

--- a/modules/yarpc/yarpc.go
+++ b/modules/yarpc/yarpc.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package yarpc
 
 import (
@@ -14,18 +34,22 @@ import (
 	"go.uber.org/zap"
 )
 
+// Module represents a collection of YARPC components.
 type Module struct {
 	l           *zap.Logger
 	handlerCtor fx.Component
 	d           *yarpc.Dispatcher
 }
 
+// Transports represent a collection Procedures that will be registered with a dispatcher.
 type Transports struct {
+	//Ts - transports to be registered.
 	Ts []transport.Procedure
 }
 
 type starter struct{}
 
+// New creates a new YARPC Module with a handler constructor.
 func New(handlerCtor fx.Component) *Module {
 	if handlerCtor == nil {
 		panic("Expect a non nil handler constructor")
@@ -34,6 +58,7 @@ func New(handlerCtor fx.Component) *Module {
 	return &Module{handlerCtor: handlerCtor}
 }
 
+// Name returns yarpc
 func (m *Module) Name() string {
 	return "yarpc"
 }
@@ -46,6 +71,7 @@ func (m *Module) populateConfig(provider config.Provider) (yarpc.Config, error) 
 	return cfg.LoadConfig(provider.Get("name").AsString(), val)
 }
 
+// Constructor returns Module components.
 func (m *Module) Constructor() []fx.Component {
 	return []fx.Component{
 		func(provider config.Provider, scope tally.Scope, logger *zap.Logger) (*yarpc.Dispatcher, error) {
@@ -73,6 +99,7 @@ func (m *Module) Constructor() []fx.Component {
 	}
 }
 
+// Stop stops the dispatcher.
 func (m *Module) Stop() error {
 	if err := m.d.Stop(); err != nil {
 		m.l.Error("Failed to stop dispatcher", zap.Error(err))

--- a/modules/yarpc/yarpc_test.go
+++ b/modules/yarpc/yarpc_test.go
@@ -1,0 +1,62 @@
+package yarpc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go.uber.org/fx/config"
+	"go.uber.org/fx/metrics"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/dig"
+	"go.uber.org/zap"
+	"go.uber.org/yarpc"
+)
+
+func TestYARPC_HTTPTransportHealthAndStop(t *testing.T) {
+	t.Parallel()
+
+	di := dig.New()
+
+	var dispatcher *yarpc.Dispatcher
+	fn := func(d *yarpc.Dispatcher) (*Transports, error) {
+		require.NotNil(t, d)
+		dispatcher = d
+		return &Transports{}, nil
+	}
+
+	module := New(fn)
+	for _, component := range module.Constructor() {
+		di.MustRegister(component)
+	}
+
+	cfg := map[string]interface{}{
+		"name": "test",
+		"modules.yarpc": map[string]interface{}{
+			"inbounds": []interface{}{
+				map[string]interface{}{
+					"http": map[string]interface{}{
+						"port": 0,
+					},
+				},
+			},
+		},
+	}
+
+	provider := config.NewStaticProvider(cfg)
+	di.MustRegister(&provider)
+	tracer := opentracing.Tracer(opentracing.NoopTracer{})
+	di.MustRegister(&tracer)
+	di.MustRegister(&metrics.NopScope)
+	logger := zap.NewNop()
+	di.MustRegister(logger)
+
+	var starter *starter
+	di.MustResolve(&starter)
+
+	require.NotNil(t, dispatcher)
+}

--- a/modules/yarpc/yarpc_test.go
+++ b/modules/yarpc/yarpc_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package yarpc
 
 import (


### PR DESCRIPTION
This PR is how YARPC module could look like with the DI refactor.
Caveat: we do need the new YARPC config, otherwise we'll need to implement converters
from map[string]interface{} to YARPC types ourselves.