### PR TITLE
Proposal: top-level API and stacks

### DIFF
--- a/app.go
+++ b/app.go
@@ -24,142 +24,238 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"reflect"
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/dig"
 	"go.uber.org/fx/internal/fxlog"
 	"go.uber.org/fx/internal/fxreflect"
 	"go.uber.org/multierr"
 )
 
-// App models a modular application
+// DefaultTimeout is the start and stop timeout used by Run.
+const DefaultTimeout = 15 * time.Second
+
+// Timeout is a convenience function to construct a context with a timeout.
+// It's only intended to reduce noise in the main function; since it doesn't
+// expose context.CancelFunc, it may leak resources.
+func Timeout(d time.Duration) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	// Assign to the blank identifier on a separate line to convince the linter
+	// that we really don't want the cancel function.
+	_ = cancel
+	return ctx
+}
+
+// An Option configures an App.
+type Option interface {
+	apply(*App)
+}
+
+type optionFunc func(*App)
+
+func (f optionFunc) apply(app *App) { f(app) }
+
+// Provide registers constructors with the application's dependency injection
+// container. Constructors provide one or more types, can depend on other
+// types available in the container, and may optionally return an error. For
+// example:
+//
+//  // Provides type *C, depends on *A and *B.
+//  func(*A, *B) *C
+//
+//  // Provides type *C, depends on *A and *B, and indicates failure by
+//  // returning an error.
+//  func(*A, *B) (*C, error)
+//
+//  // Provides type *B and *C, depends on *A, and can fail.
+//  func(*A) (*B, *C, error)
+//
+// The order in which constructors are provided doesn't matter. Constructors
+// are called lazily and their results are cached for reuse.
+//
+// Taken together, these properties make it perfectly reasonable to Provide a
+// large number of standard constructors even if only a fraction of them are
+// used.
+//
+// See the documentation for go.uber.org/dig for further details.
+func Provide(constructors ...interface{}) Option {
+	return optionFunc(func(app *App) {
+		for _, c := range constructors {
+			app.provide(c)
+		}
+	})
+}
+
+// Invoke registers functions that are executed eagerly on application start.
+// Arguments for these functions are provided from the application's
+// dependency injection container, so the arguments form the leaves of the
+// dependency resolution graph. That is, only constructors whose returned
+// types are required to invoke these functions are executed.
+//
+// Unlike constructors, invoked functions are always executed, and they're
+// always run in order. Invoked functions may have any number of returned
+// values. If the final returned object is an error, it's assumed to be a
+// success indicator. All other returned values are discarded.
+//
+// See the documentation for go.uber.org/dig for further details.
+func Invoke(funcs ...interface{}) Option {
+	return optionFunc(func(app *App) {
+		app.invokes = append(app.invokes, funcs...)
+	})
+}
+
+// Options composes a collection of Options into a single Option.
+func Options(opts ...Option) Option {
+	return optionFunc(func(app *App) {
+		for _, opt := range opts {
+			opt.apply(app)
+		}
+	})
+}
+
+// An App is a modular application built around dependency injection.
 type App struct {
+	optionErr error
 	container *dig.Container
 	lifecycle *lifecycle
+	invokes   []interface{}
 	logger    fxlog.Logger
 }
 
-// Option allows App to be customized
-type Option func(*App)
-
-// New creates a new modular application
+// New creates and initializes an App. All applications begin with the
+// Lifecycle type available in their dependency injection container.
 func New(opts ...Option) *App {
 	logger := fxlog.New()
-
-	container := dig.New()
 	lifecycle := newLifecycle(logger)
 
 	app := &App{
-		container: container,
+		container: dig.New(),
 		lifecycle: lifecycle,
 		logger:    logger,
 	}
-	app.Provide(func() Lifecycle {
-		return lifecycle
-	})
+
+	app.provide(func() Lifecycle { return lifecycle })
+
+	for _, opt := range opts {
+		opt.apply(app)
+	}
 
 	return app
 }
 
