### PR TITLE
Provide current version into container

### DIFF
--- a/app.go
+++ b/app.go
@@ -57,9 +57,8 @@ func New(opts ...Option) *App {
 		lifecycle: lifecycle,
 		logger:    logger,
 	}
-	app.Provide(func() Lifecycle {
-		return lifecycle
-	})
+	app.Provide(func() Lifecycle { return lifecycle })
+	app.Provide(func() SemanticVersion { return Version })
 
 	return app
 }

--- a/version_test.go
+++ b/version_test.go
@@ -20,9 +20,16 @@
 
 package fx
 
-// SemanticVersion is a semantic version, represented as a string. See
-// http://semver.org/.
-type SemanticVersion string
+import (
+	"context"
+	"testing"
 
-// Version is exported for runtime compatibility checks.
-const Version SemanticVersion = "1.0.0-rc1-dev"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	err := New().Start(context.Background(), func(semver SemanticVersion) {
+		assert.Equal(t, Version, semver, "Unexpected version in container.")
+	})
+	assert.NoError(t, err, "Error resolving Version from container.")
+}


### PR DESCRIPTION
Give `Version` a meaningful type and provide it into the container. This allows other packages (e.g., our internal version-heartbeating module) to do useful things.