### PR TITLE
NewTestLifecycle should return *TestLifecycle

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -98,7 +98,7 @@ func (l *lifecycle) stop() error {
 }
 
 // NewTestLifecycle creates a new test lifecycle
-func NewTestLifecycle() Lifecycle {
+func NewTestLifecycle() *TestLifecycle {
 	return &TestLifecycle{
 		newLifecycle(nil),
 	}


### PR DESCRIPTION
TestLifecycle provides a couple extra methods. These are inaccessible if
the function returns a Lifecycle instead of a TestLifecycle.