### PR TITLE
App: Add Invoke method

### DIFF
--- a/app.go
+++ b/app.go
@@ -130,6 +130,23 @@ func (s *App) start(funcs ...interface{}) error {
 	return nil
 }
 
+// Invoke calls the given functions in-order with objects from the D.I.
+// container. The function blocks until all functions have executed.
+//
+// Functions may optionally return errors. The error returned by the first
+// failing function will be returned to the caller as-is.
+//
+// This function MUST NOT be called before Start or after Stop.
+func (s *App) Invoke(funcs ...interface{}) error {
+	for _, fn := range funcs {
+		if err := s.container.Invoke(fn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Stop the app
 func (s *App) Stop(ctx context.Context) error {
 	return withTimeout(ctx, s.lifecycle.stop)

--- a/glide.lock
+++ b/glide.lock
@@ -1,19 +1,17 @@
 hash: 7ca7f137776c6c2868123eb268d08df5617dda7b73bb3ded9fa9f2975defb984
-updated: 2017-05-23T11:14:00.3087726-07:00
+updated: 2017-06-08T15:54:32.152559171-07:00
 imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/dig
-  version: c4b875442cd7be80a6e3de4ad47d6b8787e79c2c
-  subpackages:
-  - internal/graph
+  version: 0b0da34c3b8883524bd1ba49cbc63e3fcf244035
 - name: go.uber.org/multierr
   version: a3d1fc1f1316d4132fc61f4ea1159ae0613fb474
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib


### PR DESCRIPTION
This adds an Invoke method to `fx.App` which is equivalent to dig's
`Invoke` method.

The reasoning for adding this method is that you expect to be able to do
things with your fully initialized running service after it has been
started, in a serial fashion.

That is,

```go
// Arguments to Start are invoked *before* Lifecycle.Start is
// called. So these are dependencies for Starting the service.
app.Start(...)
defer app.Stop()

// Over here, we expect to be able to do things with our fully
// initialized and running service.
err := app.Invoke(func(d *yarpc.Dispatcher) error {
  // ..
})
```

An alternative to this is a `Resolve` method,

```go
var d *yarpc.Dispatcher
app.Resolve(&d)
```

But in my opinion, that's easier to misuse. People will pass `*App` around and
possibly resolve things on the request path. With Invoke, you have to
explicitly choose to do the "wrong" thing:

```go
var d *yarpc.Dispatcher
app.Invoke(func(dispatcher *yarpc.Dispatcher) {
  d = dispatcher
})
```