### PR TITLE
Add conversion for key types in map unmarshall

### DIFF
--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -223,7 +223,6 @@ func TestPopulateForMapOfDifferentKeyTypes(t *testing.T) {
 	t.Parallel()
 
 	p := NewStaticProvider(map[int]string{1: "a"})
-
 	var m map[string]string
 	require.NoError(t, p.Get(Root).Populate(&m))
 	assert.Equal(t, "a", m["1"])
@@ -231,9 +230,9 @@ func TestPopulateForMapOfDifferentKeyTypes(t *testing.T) {
 
 func TestPopulateForMapsWithNotAssignableKeyTypes(t *testing.T) {
 	t.Parallel()
+
 	p := NewStaticProvider(map[int]string{1: "a"})
 	type secretType struct{ password string }
-
 	var m map[secretType]string
 	err := p.Get(Root).Populate(&m)
 	require.Error(t, err)

--- a/config/static_provider_test.go
+++ b/config/static_provider_test.go
@@ -232,7 +232,7 @@ func TestPopulateForMapOfDifferentKeyTypes(t *testing.T) {
 func TestPopulateForMapsWithNotAssignableKeyTypes(t *testing.T) {
 	t.Parallel()
 	p := NewStaticProvider(map[int]string{1: "a"})
-	type secretType struct{password string}
+	type secretType struct{ password string }
 
 	var m map[secretType]string
 	err := p.Get(Root).Populate(&m)


### PR DESCRIPTION
Config unmarshalls only values in maps, it should unmarshal keys as well, because maps can contain different key types, e.g. `map[int]string` will fail to unmarshal to `map[string]string`.

We will support only scalar key types because we don't have a way to address them in a provider.

For example, for type:
```go
type Movie struct {
   Title string
}

var years map[Movie]int
```
When a provider will try to get a value for movie "The Third Man", it will need to specify the Movie struct somehow, `<Movie>The Third Man`.`value`?