### PR TITLE
Run CI only on 1.8.x and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go_import_path: go.uber.org/fx
 
 go:
-  - 1.8
   - 1.8.x
   - tip
 


### PR DESCRIPTION
There's no reason to run Travis on both Go 1.8 and 1.8.x - let's cut
down on the number of CI jobs and just run on the latest patch release
of each supported minor.