### PR TITLE
Make stacks composable

### DIFF
--- a/app.go
+++ b/app.go
@@ -75,7 +75,7 @@ var (
 // Provide constructors into the D.I. Container, their types will be available
 // to all other constructors, and called lazily at startup
 func (s *App) Provide(constructors ...interface{}) {
-	for _, c := range unstack(constructors) {
+	for _, c := range ungroup(constructors) {
 		fxlog.PrintProvide(s.logger, c)
 		err := s.container.Provide(c)
 		if err != nil {
@@ -104,7 +104,7 @@ func withTimeout(ctx context.Context, f func() error) error {
 
 func (s *App) start(funcs ...interface{}) error {
 	// invoke all user-land constructors in order
-	for _, fn := range unstack(funcs) {
+	for _, fn := range ungroup(funcs) {
 		if reflect.TypeOf(fn).Kind() != reflect.Func {
 			return errors.Errorf("%T %q is not a function", fn, fn)
 		}

--- a/app.go
+++ b/app.go
@@ -75,7 +75,7 @@ var (
 // Provide constructors into the D.I. Container, their types will be available
 // to all other constructors, and called lazily at startup
 func (s *App) Provide(constructors ...interface{}) {
-	for _, c := range constructors {
+	for _, c := range unstack(constructors) {
 		fxlog.PrintProvide(s.logger, c)
 		err := s.container.Provide(c)
 		if err != nil {
@@ -104,7 +104,7 @@ func withTimeout(ctx context.Context, f func() error) error {
 
 func (s *App) start(funcs ...interface{}) error {
 	// invoke all user-land constructors in order
-	for _, fn := range funcs {
+	for _, fn := range unstack(funcs) {
 		if reflect.TypeOf(fn).Kind() != reflect.Func {
 			return errors.Errorf("%T %q is not a function", fn, fn)
 		}

--- a/app_test.go
+++ b/app_test.go
@@ -98,7 +98,7 @@ func TestApp(t *testing.T) {
 			return nil
 		}
 		s := New()
-		s.Provide(Constructors{new1, new2, new3})
+		s.Provide(Group{new1, new2, new3})
 		require.NoError(t, s.Start(context.Background(), biz))
 		assert.Equal(t, 3, count)
 	})
@@ -131,7 +131,7 @@ func TestApp(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "*fx.type1 &{} is not a function")
 	})
-	t.Run("StartStack", func(t *testing.T) {
+	t.Run("StartGroup", func(t *testing.T) {
 		count := 0
 		new1 := func() *type1 {
 			return &type1{}
@@ -152,7 +152,7 @@ func TestApp(t *testing.T) {
 		}
 		s := New()
 		s.Provide(new1, new2, new3)
-		require.NoError(t, s.Start(context.Background(), Starters{biz1, biz3}))
+		require.NoError(t, s.Start(context.Background(), Group{biz1, biz3}))
 		assert.Equal(t, 2, count)
 	})
 	t.Run("StartTimeout", func(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -98,7 +98,7 @@ func TestApp(t *testing.T) {
 			return nil
 		}
 		s := New()
-		s.Provide(Group{new1, new2, new3})
+		s.Provide(Group{new1, Group{new2, new3}})
 		require.NoError(t, s.Start(context.Background(), biz))
 		assert.Equal(t, 3, count)
 	})

--- a/app_test.go
+++ b/app_test.go
@@ -79,7 +79,7 @@ func TestApp(t *testing.T) {
 		s.Start(context.Background(), biz)
 		assert.Equal(t, 4, initOrder)
 	})
-	t.Run("ProvideStack", func(t *testing.T) {
+	t.Run("ProvideGroup", func(t *testing.T) {
 		count := 0
 		new1 := func() *type1 {
 			t.Error("this module should not init: no provided type relies on it")

--- a/app_test.go
+++ b/app_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type type1 struct{}
-type type2 struct{}
-type type3 struct{}
-
 func TestApp(t *testing.T) {
+	type type1 struct{}
+	type type2 struct{}
+	type type3 struct{}
+
 	t.Run("NewCreatesApp", func(t *testing.T) {
 		s := New()
 		assert.NotNil(t, s.container)
@@ -79,6 +79,29 @@ func TestApp(t *testing.T) {
 		s.Start(context.Background(), biz)
 		assert.Equal(t, 4, initOrder)
 	})
+	t.Run("ProvideStack", func(t *testing.T) {
+		count := 0
+		new1 := func() *type1 {
+			t.Error("this module should not init: no provided type relies on it")
+			return nil
+		}
+		new2 := func() *type2 {
+			count++
+			return &type2{}
+		}
+		new3 := func(*type2) *type3 {
+			count++
+			return &type3{}
+		}
+		biz := func(s2 *type2, s3 *type3) error {
+			count++
+			return nil
+		}
+		s := New()
+		s.Provide(Constructors{new1, new2, new3})
+		require.NoError(t, s.Start(context.Background(), biz))
+		assert.Equal(t, 3, count)
+	})
 	t.Run("ModulesLazyInit", func(t *testing.T) {
 		count := 0
 		new1 := func() *type1 {
@@ -107,6 +130,30 @@ func TestApp(t *testing.T) {
 		err := s.Start(context.Background(), &type1{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "*fx.type1 &{} is not a function")
+	})
+	t.Run("StartStack", func(t *testing.T) {
+		count := 0
+		new1 := func() *type1 {
+			return &type1{}
+		}
+		new2 := func() *type2 {
+			return &type2{}
+		}
+		new3 := func(*type2) *type3 {
+			return &type3{}
+		}
+		biz1 := func(*type1) error {
+			count++
+			return nil
+		}
+		biz3 := func(*type3) error {
+			count++
+			return nil
+		}
+		s := New()
+		s.Provide(new1, new2, new3)
+		require.NoError(t, s.Start(context.Background(), Starters{biz1, biz3}))
+		assert.Equal(t, 2, count)
 	})
 	t.Run("StartTimeout", func(t *testing.T) {
 		s := New()

--- a/group.go
+++ b/group.go
@@ -20,15 +20,15 @@
 
 package fx
 
-type stack interface {
-	stack() []interface{}
+type grouper interface {
+	group() []interface{}
 }
 
-func unstack(funcs []interface{}) []interface{} {
+func ungroup(funcs []interface{}) []interface{} {
 	ret := make([]interface{}, 0, len(funcs))
 	for _, f := range funcs {
-		if stack, ok := f.(stack); ok {
-			ret = append(ret, unstack(stack.stack())...)
+		if group, ok := f.(grouper); ok {
+			ret = append(ret, ungroup(group.group())...)
 		} else {
 			ret = append(ret, f)
 		}
@@ -40,6 +40,6 @@ func unstack(funcs []interface{}) []interface{} {
 // object.
 type Group []interface{}
 
-func (g Group) stack() []interface{} {
+func (g Group) group() []interface{} {
 	return []interface{}(g)
 }

--- a/stack.go
+++ b/stack.go
@@ -36,17 +36,10 @@ func unstack(funcs []interface{}) []interface{} {
 	return ret
 }
 
-// Constructors composes multiple constructors into a single Provide-able
+// A Group composes multiple constructors or invokable functions into a single
 // object.
-type Constructors []interface{}
+type Group []interface{}
 
-func (c Constructors) stack() []interface{} {
-	return []interface{}(c)
-}
-
-// Starters composes multiple functions into a single Start-able object.
-type Starters []interface{}
-
-func (s Starters) stack() []interface{} {
-	return []interface{}(s)
+func (g Group) stack() []interface{} {
+	return []interface{}(g)
 }

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx
+
+type stack interface {
+	stack() []interface{}
+}
+
+func unstack(funcs []interface{}) []interface{} {
+	ret := make([]interface{}, 0, len(funcs))
+	for _, f := range funcs {
+		if stack, ok := f.(stack); ok {
+			ret = append(ret, unstack(stack.stack())...)
+		} else {
+			ret = append(ret, f)
+		}
+	}
+	return ret
+}
+
+// Constructors composes multiple constructors into a single Provide-able
+// object.
+type Constructors []interface{}
+
+func (c Constructors) stack() []interface{} {
+	return []interface{}(c)
+}
+
+// Starters composes multiple functions into a single Start-able object.
+type Starters []interface{}
+
+func (s Starters) stack() []interface{} {
+	return []interface{}(s)
+}


### PR DESCRIPTION
This PR sketches out one approach to making stacks composable. It introduces a `Group` type (bikeshed away), that let modules transparently provide multiple types or offer an all-in-one starter.