### PR TITLE
Move TestLifecycle into an fxtest subpackage

### DIFF
--- a/app.go
+++ b/app.go
@@ -126,7 +126,7 @@ type App struct {
 // Lifecycle type available in their dependency injection container.
 func New(opts ...Option) *App {
 	logger := fxlog.New()
-	lc := &lifecycleWrapper{lifecycle.NewLifecycle(logger)}
+	lc := &lifecycleWrapper{lifecycle.New(logger)}
 
 	app := &App{
 		container: dig.New(),

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -44,7 +44,7 @@ type Lifecycle struct {
 // NewLifecycle creates a new test lifecycle.
 func NewLifecycle(t TB) *Lifecycle {
 	return &Lifecycle{
-		Lifecycle: lifecycle.NewLifecycle(nil),
+		Lifecycle: lifecycle.New(nil),
 		t:         t,
 	}
 }

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxtest
+
+import (
+	"go.uber.org/fx"
+	"go.uber.org/fx/internal/lifecycle"
+)
+
+// TB is a subset of the standard library's testing.TB interface. It's
+// satisfied by both *testing.T and *testing.B.
+type TB interface {
+	Errorf(string, ...interface{})
+	FailNow()
+}
+
+// Lifecycle is a testing spy for fx.Lifecycle. It exposes Start and Stop
+// methods (and some test-specific helpers) so that unit tests can exercise
+// hooks.
+type Lifecycle struct {
+	*lifecycle.Lifecycle
+
+	t TB
+}
+
+// NewLifecycle creates a new test lifecycle.
+func NewLifecycle(t TB) *Lifecycle {
+	return &Lifecycle{
+		Lifecycle: lifecycle.NewLifecycle(nil),
+		t:         t,
+	}
+}
+
+// Start executes all registered OnStart hooks in order, halting at the first
+// hook that doesn't succeed.
+func (l *Lifecycle) Start() error { return l.Lifecycle.Start() }
+
+// MustStart calls Start, failing the test if an error is encountered.
+func (l *Lifecycle) MustStart() {
+	if err := l.Start(); err != nil {
+		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
+		l.t.FailNow()
+	}
+}
+
+// Stop calls all OnStop hooks whose OnStart counterpart was called, running
+// in reverse order.
+//
+// If any hook returns an error, execution continues for a best-effort
+// cleanup. Any errors encountered are collected into a single error and
+// returned.
+func (l *Lifecycle) Stop() error { return l.Lifecycle.Stop() }
+
+// MustStop calls Stop, failing the test if an error is encountered.
+func (l *Lifecycle) MustStop() {
+	if err := l.Stop(); err != nil {
+		l.t.Errorf("lifecycle didn't stop cleanly: %v", err)
+		l.t.FailNow()
+	}
+}
+
+// Append registers a new Hook.
+func (l *Lifecycle) Append(h fx.Hook) {
+	l.Lifecycle.Append(lifecycle.Hook{
+		OnStart: h.OnStart,
+		OnStop:  h.OnStop,
+	})
+}

--- a/fxtest/fxtest_test.go
+++ b/fxtest/fxtest_test.go
@@ -24,13 +24,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"go.uber.org/fx"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type tb struct{ n int }
 
+func (t *tb) Logf(string, ...interface{})   {}
 func (t *tb) Errorf(string, ...interface{}) {}
 func (t *tb) FailNow()                      { t.n++ }
 

--- a/fxtest/fxtest_test.go
+++ b/fxtest/fxtest_test.go
@@ -52,7 +52,7 @@ func TestSuccess(t *testing.T) {
 	lc.MustStart()
 	assert.Equal(t, 1, count, "Expected OnStart hook to run.")
 	lc.MustStop()
-	assert.Equal(t, 2, count, "Expected OnStart hook to run.")
+	assert.Equal(t, 2, count, "Expected OnStop hook to run.")
 }
 
 func TestStartFail(t *testing.T) {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -41,8 +41,8 @@ type Lifecycle struct {
 	position int
 }
 
-// NewLifecycle constructs a new Lifecycle.
-func NewLifecycle(logger fxlog.Logger) *Lifecycle {
+// New constructs a new Lifecycle.
+func New(logger fxlog.Logger) *Lifecycle {
 	if logger == nil {
 		logger = fxlog.New()
 	}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package lifecycle
+
+import (
+	"go.uber.org/fx/internal/fxlog"
+	"go.uber.org/fx/internal/fxreflect"
+	"go.uber.org/multierr"
+)
+
+// A Hook is a pair of start and stop callbacks, either of which can be nil,
+// plus a string identifying the supplier of the hook.
+type Hook struct {
+	OnStart func() error
+	OnStop  func() error
+	caller  string
+}
+
+// Lifecycle coordinates application lifecycle hooks.
+type Lifecycle struct {
+	logger   fxlog.Logger
+	hooks    []Hook
+	position int
+}
+
+// NewLifecycle constructs a new Lifecycle.
+func NewLifecycle(logger fxlog.Logger) *Lifecycle {
+	if logger == nil {
+		logger = fxlog.New()
+	}
+	return &Lifecycle{logger: logger}
+}
+
+// Append adds a Hook to the lifecycle.
+func (l *Lifecycle) Append(hook Hook) {
+	hook.caller = fxreflect.Caller()
+	l.hooks = append(l.hooks, hook)
+}
+
+// Start runs all OnStart hooks, returning immediately if it encounters an
+// error.
+func (l *Lifecycle) Start() error {
+	for i, hook := range l.hooks {
+		if hook.OnStart != nil {
+			l.logger.Printf("START\t\t%s()", hook.caller)
+			if err := hook.OnStart(); err != nil {
+				return err
+			}
+		}
+		// Mark last successful OnStart.
+		l.position = i
+	}
+	return nil
+}
+
+// Stop runs any OnStop hooks whose OnStart counterpart succeeded. OnStop
+// hooks run in reverse order.
+func (l *Lifecycle) Stop() error {
+	if len(l.hooks) == 0 {
+		return nil
+	}
+	var errs []error
+	// Run backward from last successful OnStart.
+	for i := l.position; i >= 0; i-- {
+		if l.hooks[i].OnStop == nil {
+			continue
+		}
+		l.logger.Printf("STOP\t\t%s()", l.hooks[i].caller)
+		if err := l.hooks[i].OnStop(); err != nil {
+			// For best-effort cleanup, keep going after errors.
+			errs = append(errs, err)
+		}
+	}
+	return multierr.Combine(errs...)
+}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestLifecycleStart(t *testing.T) {
 	t.Run("ExecutesInOrder", func(t *testing.T) {
-		l := NewLifecycle(nil)
+		l := New(nil)
 		count := 0
 
 		l.Append(Hook{
@@ -54,7 +54,7 @@ func TestLifecycleStart(t *testing.T) {
 		assert.Equal(t, 2, count)
 	})
 	t.Run("ErrHaltsChainAndRollsBack", func(t *testing.T) {
-		l := NewLifecycle(nil)
+		l := New(nil)
 		err := errors.New("a starter error")
 		starterCount := 0
 		stopperCount := 0
@@ -130,7 +130,7 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Equal(t, 0, count)
 	})
 	t.Run("ErrDoesntHaltChain", func(t *testing.T) {
-		l := NewLifecycle(nil)
+		l := New(nil)
 		count := 0
 
 		l.Append(Hook{
@@ -152,7 +152,7 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Equal(t, 2, count)
 	})
 	t.Run("GathersAllErrs", func(t *testing.T) {
-		l := NewLifecycle(nil)
+		l := New(nil)
 
 		err := errors.New("some stop error")
 		err2 := errors.New("some other stop error")

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package fx
+package lifecycle
 
 import (
 	"errors"
@@ -32,7 +32,7 @@ import (
 
 func TestLifecycleStart(t *testing.T) {
 	t.Run("ExecutesInOrder", func(t *testing.T) {
-		l := newLifecycle(nil)
+		l := NewLifecycle(nil)
 		count := 0
 
 		l.Append(Hook{
@@ -50,11 +50,11 @@ func TestLifecycleStart(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, l.start())
+		assert.NoError(t, l.Start())
 		assert.Equal(t, 2, count)
 	})
 	t.Run("ErrHaltsChainAndRollsBack", func(t *testing.T) {
-		l := newLifecycle(nil)
+		l := NewLifecycle(nil)
 		err := errors.New("a starter error")
 		starterCount := 0
 		stopperCount := 0
@@ -93,8 +93,8 @@ func TestLifecycleStart(t *testing.T) {
 			},
 		})
 
-		assert.Error(t, err, l.start())
-		assert.NoError(t, l.stop())
+		assert.Error(t, err, l.Start())
+		assert.NoError(t, l.Stop())
 
 		assert.Equal(t, 2, starterCount, "expected the first and second starter to execute")
 		assert.Equal(t, 1, stopperCount, "expected the first stopper to execute since the second starter failed")
@@ -103,15 +103,11 @@ func TestLifecycleStart(t *testing.T) {
 
 func TestLifecycleStop(t *testing.T) {
 	t.Run("DoesNothingOn0Hooks", func(t *testing.T) {
-		l := &lifecycle{
-			logger: fxlog.New(),
-		}
-		assert.Nil(t, l.stop(), "no lifecycle hooks should have resulted in stop returning nil")
+		l := &Lifecycle{logger: fxlog.New()}
+		assert.Nil(t, l.Stop(), "no lifecycle hooks should have resulted in stop returning nil")
 	})
 	t.Run("ExecutesInReverseOrder", func(t *testing.T) {
-		l := &lifecycle{
-			logger: fxlog.New(),
-		}
+		l := &Lifecycle{logger: fxlog.New()}
 		count := 2
 
 		l.Append(Hook{
@@ -129,12 +125,12 @@ func TestLifecycleStop(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, l.start())
-		assert.NoError(t, l.stop())
+		assert.NoError(t, l.Start())
+		assert.NoError(t, l.Stop())
 		assert.Equal(t, 0, count)
 	})
 	t.Run("ErrDoesntHaltChain", func(t *testing.T) {
-		l := newLifecycle(nil)
+		l := NewLifecycle(nil)
 		count := 0
 
 		l.Append(Hook{
@@ -151,12 +147,12 @@ func TestLifecycleStop(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, l.start())
-		assert.Equal(t, err, l.stop())
+		assert.NoError(t, l.Start())
+		assert.Equal(t, err, l.Stop())
 		assert.Equal(t, 2, count)
 	})
 	t.Run("GathersAllErrs", func(t *testing.T) {
-		l := newLifecycle(nil)
+		l := NewLifecycle(nil)
 
 		err := errors.New("some stop error")
 		err2 := errors.New("some other stop error")
@@ -172,7 +168,7 @@ func TestLifecycleStop(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, l.start())
-		assert.Equal(t, multierr.Combine(err, err2), l.stop())
+		assert.NoError(t, l.Start())
+		assert.Equal(t, multierr.Combine(err, err2), l.Stop())
 	})
 }


### PR DESCRIPTION
This PR moves the testing spy for `fx.Lifecycle` into a separate
`fxtest` subpackage. This cleans up the documentation for the main
package and lets us (in the future) take dependencies on the `testing`
package in our test helpers.

Fixes #520.