-var (
-	// DefaultStartTimeout will be used to start app in Run
-	DefaultStartTimeout = 15 * time.Second
-
-	// DefaultStopTimeout will be used to stop app in Run
-	DefaultStopTimeout = 5 * time.Second
-)
-
-// Provide constructors into the D.I. Container, their types will be available
-// to all other constructors, and called lazily at startup
-func (s *App) Provide(constructors ...interface{}) {
-	for _, c := range constructors {
-		fxlog.PrintProvide(s.logger, c)
-		err := s.container.Provide(c)
-		if err != nil {
-			s.logger.Panic(err)
-		}
-	}
-}
-
-// Start the app by explicitly invoking all the user-provided constructors.
+// Run starts the application, blocks on the signals channel, and then
+// gracefully shuts the application down. It uses DefaultTimeout for the start
+// and stop timeouts.
 //
-// See dig.Invoke for moreinformation.
-func (s *App) Start(ctx context.Context, funcs ...interface{}) error {
-	return withTimeout(ctx, func() error { return s.start(funcs...) })
-}
+// See Start and Stop for application lifecycle details.
+func (app *App) Run() {
+	if err := app.Start(Timeout(DefaultTimeout)); err != nil {
+		app.logger.Fatalf("ERROR\t\tFailed to start: %v", err)
+	}
 
-func withTimeout(ctx context.Context, f func() error) error {
-	c := make(chan error)
-	go func() { c <- f() }()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-c:
-		return err
+	fxlog.PrintSignal(app.logger, <-app.Done())
+
+	if err := app.Stop(Timeout(DefaultTimeout)); err != nil {
+		app.logger.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
 	}
 }
 
-func (s *App) start(funcs ...interface{}) error {
-	// invoke all user-land constructors in order
-	for _, fn := range funcs {
-		if reflect.TypeOf(fn).Kind() != reflect.Func {
-			return errors.Errorf("%T %q is not a function", fn, fn)
-		}
-
-		s.logger.Printf("INVOKE\t\t%s", fxreflect.FuncName(fn))
-
-		if err := s.container.Invoke(fn); err != nil {
-			return err
-		}
-	}
-
-	// start or rollback on err
-	if err := s.lifecycle.start(); err != nil {
-		s.logger.Printf("ERROR\t\tStart failed, rolling back: %v", err)
-		if stopErr := s.lifecycle.stop(); stopErr != nil {
-			s.logger.Printf("ERROR\t\tCouldn't rollback cleanly: %v", stopErr)
-			return multierr.Combine(err, stopErr)
-		}
-		return err
-	}
-
-	s.logger.Printf("RUNNING")
-
-	return nil
+// Start starts the application.
+//
+// First, Start checks whether any errors were encountered while applying
+// Options. If so, it returns immediately.
+//
+// It then executes all functions supplied via the Invoke option. Supplying
+// arguments to these functions requires calling some of the constructors
+// supplied by the Provide option. If any invoked function fails, an error is
+// returned immediately.
+//
+// By taking a dependency on the Lifecycle type, some of the executed
+// constructors may register start and stop hooks. After executing all Invoke
+// functions, Start executes all OnStart hooks registered with the
+// application's Lifecycle, starting with the root of the dependency graph.
+// This ensures that each constructor's start hooks aren't executed until all
+// its dependencies' start hooks complete. If any of the start hooks return an
+// error, start short-circuits.
+func (app *App) Start(ctx context.Context) error {
+	return withTimeout(ctx, func() error { return app.start() })
 }
 
-// Stop the app
-func (s *App) Stop(ctx context.Context) error {
-	return withTimeout(ctx, s.lifecycle.stop)
+// Stop gracefully stops the application. It executes any registered OnStop
+// hooks in reverse order (from the leaves of the dependency tree to the
+// roots), so that types are stopped before their dependencies.
+//
+// If the application didn't start cleanly, only hooks whose OnStart phase was
+// called are executed. However, all those hooks are always executed, even if
+// some fail.
+func (app *App) Stop(ctx context.Context) error {
+	return withTimeout(ctx, app.lifecycle.stop)
 }
 
-// Done allows blocking on SIGINT or SIGTERM
-func (App) Done() <-chan os.Signal {
+// Done returns a channel of signals to block on after starting the
+// application.
+func (app *App) Done() <-chan os.Signal {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	return c
 }
 
-// Run starts the app, blocks for SIGINT or SIGTERM, then gracefully stops
-func (s *App) Run(funcs ...interface{}) {
-	startCtx, cancelStart := context.WithTimeout(context.Background(), DefaultStartTimeout)
-	defer cancelStart()
+func (app *App) provide(constructor interface{}) {
+	if app.optionErr != nil {
+		return
+	}
+	fxlog.PrintProvide(app.logger, constructor)
+	if err := app.container.Provide(constructor); err != nil {
+		app.optionErr = multierr.Append(app.optionErr, err)
+	}
+}
 
-	// start the app, rolling back on err
-	if err := s.Start(startCtx, funcs...); err != nil {
-		s.logger.Fatalf("ERROR\t\tFailed to start: %v", err)
+func (app *App) start() error {
+	if app.optionErr != nil {
+		// Some provides failed, short-circuit immediately.
+		return app.optionErr
 	}
 
-	// block on SIGINT and SIGTERM
-	fxlog.PrintSignal(s.logger, <-s.Done())
+	// Execute invokes.
+	for _, fn := range app.invokes {
+		app.logger.Printf("INVOKE\t\t%s", fxreflect.FuncName(fn))
+		if err := app.container.Invoke(fn); err != nil {
+			return err
+		}
+	}
 
-	// gracefully shutdown the app
-	stopCtx, cancelStop := context.WithTimeout(context.Background(), DefaultStopTimeout)
-	defer cancelStop()
-	if err := s.Stop(stopCtx); err != nil {
-		s.logger.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
+	// Attempt to start cleanly.
+	if err := app.lifecycle.start(); err != nil {
+		// Start failed, roll back.
+		app.logger.Printf("ERROR\t\tStart failed, rolling back: %v", err)
+		if stopErr := app.lifecycle.stop(); stopErr != nil {
+			app.logger.Printf("ERROR\t\tCouldn't rollback cleanly: %v", stopErr)
+			return multierr.Combine(err, stopErr)
+		}
+		return err
+	}
+
+	app.logger.Printf("RUNNING")
+	return nil
+}
+
+func withTimeout(ctx context.Context, f func() error) error {
+	stop := make(chan struct{})
+	defer close(stop)
+
+	c := make(chan error)
+	go func() {
+		select {
+		case <-stop:
+		case c <- f():
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-c:
+		return err
 	}
 }

--- a/app.go
+++ b/app.go
@@ -89,9 +89,7 @@ func Provide(constructors ...interface{}) Option {
 
 // Invoke registers functions that are executed eagerly on application start.
 // Arguments for these functions are provided from the application's
-// dependency injection container, so the arguments form the leaves of the
-// dependency resolution graph. That is, only constructors whose returned
-// types are required to invoke these functions are executed.
+// dependency injection container.
 //
 // Unlike constructors, invoked functions are always executed, and they're
 // always run in order. Invoked functions may have any number of returned
@@ -231,7 +229,7 @@ func (app *App) start() error {
 		app.logger.Printf("ERROR\t\tStart failed, rolling back: %v", err)
 		if stopErr := app.lifecycle.stop(); stopErr != nil {
 			app.logger.Printf("ERROR\t\tCouldn't rollback cleanly: %v", stopErr)
-			return multierr.Combine(err, stopErr)
+			return multierr.Append(err, stopErr)
 		}
 		return err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -39,7 +39,7 @@ func NewLogger() *log.Logger {
 func NewHandler(logger *log.Logger) http.Handler {
 	logger.Print("Executing NewHandler.")
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		log.Print("Got a request.")
+		logger.Print("Got a request.")
 		w.Write([]byte("Your lucky number is 42."))
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -37,9 +37,8 @@ func NewLogger() *log.Logger {
 
 func NewHandler(logger *log.Logger) http.Handler {
 	logger.Print("Executing NewHandler.")
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		logger.Print("Got a request.")
-		w.Write([]byte("Your lucky number is 42."))
 	})
 }
 
@@ -47,7 +46,7 @@ func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
 	logger.Print("Executing NewMux.")
 	mux := http.NewServeMux()
 	server := &http.Server{
-		Addr:    ":0",
+		Addr:    ":8080",
 		Handler: mux,
 	}
 	// If NewMux is called, we know that someone is using the mux. In that case,
@@ -89,6 +88,7 @@ func Example() {
 	}
 
 	// Normally, we'd block here with <-app.Done().
+	http.Get("http://localhost:8080/")
 
 	if err := app.Stop(fx.Timeout(time.Second)); err != nil {
 		log.Fatal(err)
@@ -98,5 +98,6 @@ func Example() {
 	// [Example] Executing NewMux.
 	// [Example] Executing NewHandler.
 	// [Example] Starting HTTP server.
+	// [Example] Got a request.
 	// [Example] Stopping HTTP server.
 }

--- a/example_test.go
+++ b/example_test.go
@@ -21,7 +21,6 @@
 package fx_test
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"os"
@@ -61,7 +60,7 @@ func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
 		},
 		OnStop: func() error {
 			logger.Print("Stopping HTTP server.")
-			return server.Shutdown(context.Background())
+			return server.Close()
 		},
 	})
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+func NewLogger() *log.Logger {
+	logger := log.New(os.Stdout, "[Example] " /* prefix */, 0 /* flags */)
+	logger.Print("Executing NewLogger.")
+	return logger
+}
+
+func NewHandler(logger *log.Logger) http.Handler {
+	logger.Print("Executing NewHandler.")
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		log.Print("Got a request.")
+		w.Write([]byte("Your lucky number is 42."))
+	})
+}
+
+func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
+	logger.Print("Executing NewMux.")
+	mux := http.NewServeMux()
+	server := &http.Server{
+		Addr:    ":0",
+		Handler: mux,
+	}
+	// If NewMux is called, we know that someone is using the mux. In that case,
+	// start up and shut down an HTTP server with the application.
+	lc.Append(fx.Hook{
+		OnStart: func() error {
+			logger.Print("Starting HTTP server.")
+			go server.ListenAndServe()
+			return nil
+		},
+		OnStop: func() error {
+			logger.Print("Stopping HTTP server.")
+			return server.Shutdown(context.Background())
+		},
+	})
+
+	return mux
+}
+
+func Register(mux *http.ServeMux, h http.Handler) {
+	mux.Handle("/", h)
+}
+
+func Example() {
+	app := fx.New(
+		// Provide all the constructors we need.
+		fx.Provide(NewLogger, NewHandler, NewMux),
+		// Before starting, register the handler. This forces resolution of all
+		// the types in the container. Since the mux is now being used, its
+		// startup hook gets registered and the application includes an HTTP
+		// server.
+		fx.Invoke(Register),
+	)
+
+	// In a real application, we could just use app.Run() here. Since we don't
+	// want this example to run forever, we'll use Start and Stop.
+	if err := app.Start(fx.Timeout(time.Second)); err != nil {
+		log.Fatal(err)
+	}
+
+	// Normally, we'd block here with <-app.Done().
+
+	if err := app.Stop(fx.Timeout(time.Second)); err != nil {
+		log.Fatal(err)
+	}
+	// Output:
+	// [Example] Executing NewLogger.
+	// [Example] Executing NewMux.
+	// [Example] Executing NewHandler.
+	// [Example] Starting HTTP server.
+	// [Example] Stopping HTTP server.
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3b78aa133d70210c6178ef7fc985a9619fc02637507d44983392d80a8230149b
-updated: 2017-06-19T14:45:33.424505016-07:00
+hash: 9c6711fa34939b2d814cea48ed8309dbf514ccf3b226c157916df7e1da4acfbb
+updated: 2017-06-20T08:54:46.939092583-07:00
 imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
@@ -13,7 +13,7 @@ testImports:
   subpackages:
   - spew
 - name: github.com/golang/lint
-  version: a5f4a247366d8fc436941822e14fc3eac7727015
+  version: c5fb716d6688a859aae56d26d3e6070808df29f7
   subpackages:
   - golint
 - name: github.com/pmezard/go-difflib
@@ -30,6 +30,6 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/tools
-  version: bc6db94186c03835daa5c1c679fba599dc1f3b79
+  version: 63c6481f3be3d4c29183574fa76516c4e7f54c6e
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: 3b78aa133d70210c6178ef7fc985a9619fc02637507d44983392d80a8230149b
 updated: 2017-06-19T14:45:33.424505016-07:00
 imports:
-- name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/dig

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,5 @@
 package: go.uber.org/fx
 import:
-- package: github.com/pkg/errors
-  version: ~0.8.0
 - package: go.uber.org/multierr
   version: ~0.2.0
 - package: go.uber.org/dig

--- a/inject.go
+++ b/inject.go
@@ -25,23 +25,18 @@ import (
 	"reflect"
 )
 
-// Inject fills the given struct with values from the DI container when passed
-// to App.Start.
-//
-// 	var target struct {
-// 		Dispatcher *yarpc.Dispatcher
-// 	}
-// 	err := app.Start(ctx, Inject(&target))
+// Inject fills the given struct with values from the dependency injection
+// container on application start.
 //
 // The target MUST be a pointer to a struct. Only exported fields will be
 // filled.
-func Inject(target interface{}) interface{} {
+func Inject(target interface{}) Option {
 	v := reflect.ValueOf(target)
 
 	if t := v.Type(); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
-		return func() error {
+		return Invoke(func() error {
 			return fmt.Errorf("Inject expected a pointer to a struct, got a %v", t)
-		}
+		})
 	}
 
 	v = v.Elem()
@@ -106,5 +101,5 @@ func Inject(target interface{}) interface{} {
 		},
 	)
 
-	return fn.Interface()
+	return Invoke(fn.Interface())
 }

--- a/inject_test.go
+++ b/inject_test.go
@@ -295,7 +295,10 @@ func ExampleInject() {
 		Inject(&target),
 	)
 
-	app.Start(context.Background())
+	if err := app.Start(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+
 	target.Logger.Print("Injected!")
 
 	// Output:

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -104,8 +104,8 @@ func NewTestLifecycle() *TestLifecycle {
 	}
 }
 
-// TestLifecycle makes testing funcs that rely on Lifecycle possible by
-// exposing a Start and Stop func which can be called manually in unit tests.
+// TestLifecycle exposes Start and Stop methods, which allows unit tests to
+// exercise Lifecycle hooks.
 type TestLifecycle struct {
 	*lifecycle
 }


### PR DESCRIPTION
This PR proposes a tweak of the top-level application API that makes
stacks much nicer.

The meat of the change is simple: it makes constructors and invokes
options passed to `New`. This has a few benefits:

- Conceptually, it fully defines the application during construction.
This reduces the temptation to pass the application object out of main.
- It lets us mirror dig's `Provide` and `Invoke` terminology, which
makes it easier to navigate docs.
- It naturally leads to the `Options` constructor, which lets a stack
define both provides and invokes in a single object.

You can see an example application in the included example. A stack
might look like this:

```
package fxstack

var Stack = fx.Options(
  fx.Provide(
    foo.Module,
    bar.Module,
    baz.Module,
  ),
  fx.Invoke(
    foo.Run,
    baz.Run,
  ),
)
```

In a user's main function, we'd see this:

```
app := fx.New(fxstack.Stack)
app.Run()
```

To reduce the wordiness of users' code, this PR also provides a small
context construction helper and makes `Inject` a standalone `Option`.