### PR TITLE
Stop CI on Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go_import_path: go.uber.org/fx
 
 go:
-  - 1.7
   - 1.8
   - 1.8.x
   - tip


### PR DESCRIPTION
In order to write good examples of application startup and shutdown,
we'll want to use some server type that's common in open source. The
natural candidate is `http.Server`. Unfortunately, `Server` doesn't have
`Close` or `Shutdown` in Go 1.7.

Since we don't currently have any users on 1.7, we should optimize for
good examples and limit support to Go 1.8 and above.