### PR TITLE
Remove global usage in logging

### DIFF
--- a/app.go
+++ b/app.go
@@ -75,7 +75,7 @@ var (
 // to all other constructors, and called lazily at startup
 func (s *App) Provide(constructors ...interface{}) {
 	for _, c := range constructors {
-		s.logger.PrintProvide(c)
+		fxlog.PrintProvide(s.logger, c)
 		err := s.container.Provide(c)
 		if err != nil {
 			s.logger.Panic(err)
@@ -148,7 +148,7 @@ func (s *App) RunForever(funcs ...interface{}) {
 	// block on SIGINT and SIGTERM
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	s.logger.PrintSignal(<-c)
+	fxlog.PrintSignal(s.logger, <-c)
 
 	// gracefully shutdown the app
 	stopCtx, cancelStop := context.WithTimeout(context.Background(), DefaultStopTimeout)

--- a/app.go
+++ b/app.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -40,6 +39,7 @@ import (
 type App struct {
 	container *dig.Container
 	lifecycle *lifecycle
+	logger    fxlog.Logger
 }
 
 // New creates a new modular application
@@ -50,6 +50,9 @@ func New(constructors ...interface{}) *App {
 	app := &App{
 		container: container,
 		lifecycle: lifecycle,
+
+		// TODO need a way to inject a mock logger
+		logger: fxlog.New(),
 	}
 	app.Provide(func() Lifecycle {
 		return lifecycle
@@ -71,14 +74,14 @@ var (
 // to all other constructors, and called lazily at startup
 func (s *App) Provide(constructors ...interface{}) {
 	for _, c := range constructors {
-		fxlog.PrintProvide(c)
+		s.logger.PrintProvide(c)
 
 		// load module directly into the container and dont store in
 		// s.constructors - this makes the module "free" because they wont
 		// be called unless a type in s.constructors directly relies on them
 		err := s.container.Provide(c)
 		if err != nil {
-			fxlog.Panic(err)
+			s.logger.Panic(err)
 		}
 	}
 }
@@ -108,7 +111,7 @@ func (s *App) start(funcs ...interface{}) error {
 			return errors.Errorf("%T %q is not a function", fn, fn)
 		}
 
-		fxlog.Printf("INVOKE\t\t%s", fxreflect.FuncName(fn))
+		s.logger.Printf("INVOKE\t\t%s", fxreflect.FuncName(fn))
 
 		if err := s.container.Invoke(fn); err != nil {
 			return err
@@ -117,15 +120,15 @@ func (s *App) start(funcs ...interface{}) error {
 
 	// start or rollback on err
 	if err := s.lifecycle.start(); err != nil {
-		fxlog.Printf("ERROR\t\tStart failed, rolling back: %v", err)
+		s.logger.Printf("ERROR\t\tStart failed, rolling back: %v", err)
 		if stopErr := s.lifecycle.stop(); stopErr != nil {
-			fxlog.Printf("ERROR\t\tCouldn't rollback cleanly: %v", stopErr)
+			s.logger.Printf("ERROR\t\tCouldn't rollback cleanly: %v", stopErr)
 			return multierr.Combine(err, stopErr)
 		}
 		return err
 	}
 
-	fxlog.Printf("RUNNING")
+	s.logger.Printf("RUNNING")
 
 	return nil
 }
@@ -142,24 +145,18 @@ func (s *App) RunForever(funcs ...interface{}) {
 
 	// start the app, rolling back on err
 	if err := s.Start(startCtx, funcs...); err != nil {
-		fxlog.Fatalf("ERROR\t\tFailed to start: %v", err)
+		s.logger.Fatalf("ERROR\t\tFailed to start: %v", err)
 	}
 
 	// block on SIGINT and SIGTERM
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	fxlog.PrintSignal(<-c)
+	s.logger.PrintSignal(<-c)
 
 	// gracefully shutdown the app
 	stopCtx, cancelStop := context.WithTimeout(context.Background(), DefaultStopTimeout)
 	defer cancelStop()
 	if err := s.Stop(stopCtx); err != nil {
-		fxlog.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
+		s.logger.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
 	}
-}
-
-// Use runtime to inspect the function and get the import path and file of where it's defined
-func funcLocation(c interface{}) (string, int) {
-	mfunc := runtime.FuncForPC(reflect.ValueOf(c).Pointer())
-	return mfunc.FileLine(mfunc.Entry())
 }

--- a/app.go
+++ b/app.go
@@ -48,9 +48,7 @@ func New(constructors ...interface{}) *App {
 	logger := fxlog.New()
 
 	container := dig.New()
-	lifecycle := &lifecycle{
-		logger: logger,
-	}
+	lifecycle := newLifecycle(logger)
 
 	app := &App{
 		container: container,

--- a/app.go
+++ b/app.go
@@ -44,15 +44,18 @@ type App struct {
 
 // New creates a new modular application
 func New(constructors ...interface{}) *App {
+	// TODO need a way to inject logger, and other opts in the future
+	logger := fxlog.New()
+
 	container := dig.New()
-	lifecycle := &lifecycle{}
+	lifecycle := &lifecycle{
+		logger: logger,
+	}
 
 	app := &App{
 		container: container,
 		lifecycle: lifecycle,
-
-		// TODO need a way to inject a mock logger
-		logger: fxlog.New(),
+		logger:    logger,
 	}
 	app.Provide(func() Lifecycle {
 		return lifecycle
@@ -75,10 +78,6 @@ var (
 func (s *App) Provide(constructors ...interface{}) {
 	for _, c := range constructors {
 		s.logger.PrintProvide(c)
-
-		// load module directly into the container and dont store in
-		// s.constructors - this makes the module "free" because they wont
-		// be called unless a type in s.constructors directly relies on them
 		err := s.container.Provide(c)
 		if err != nil {
 			s.logger.Panic(err)

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -42,8 +42,8 @@ type Logger interface {
 }
 
 // New returns a new StdLogger
-func New() StdLogger {
-	return StdLogger{
+func New() *StdLogger {
+	return &StdLogger{
 		l: log.New(os.Stderr, "", log.LstdFlags),
 	}
 }
@@ -82,7 +82,6 @@ func (s StdLogger) PrintProvide(t interface{}) {
 	if reflect.TypeOf(t).Kind() == reflect.Func {
 		for _, rtype := range fxreflect.ReturnTypes(t) {
 			s.l.Printf("PROVIDE\t%s <= %s", rtype, fxreflect.FuncName(t))
-			fmt.Println(rtype)
 		}
 	} else {
 		s.l.Printf("PROVIDE\t%s", reflect.TypeOf(t).String())

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -36,9 +36,6 @@ type Logger interface {
 	Printf(string, ...interface{})
 	Panic(error)
 	Fatalf(string, ...interface{})
-
-	PrintProvide(interface{})
-	PrintSignal(os.Signal)
 }
 
 // New returns a new StdLogger
@@ -78,18 +75,18 @@ func prepend(str string) string {
 }
 
 // PrintProvide logs a type provided into the dig.Container
-func (s StdLogger) PrintProvide(t interface{}) {
+func PrintProvide(l Logger, t interface{}) {
 	if reflect.TypeOf(t).Kind() == reflect.Func {
 		for _, rtype := range fxreflect.ReturnTypes(t) {
-			s.l.Printf("PROVIDE\t%s <= %s", rtype, fxreflect.FuncName(t))
+			l.Printf("PROVIDE\t%s <= %s", rtype, fxreflect.FuncName(t))
 		}
 	} else {
-		s.l.Printf("PROVIDE\t%s", reflect.TypeOf(t).String())
+		l.Printf("PROVIDE\t%s", reflect.TypeOf(t).String())
 	}
 }
 
 // PrintSignal logs an os.Signal
-func (s StdLogger) PrintSignal(signal os.Signal) {
+func PrintSignal(l Logger, signal os.Signal) {
 	fmt.Println("")
-	s.l.Println(strings.ToUpper(signal.String()))
+	l.Println(strings.ToUpper(signal.String()))
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -40,6 +40,15 @@ type Hook struct {
 	caller  string
 }
 
+func newLifecycle(logger fxlog.Logger) *lifecycle {
+	if logger == nil {
+		logger = fxlog.New()
+	}
+	return &lifecycle{
+		logger: logger,
+	}
+}
+
 type lifecycle struct {
 	logger   fxlog.Logger
 	hooks    []Hook
@@ -91,9 +100,7 @@ func (l *lifecycle) stop() error {
 // NewTestLifecycle creates a new test lifecycle
 func NewTestLifecycle() Lifecycle {
 	return &TestLifecycle{
-		lifecycle{
-			logger: fxlog.New(),
-		},
+		newLifecycle(nil),
 	}
 }
 
@@ -101,7 +108,7 @@ func NewTestLifecycle() Lifecycle {
 // possible be exposing a Start and Stop func which can be
 // called manually in the context of a unit test.
 type TestLifecycle struct {
-	lifecycle
+	*lifecycle
 }
 
 // Start the lifecycle

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -40,10 +40,6 @@ type Hook struct {
 	caller  string
 }
 
-func newLifecycle() Lifecycle {
-	return &lifecycle{}
-}
-
 type lifecycle struct {
 	logger   fxlog.Logger
 	hooks    []Hook
@@ -90,6 +86,15 @@ func (l *lifecycle) stop() error {
 		}
 	}
 	return multierr.Combine(errs...)
+}
+
+// NewTestLifecycle creates a new test lifecycle
+func NewTestLifecycle() Lifecycle {
+	return &TestLifecycle{
+		lifecycle{
+			logger: fxlog.New(),
+		},
+	}
 }
 
 // TestLifecycle makes testing funcs that rely on Lifecycle

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -45,6 +45,7 @@ func newLifecycle() Lifecycle {
 }
 
 type lifecycle struct {
+	logger   fxlog.Logger
 	hooks    []Hook
 	position int
 }
@@ -60,7 +61,7 @@ func (l *lifecycle) Append(hook Hook) {
 func (l *lifecycle) start() error {
 	for i, hook := range l.hooks {
 		if hook.OnStart != nil {
-			fxlog.Printf("START\t\t%s()", hook.caller)
+			l.logger.Printf("START\t\t%s()", hook.caller)
 			if err := hook.OnStart(); err != nil {
 				return err
 			}
@@ -83,7 +84,7 @@ func (l *lifecycle) stop() error {
 		if l.hooks[i].OnStop == nil {
 			continue
 		}
-		fxlog.Printf("STOP\t\t%s()", l.hooks[i].caller)
+		l.logger.Printf("STOP\t\t%s()", l.hooks[i].caller)
 		if err := l.hooks[i].OnStop(); err != nil {
 			errs = append(errs, err)
 		}

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/fx/internal/fxlog"
 	"go.uber.org/multierr"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ import (
 
 func TestLifecycleStart(t *testing.T) {
 	t.Run("ExecutesInOrder", func(t *testing.T) {
-		l := &lifecycle{}
+		l := newLifecycle(nil)
 		count := 0
 
 		l.Append(Hook{
@@ -53,7 +54,7 @@ func TestLifecycleStart(t *testing.T) {
 		assert.Equal(t, 2, count)
 	})
 	t.Run("ErrHaltsChainAndRollsBack", func(t *testing.T) {
-		l := &lifecycle{}
+		l := newLifecycle(nil)
 		err := errors.New("a starter error")
 		starterCount := 0
 		stopperCount := 0
@@ -102,11 +103,15 @@ func TestLifecycleStart(t *testing.T) {
 
 func TestLifecycleStop(t *testing.T) {
 	t.Run("DoesNothingOn0Hooks", func(t *testing.T) {
-		l := &lifecycle{}
+		l := &lifecycle{
+			logger: fxlog.New(),
+		}
 		assert.Nil(t, l.stop(), "no lifecycle hooks should have resulted in stop returning nil")
 	})
 	t.Run("ExecutesInReverseOrder", func(t *testing.T) {
-		l := &lifecycle{}
+		l := &lifecycle{
+			logger: fxlog.New(),
+		}
 		count := 2
 
 		l.Append(Hook{
@@ -129,7 +134,7 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Equal(t, 0, count)
 	})
 	t.Run("ErrDoesntHaltChain", func(t *testing.T) {
-		l := &lifecycle{}
+		l := newLifecycle(nil)
 		count := 0
 
 		l.Append(Hook{
@@ -151,7 +156,7 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Equal(t, 2, count)
 	})
 	t.Run("GathersAllErrs", func(t *testing.T) {
-		l := &lifecycle{}
+		l := newLifecycle(nil)
 
 		err := errors.New("some stop error")
 		err2 := errors.New("some other stop error")


### PR DESCRIPTION
This PR removes calling the global `log.std` in favor of an interface.

Once this PR is in, I'll tear through the `fx.App` object to allow a logger to be injected, in which case I can write a behavior test verifying the entirety of the logging output.