### PR TITLE
Bring back stats to the task module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   can now be accessed via `auth.Load()` call.
 - **[Breaking]** Removed service.Host altogether. Metrics, config etc. are used
   explicitly where required.
+- **[Breaking]** Module providers take in a `tally.Scope` so they can be
+  propagated through module creation.
 
 ## v1.0.0-beta3 (28 Mar 2017)
 

--- a/modules/task/execution.go
+++ b/modules/task/execution.go
@@ -65,8 +65,7 @@ type fnSignature struct {
 
 // Execute executes the function
 func (s *fnSignature) Execute(ctx context.Context) ([]reflect.Value, error) {
-	// TODO(madhu): Add back after module refactor
-	//globalBackendStatsClient().TaskExecutionCount().Inc(1)
+	globalBackendStatsClient().TaskExecutionCount().Inc(1)
 	targetArgs := make([]reflect.Value, 0, len(s.Args)+1)
 	targetArgs = append(targetArgs, reflect.ValueOf(ctx))
 	for _, arg := range s.Args {
@@ -85,15 +84,13 @@ func Enqueue(fn interface{}, args ...interface{}) error {
 	fnName := getFunctionName(fn)
 	_, ok := fnLookup.getFn(fnName)
 	if !ok {
-		// TODO(madhu): Add back after module refactor
-		//globalBackendStatsClient().TaskPublishFail().Inc(1)
+		globalBackendStatsClient().TaskPublishFail().Inc(1)
 		return fmt.Errorf("function: %q not found. Did you forget to register?", fnName)
 	}
 	fnType := reflect.TypeOf(fn)
 	// Validate function against arguments
 	if err := validateFnAgainstArgs(fnType, args); err != nil {
-		// TODO(madhu): Add back after module refactor
-		//globalBackendStatsClient().TaskPublishFail().Inc(1)
+		globalBackendStatsClient().TaskPublishFail().Inc(1)
 		return err
 	}
 	// Publish function to the backend
@@ -101,12 +98,10 @@ func Enqueue(fn interface{}, args ...interface{}) error {
 	s := fnSignature{FnName: fnName, Args: args[1:]}
 	sBytes, err := GlobalBackend().Encoder().Marshal(s)
 	if err != nil {
-		// TODO(madhu): Add back after module refactor
-		//globalBackendStatsClient().TaskPublishFail().Inc(1)
+		globalBackendStatsClient().TaskPublishFail().Inc(1)
 		return errors.Wrap(err, "unable to encode the function or args")
 	}
-	// TODO(madhu): Add back after module refactor
-	//globalBackendStatsClient().TaskPublishCount().Inc(1)
+	globalBackendStatsClient().TaskPublishCount().Inc(1)
 	return GlobalBackend().Enqueue(ctx, sBytes)
 }
 
@@ -149,9 +144,8 @@ func MustRegister(fn interface{}) {
 
 // Run decodes the message and executes as a task
 func Run(ctx context.Context, message []byte) error {
-	// TODO(madhu): Add back after module refactor
-	//stopwatch := globalBackendStatsClient().TaskExecutionTime().Start()
-	//defer stopwatch.Stop()
+	stopwatch := globalBackendStatsClient().TaskExecutionTime().Start()
+	defer stopwatch.Stop()
 
 	var s fnSignature
 	if err := GlobalBackend().Encoder().Unmarshal(message, &s); err != nil {
@@ -160,8 +154,7 @@ func Run(ctx context.Context, message []byte) error {
 	// TODO (madhu): Do we need a timeout here?
 	retValues, err := s.Execute(ctx)
 	if err != nil {
-		// TODO(madhu): Add back after module refactor
-		//globalBackendStatsClient().TaskExecuteFail().Inc(1)
+		globalBackendStatsClient().TaskExecuteFail().Inc(1)
 		return err
 	}
 	// Assume only an error will be returned since that is verified before adding to fnRegister

--- a/modules/task/execution_test.go
+++ b/modules/task/execution_test.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"testing"
 
+	"go.uber.org/fx/metrics"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
@@ -39,7 +41,7 @@ var (
 )
 
 func globalBackendSetup(t *testing.T) func() {
-	_testScope = tally.NoopScope
+	_testScope = metrics.NopScope
 	_globalBackend = NewManagedInMemBackend(Config{})
 	require.NoError(t, _globalBackend.Start())
 	_errorCh = _globalBackend.(*managedBackend).Backend.(*inMemBackend).errorCh
@@ -193,16 +195,13 @@ func TestEnqueueSimpleFn(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Simple error")
 
-	// TODO(madhu): Add back after module refactor
-	/*
-		snapshot := _testScope.(tally.TestScope).Snapshot()
-		timers := snapshot.Timers()
-		counters := snapshot.Counters()
+	snapshot := _testScope.(tally.TestScope).Snapshot()
+	timers := snapshot.Timers()
+	counters := snapshot.Counters()
 
-		assert.True(t, counters["count"].Value() > 0)
-		assert.True(t, counters["fail"].Value() > 0)
-		assert.NotNil(t, timers["time"].Values())
-	*/
+	assert.True(t, counters["count"].Value() > 0)
+	assert.True(t, counters["fail"].Value() > 0)
+	assert.NotNil(t, timers["time"].Values())
 }
 
 func TestEnqueueMapFn(t *testing.T) {

--- a/modules/task/task_test.go
+++ b/modules/task/task_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 var (
@@ -54,7 +55,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestMemBackendModuleWorkflowWithContext(t *testing.T) {
-	mod, err := newAsyncModule(_memBackendFn, DisableExecution())
+	mod, err := newAsyncModule(_memBackendFn, tally.NoopScope, DisableExecution())
 	require.NoError(t, err)
 	require.NotNil(t, mod)
 	b := GlobalBackend()
@@ -71,7 +72,7 @@ func TestMemBackendModuleWorkflowWithContext(t *testing.T) {
 }
 
 func TestModuleStartWithExecuteAsyncError(t *testing.T) {
-	mod, err := newAsyncModule(_errBackendFn)
+	mod, err := newAsyncModule(_errBackendFn, tally.NoopScope)
 	require.NoError(t, err)
 	require.NotNil(t, mod)
 	err = mod.Start()
@@ -80,7 +81,7 @@ func TestModuleStartWithExecuteAsyncError(t *testing.T) {
 }
 
 func TestNewError(t *testing.T) {
-	mod, err := newAsyncModule(_backendFnWithErr)
+	mod, err := newAsyncModule(_backendFnWithErr, tally.NoopScope)
 	require.Error(t, err)
 	require.Nil(t, mod)
 }
@@ -88,6 +89,7 @@ func TestNewError(t *testing.T) {
 func TestNewWithOptionsError(t *testing.T) {
 	mod, err := newAsyncModule(
 		_memBackendFn,
+		tally.NoopScope,
 		func(*Config) error { return errors.New("options error") },
 	)
 	require.Error(t, err)
@@ -98,7 +100,7 @@ func TestNewWithOptionsError(t *testing.T) {
 func createModule(t *testing.T, b BackendCreateFunc, options ...ModuleOption) Backend {
 	moduleProvider := New(b, options...)
 	assert.NotNil(t, moduleProvider)
-	mod, err := moduleProvider.Create()
+	mod, err := moduleProvider.Create(tally.NoopScope)
 	assert.NotNil(t, mod)
 	assert.NoError(t, err)
 	return _globalBackend

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"go.uber.org/fx/config"
 )
 
@@ -123,15 +124,15 @@ func TestDefaultTimeouts(t *testing.T) {
 	assert.Equal(t, 10*time.Second, m.StopTimeout)
 }
 
-func nopModule() (Module, error) {
+func nopModule(tally.Scope) (Module, error) {
 	return nil, nil
 }
 
-func errModule() (Module, error) {
+func errModule(tally.Scope) (Module, error) {
 	return nil, errors.New("intentional module creation failure")
 }
 
-func timeoutStartModule() (Module, error) {
+func timeoutStartModule(tally.Scope) (Module, error) {
 	return timeoutStart{}, nil
 }
 
@@ -146,7 +147,7 @@ func (timeoutStart) Stop() error {
 	return nil
 }
 
-func timeoutStopModule() (Module, error) {
+func timeoutStopModule(tally.Scope) (Module, error) {
 	return timeoutStop{}, nil
 }
 

--- a/service/manager.go
+++ b/service/manager.go
@@ -275,7 +275,7 @@ func (m *manager) addModule(provider ModuleProvider, options ...ModuleOption) er
 	if m.locked {
 		return fmt.Errorf("can't add module: service already started")
 	}
-	moduleWrapper, err := newModuleWrapper(m.Name(), m.Roles(), provider, options...)
+	moduleWrapper, err := newModuleWrapper(m.Name(), m.Roles(), m.Metrics(), provider, options...)
 	if err != nil {
 		return err
 	}

--- a/service/manager_test.go
+++ b/service/manager_test.go
@@ -290,7 +290,7 @@ func TestStartManager_WithErrors(t *testing.T) {
 	s := makeManager()
 	moduleProvider := &StubModuleProvider{
 		NameVal: "stubModule",
-		CreateVal: func() (Module, error) {
+		CreateVal: func(tally.Scope) (Module, error) {
 			return &StubModule{
 				StartError: errors.New("can't start this"),
 			}, nil

--- a/service/module_test.go
+++ b/service/module_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 const (
@@ -104,6 +105,7 @@ func TestModuleOptions(t *testing.T) {
 			}
 			moduleWrapper, err := newModuleWrapper(
 				_nopName, _nopRoles,
+				tally.NoopScope,
 				NewDefaultStubModuleProvider(),
 				moduleOptions...,
 			)
@@ -117,6 +119,7 @@ func TestModuleOptions(t *testing.T) {
 func TestModuleWrapper(t *testing.T) {
 	moduleWrapper, err := newModuleWrapper(
 		_nopName, _nopRoles,
+		tally.NoopScope,
 		NewDefaultStubModuleProvider(),
 		WithName("hello"),
 	)
@@ -131,10 +134,15 @@ func TestModuleWrapper(t *testing.T) {
 	assert.Error(t, moduleWrapper.Stop())
 	assert.NoError(t, moduleWrapper.Start())
 	assert.NoError(t, moduleWrapper.Stop())
-	moduleWrapper, err = newModuleWrapper(_nopName, _nopRoles, NewStubModuleProvider("stub", nil))
+	moduleWrapper, err = newModuleWrapper(
+		_nopName,
+		_nopRoles,
+		tally.NoopScope,
+		NewStubModuleProvider("stub", nil),
+	)
 	assert.NoError(t, err)
 	assert.Nil(t, moduleWrapper)
-	moduleWrapper, err = newModuleWrapper(_nopName, _nopRoles, nil)
+	moduleWrapper, err = newModuleWrapper(_nopName, _nopRoles, tally.NoopScope, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, moduleWrapper)
 }

--- a/service/stub_module.go
+++ b/service/stub_module.go
@@ -20,10 +20,12 @@
 
 package service
 
+import "github.com/uber-go/tally"
+
 // StubModuleProvider implements the ModuleProvider interface for testing.
 type StubModuleProvider struct {
 	NameVal   string
-	CreateVal func() (Module, error)
+	CreateVal func(tally.Scope) (Module, error)
 }
 
 var _ ModuleProvider = &StubModuleProvider{}
@@ -45,8 +47,8 @@ func (p *StubModuleProvider) DefaultName() string {
 }
 
 // Create creates a new Module.
-func (p *StubModuleProvider) Create() (Module, error) {
-	return p.CreateVal()
+func (p *StubModuleProvider) Create(scope tally.Scope) (Module, error) {
+	return p.CreateVal(scope)
 }
 
 // A StubModule implements the Module interface for testing
@@ -65,8 +67,8 @@ var DefaultStubModuleCreateFunc = NewStubModuleCreateFunc(&StubModule{})
 // If stubModule is nil, this will return nil for the new Module.
 //
 // Host will be overwritten.
-func NewStubModuleCreateFunc(stubModule *StubModule) func() (Module, error) {
-	return func() (Module, error) {
+func NewStubModuleCreateFunc(stubModule *StubModule) func(tally.Scope) (Module, error) {
+	return func(tally.Scope) (Module, error) {
 		if stubModule == nil {
 			return nil, nil
 		}


### PR DESCRIPTION
This was deleted with the earlier commit to remove service.Host. Adding back now with passing in a metrics scope to enable task module stats.