### PR TITLE
Allow to provide objects for the App

### DIFF
--- a/app.go
+++ b/app.go
@@ -181,7 +181,7 @@ func funcLocation(c interface{}) (string, int) {
 }
 
 func logCaller(name string) {
-	_, file, line, ok := runtime.Caller(2)
+	_, file, line, ok := runtime.Caller(3)
 	if !ok {
 		panic("can't determine caller")
 	}

--- a/app.go
+++ b/app.go
@@ -181,10 +181,7 @@ func funcLocation(c interface{}) (string, int) {
 }
 
 func logCaller(name string) {
-	_, file, line, ok := runtime.Caller(3)
-	if !ok {
-		panic("can't determine caller")
+	if _, file, line, ok := runtime.Caller(3); ok {
+		log.Printf("%s was called %s %d\n", name, file, line)
 	}
-
-	log.Printf("%s was called %s %d\n", name, file, line)
 }

--- a/app.go
+++ b/app.go
@@ -77,9 +77,13 @@ var (
 // to all other constructors, and called lazily at startup
 func (s *App) Provide(constructors ...interface{}) {
 	for _, c := range constructors {
-		// Print the constructor signature, file and line number from where it has come
-		file, line := funcLocation(c)
-		log.Printf("Providing constructor %q from %v:%d", reflect.TypeOf(c).String(), file, line)
+		if reflect.TypeOf(c).Kind() == reflect.Func {
+			// Print the constructor signature, file and line number from where it has come
+			file, line := funcLocation(c)
+			log.Printf("Providing constructor %q from %v:%d", reflect.TypeOf(c).String(), file, line)
+		} else {
+			log.Printf("Providing object %q", c)
+		}
 
 		// load module directly into the container and dont store in
 		// s.constructors - this makes the module "free" because they wont

--- a/app.go
+++ b/app.go
@@ -76,13 +76,15 @@ var (
 // Provide constructors into the D.I. Container, their types will be available
 // to all other constructors, and called lazily at startup
 func (s *App) Provide(constructors ...interface{}) {
+	logCaller("Provide")
+
 	for _, c := range constructors {
 		if reflect.TypeOf(c).Kind() == reflect.Func {
 			// Print the constructor signature, file and line number from where it has come
 			file, line := funcLocation(c)
 			log.Printf("Providing constructor %q from %v:%d", reflect.TypeOf(c).String(), file, line)
 		} else {
-			log.Printf("Providing object %q", c)
+			log.Printf("Providing object %q", reflect.TypeOf(c).String())
 		}
 
 		// load module directly into the container and dont store in
@@ -120,6 +122,7 @@ func (s *App) start(funcs ...interface{}) error {
 		if reflect.TypeOf(fn).Kind() != reflect.Func {
 			return errors.Errorf("%T %q is not a function", fn, fn)
 		}
+
 		file, line := funcLocation(fn)
 		log.Printf("Invoking constructor %q from %v:%d", reflect.TypeOf(fn).String(), file, line)
 
@@ -175,4 +178,13 @@ func (s *App) RunForever(funcs ...interface{}) {
 func funcLocation(c interface{}) (string, int) {
 	mfunc := runtime.FuncForPC(reflect.ValueOf(c).Pointer())
 	return mfunc.FileLine(mfunc.Entry())
+}
+
+func logCaller(name string) {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		panic("can't determine caller")
+	}
+
+	log.Printf("%s was called %s %d\n", name, file, line)
 }

--- a/app_test.go
+++ b/app_test.go
@@ -139,7 +139,7 @@ func TestApp(t *testing.T) {
 		err = s.Stop(stopCtx)
 		assert.Contains(t, err.Error(), "context deadline exceeded")
 	})
-	t.Run("ProvideDoesn'tPanicForObjectInstances", func(t *testing.T) {
+	t.Run("ProvideDoesNotPanicForObjectInstances", func(t *testing.T) {
 		type empty struct{}
 		assert.NotPanics(t, func() { New().Provide(&empty{}) })
 	})

--- a/app_test.go
+++ b/app_test.go
@@ -139,4 +139,8 @@ func TestApp(t *testing.T) {
 		err = s.Stop(stopCtx)
 		assert.Contains(t, err.Error(), "context deadline exceeded")
 	})
+	t.Run("ProvideDoesn'tPanicForObjectInstances", func(t *testing.T) {
+		type empty struct{}
+		assert.NotPanics(t, func() { New().Provide(&empty{}) })
+	})
 }


### PR DESCRIPTION
Right now we can register only constructors and the only reason we panic is because of trying to read the function information from a pointer.

Container.Provide lets us to register any object.