### PR TITLE
travis: Test against Go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
   - 1.7
   - 1.8
   - 1.8.x
+  - tip
 
 install:
   - make install


### PR DESCRIPTION
This adds Go tip to the list of Go versions being tested against. This
will ensure we have forwards compatibility with upcoming Go versions.