### PR TITLE
Introduce an expand config provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **[Breaking]** Remove lookup function from the YAML provider constructor and add
   explicit constructors `WithExpand` to use interpolation.
 - Add a SetStaticConfigFiles method to load yaml files that should not be interpolated.
+- Introduce an ExpandProvider wrapper for config providers.
 
 ## v1.0.0-beta3 (28 Mar 2017)
 

--- a/config/expand_provider.go
+++ b/config/expand_provider.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+type expandProvider struct {
+	p       Provider
+	mapping func(string) string
+}
+
+// NewExpandProvider returns a config provider that uses
+// a mapping function to expand ${var} or $var values in
+// the values returned by the provider p.
+// Provider uses a lazy substitution i.e. a value will be
+// interpolated iff it was requested.
+func NewExpandProvider(p Provider, mapping func(string) string) Provider {
+	if p == nil {
+		panic("received a nil provider")
+	}
+
+	if mapping == nil {
+		panic("received a nil mapping function")
+	}
+
+	return &expandProvider{p: p, mapping: mapping}
+}
+
+// Name returns expand
+func (e *expandProvider) Name() string {
+	return "expand"
+}
+
+// Get returns the value that has ${var} or $var replaced
+// based on the mapping function.
+func (e *expandProvider) Get(key string) Value {
+	v := e.p.Get(key)
+	if !v.HasValue() {
+		return NewValue(e, key, nil, false, Invalid, nil)
+	}
+
+	m := os.Expand(fmt.Sprint(v.Value()), e.mapping)
+	return NewValue(e, key, m, true, String, &v.Timestamp)
+}
+
+// RegisterChangeCallback registers the callback
+// in the underlying provider.
+func (e *expandProvider) RegisterChangeCallback(key string, callback ChangeCallback) error {
+	return e.p.RegisterChangeCallback(key, func(key string, provider string, data interface{}) {
+		data = os.Expand(fmt.Sprint(data), e.mapping)
+		callback(key, e.Name(), data)
+	})
+}
+
+// UnregisterChangeCallback unregisters a callback
+// in the underlying provider.
+func (e *expandProvider) UnregisterChangeCallback(token string) error {
+	return e.p.UnregisterChangeCallback(token)
+}

--- a/config/expand_provider_test.go
+++ b/config/expand_provider_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package config
 
 import (

--- a/config/expand_provider_test.go
+++ b/config/expand_provider_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestNewExpandProvider(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() { NewExpandProvider(nil, nil) })
+	require.Panics(t, func() { NewExpandProvider(NewStaticProvider(""), nil) })
+	p := NewExpandProvider(NewStaticProvider(""), os.Getenv)
+	require.NotNil(t, p)
+	assert.Equal(t, "expand", p.Name())
+}
+
+func TestExpandProvider_Get(t *testing.T) {
+	t.Parallel()
+
+	s := NewStaticProvider(map[string]interface{}{"a": "${1}", "b": 2})
+	f := func(key string) string {
+		require.Equal(t, "1", key)
+		return "one"
+	}
+
+	p := NewExpandProvider(s, f)
+	require.Equal(t, "one", p.Get("a").AsString())
+	require.Equal(t, "2", p.Get("b").AsString())
+	require.False(t, p.Get("c").HasValue())
+}
+
+func TestExpandProvider_RegisterChangeCallback(t *testing.T) {
+	t.Parallel()
+
+	d := NewMockDynamicProvider(map[string]interface{}{})
+	f := func(key string) string {
+		require.Equal(t, "1", key)
+		return "one"
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	p := NewExpandProvider(d, f)
+	err := p.RegisterChangeCallback("a", func(key string, provider string, data interface{}) {
+		require.Equal(t, "a", key)
+		require.Equal(t, "one", data)
+		wg.Done()
+	})
+
+	require.NoError(t, err)
+
+	err = p.RegisterChangeCallback("b", func(key string, provider string, data interface{}) {
+		require.Equal(t, "b", key)
+		require.Equal(t, "2", data)
+		wg.Done()
+	})
+
+	require.NoError(t, err)
+
+	d.Set("a", "${1}")
+	d.Set("b", 2)
+
+	wg.Wait()
+
+	assert.NoError(t, p.UnregisterChangeCallback("a"))
+}


### PR DESCRIPTION
Sometimes it is hard to expand variables in a provider constructor. 
ExpandConfig provider can be used as a wrapper to lazy interpolate
values from any configuration provider.