### PR TITLE
Clean up hanging functions in fxlog

### DIFF
--- a/app.go
+++ b/app.go
@@ -119,7 +119,7 @@ type App struct {
 	container *dig.Container
 	lifecycle *lifecycleWrapper
 	invokes   []interface{}
-	logger    fxlog.Logger
+	logger    *fxlog.Logger
 }
 
 // New creates and initializes an App. All applications begin with the
@@ -153,7 +153,7 @@ func (app *App) Run() {
 		app.logger.Fatalf("ERROR\t\tFailed to start: %v", err)
 	}
 
-	fxlog.PrintSignal(app.logger, <-app.Done())
+	app.logger.PrintSignal(<-app.Done())
 
 	if err := app.Stop(Timeout(DefaultTimeout)); err != nil {
 		app.logger.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
@@ -204,7 +204,7 @@ func (app *App) provide(constructor interface{}) {
 	if app.optionErr != nil {
 		return
 	}
-	fxlog.PrintProvide(app.logger, constructor)
+	app.logger.PrintProvide(constructor)
 	if err := app.container.Provide(constructor); err != nil {
 		app.optionErr = multierr.Append(app.optionErr, err)
 	}

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -30,6 +30,12 @@ import (
 	"go.uber.org/fx/internal/fxreflect"
 )
 
+var _exit = func() { os.Exit(1) }
+
+type standard interface {
+	Printf(string, ...interface{})
+}
+
 // New returns a new Logger.
 func New() *Logger {
 	return &Logger{log.New(os.Stderr, "", log.LstdFlags)}
@@ -37,12 +43,12 @@ func New() *Logger {
 
 // A Logger writes output to standard error.
 type Logger struct {
-	std *log.Logger
+	std standard
 }
 
 // Println logs a single Fx line.
 func (l *Logger) Println(str string) {
-	l.std.Println(prepend(str))
+	l.std.Printf(prepend(str))
 }
 
 // Printf logs a formatted Fx line.
@@ -63,18 +69,19 @@ func (l *Logger) PrintProvide(t interface{}) {
 
 // PrintSignal logs an os.Signal.
 func (l *Logger) PrintSignal(signal os.Signal) {
-	fmt.Println("")
 	l.Println(strings.ToUpper(signal.String()))
 }
 
 // Panic logs an Fx line then panics.
 func (l *Logger) Panic(err error) {
-	l.std.Panic(prepend(err.Error()))
+	l.std.Printf(prepend(err.Error()))
+	panic(err)
 }
 
 // Fatalf logs an Fx line then fatals.
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-	l.std.Fatalf(prepend(format), v...)
+	l.std.Printf(prepend(format), v...)
+	_exit()
 }
 
 func prepend(str string) string {

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -32,7 +32,7 @@ import (
 
 var _exit = func() { os.Exit(1) }
 
-type standard interface {
+type printer interface {
 	Printf(string, ...interface{})
 }
 
@@ -43,7 +43,7 @@ func New() *Logger {
 
 // A Logger writes output to standard error.
 type Logger struct {
-	std standard
+	std printer
 }
 
 // Println logs a single Fx line.

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fxlog
 
 import (

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -1,0 +1,94 @@
+package fxlog
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type spy struct {
+	*bytes.Buffer
+}
+
+func newSpy() *spy {
+	return &spy{bytes.NewBuffer(nil)}
+}
+
+func (s *spy) Printf(format string, is ...interface{}) {
+	fmt.Fprintln(s, fmt.Sprintf(format, is...))
+}
+
+// stubs the exit call, returns a function that restores a real exit function
+// and asserts that the stub was called.
+func stubExit() func(testing.TB) {
+	prev := _exit
+	var called bool
+	_exit = func() { called = true }
+	return func(t testing.TB) {
+		assert.True(t, called, "Exit wasn't called.")
+		_exit = prev
+	}
+}
+
+func TestNew(t *testing.T) {
+	assert.NotPanics(t, func() { New() })
+}
+
+func TestPrint(t *testing.T) {
+	sink := newSpy()
+	logger := &Logger{sink}
+
+	t.Run("println", func(t *testing.T) {
+		sink.Reset()
+		logger.Println("foo")
+		assert.Equal(t, "[Fx] foo\n", sink.String())
+	})
+
+	t.Run("printf", func(t *testing.T) {
+		sink.Reset()
+		logger.Printf("foo %d", 42)
+		assert.Equal(t, "[Fx] foo 42\n", sink.String())
+	})
+
+	t.Run("printProvide", func(t *testing.T) {
+		sink.Reset()
+		logger.PrintProvide(bytes.NewBuffer)
+		assert.Equal(t, "[Fx] PROVIDE\t*bytes.Buffer <= bytes.NewBuffer()\n", sink.String())
+	})
+
+	t.Run("printProvideInvalid", func(t *testing.T) {
+		sink.Reset()
+		// No logging on invalid provides, since we're already logging an error
+		// elsewhere.
+		logger.PrintProvide(bytes.NewBuffer(nil))
+		assert.Equal(t, "", sink.String())
+	})
+
+	t.Run("printSignal", func(t *testing.T) {
+		sink.Reset()
+		logger.PrintSignal(os.Interrupt)
+		assert.Equal(t, "[Fx] INTERRUPT\n", sink.String())
+	})
+}
+
+func TestPanic(t *testing.T) {
+	sink := newSpy()
+	logger := &Logger{sink}
+	assert.Panics(t, func() { logger.Panic(errors.New("foo")) })
+	assert.Equal(t, "[Fx] foo\n", sink.String())
+}
+
+func TestFatal(t *testing.T) {
+	sink := newSpy()
+	logger := &Logger{sink}
+
+	undo := stubExit()
+	defer undo(t)
+
+	logger.Fatalf("foo %d", 42)
+	assert.Equal(t, "[Fx] foo 42\n", sink.String())
+}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -36,13 +36,13 @@ type Hook struct {
 
 // Lifecycle coordinates application lifecycle hooks.
 type Lifecycle struct {
-	logger   fxlog.Logger
+	logger   *fxlog.Logger
 	hooks    []Hook
 	position int
 }
 
 // New constructs a new Lifecycle.
-func New(logger fxlog.Logger) *Lifecycle {
+func New(logger *fxlog.Logger) *Lifecycle {
 	if logger == nil {
 		logger = fxlog.New()
 	}


### PR DESCRIPTION
The internal fxlog package is structured around an interface that (a)
isn't satisfied by any other logging library, and (b) has only one
implementation. This PR simplifies things a bit by dropping the
interface and making the helper functions into methods. Along the way,
it rationalizes the pointer/value semantics of the logger type - `New`
returns a pointer, and all the methods have pointer receivers.

If we want to make fx's logging pluggable in the future, we'll still
need these changes: we'll want the user to supply an object that
satisfies the same interface as the standard library's `*log.Logger`,
and we'll wrap it in the same concrete type that we're using now.