### PR TITLE
Provide a testing harness for apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## v1.0.0-rc2 (unreleased)
 
-- No changes yet.
+- Add a `Logger` option, which allows users to send Fx's logs to different
+  sink.
+- Add `fxtest.App`, which redirects log output to the user's `testing.TB` and
+  provides some lifecycle helpers.
 
 ## v1.0.0-rc1 (20 Jun 2017)
 

--- a/app_test.go
+++ b/app_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -206,4 +207,21 @@ func TestAppStop(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "OnStop fail")
 	})
+}
+
+type printerSpy struct {
+	*bytes.Buffer
+}
+
+func (ps printerSpy) Printf(format string, args ...interface{}) {
+	fmt.Fprintf(ps.Buffer, format, args...)
+	ps.Buffer.WriteRune('\n')
+}
+
+func TestReplaceLogger(t *testing.T) {
+	spy := printerSpy{&bytes.Buffer{}}
+	app := New(Logger(spy))
+	require.NoError(t, app.Start(context.Background()))
+	require.NoError(t, app.Stop(context.Background()))
+	assert.Contains(t, spy.String(), "RUNNING")
 }

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -21,6 +21,8 @@
 package fxtest
 
 import (
+	"context"
+
 	"go.uber.org/fx"
 	"go.uber.org/fx/internal/lifecycle"
 )
@@ -32,6 +34,50 @@ type TB interface {
 	Logf(string, ...interface{})
 	Errorf(string, ...interface{})
 	FailNow()
+}
+
+type testPrinter struct {
+	TB
+}
+
+func (p *testPrinter) Printf(format string, args ...interface{}) {
+	p.Logf(format, args...)
+}
+
+// App is a wrapper around fx.App that provides some testing helpers. By
+// default, it uses the provided TB as the application's logging backend.
+type App struct {
+	*fx.App
+
+	tb TB
+}
+
+// New creates a new test application.
+func New(tb TB, opts ...fx.Option) *App {
+	allOpts := make([]fx.Option, 0, len(opts))
+	allOpts = append(allOpts, fx.Logger(&testPrinter{tb}))
+	allOpts = append(allOpts, opts...)
+	return &App{
+		App: fx.New(allOpts...),
+		tb:  tb,
+	}
+}
+
+// MustStart calls Start, failing the test if an error is encountered.
+func (app *App) MustStart() *App {
+	if err := app.Start(context.Background()); err != nil {
+		app.tb.Errorf("application didn't start cleanly: %v", err)
+		app.tb.FailNow()
+	}
+	return app
+}
+
+// MustStop calls Stop, failing the test if an error is encountered.
+func (app *App) MustStop() {
+	if err := app.Stop(context.Background()); err != nil {
+		app.tb.Errorf("application didn't stop cleanly: %v", err)
+		app.tb.FailNow()
+	}
 }
 
 var _ fx.Lifecycle = (*Lifecycle)(nil)
@@ -57,11 +103,12 @@ func NewLifecycle(t TB) *Lifecycle {
 func (l *Lifecycle) Start() error { return l.lc.Start() }
 
 // MustStart calls Start, failing the test if an error is encountered.
-func (l *Lifecycle) MustStart() {
+func (l *Lifecycle) MustStart() *Lifecycle {
 	if err := l.Start(); err != nil {
 		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
 		l.t.FailNow()
 	}
+	return l
 }
 
 // Stop calls all OnStop hooks whose OnStart counterpart was called, running

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -30,7 +30,6 @@ import (
 // TB is a subset of the standard library's testing.TB interface. It's
 // satisfied by both *testing.T and *testing.B.
 type TB interface {
-	// TODO: Use Logf to implement an fxlog.Logger that doesn't spam the console
 	Logf(string, ...interface{})
 	Errorf(string, ...interface{})
 	FailNow()
@@ -54,7 +53,7 @@ type App struct {
 
 // New creates a new test application.
 func New(tb TB, opts ...fx.Option) *App {
-	allOpts := make([]fx.Option, 0, len(opts))
+	allOpts := make([]fx.Option, 0, len(opts)+1)
 	allOpts = append(allOpts, fx.Logger(&testPrinter{tb}))
 	allOpts = append(allOpts, opts...)
 	return &App{

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -47,11 +47,6 @@ type Logger struct {
 	Printer
 }
 
-// Println logs a single Fx line.
-func (l *Logger) Println(str string) {
-	l.Printer.Printf(prepend(str))
-}
-
 // Printf logs a formatted Fx line.
 func (l *Logger) Printf(format string, v ...interface{}) {
 	l.Printer.Printf(prepend(format), v...)
@@ -70,7 +65,7 @@ func (l *Logger) PrintProvide(t interface{}) {
 
 // PrintSignal logs an os.Signal.
 func (l *Logger) PrintSignal(signal os.Signal) {
-	l.Println(strings.ToUpper(signal.String()))
+	l.Printf(strings.ToUpper(signal.String()))
 }
 
 // Panic logs an Fx line then panics.

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -32,28 +32,29 @@ import (
 
 var _exit = func() { os.Exit(1) }
 
-type printer interface {
+// Printer is a formatting printer.
+type Printer interface {
 	Printf(string, ...interface{})
 }
 
-// New returns a new Logger.
+// New returns a new Logger backed by the standard library's log package.
 func New() *Logger {
 	return &Logger{log.New(os.Stderr, "", log.LstdFlags)}
 }
 
 // A Logger writes output to standard error.
 type Logger struct {
-	std printer
+	Printer
 }
 
 // Println logs a single Fx line.
 func (l *Logger) Println(str string) {
-	l.std.Printf(prepend(str))
+	l.Printer.Printf(prepend(str))
 }
 
 // Printf logs a formatted Fx line.
 func (l *Logger) Printf(format string, v ...interface{}) {
-	l.std.Printf(prepend(format), v...)
+	l.Printer.Printf(prepend(format), v...)
 }
 
 // PrintProvide logs a type provided into the dig.Container.
@@ -74,13 +75,13 @@ func (l *Logger) PrintSignal(signal os.Signal) {
 
 // Panic logs an Fx line then panics.
 func (l *Logger) Panic(err error) {
-	l.std.Printf(prepend(err.Error()))
+	l.Printer.Printf(prepend(err.Error()))
 	panic(err)
 }
 
 // Fatalf logs an Fx line then fatals.
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-	l.std.Printf(prepend(format), v...)
+	l.Printer.Printf(prepend(format), v...)
 	_exit()
 }
 

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -62,12 +62,6 @@ func TestPrint(t *testing.T) {
 	sink := newSpy()
 	logger := &Logger{sink}
 
-	t.Run("println", func(t *testing.T) {
-		sink.Reset()
-		logger.Println("foo")
-		assert.Equal(t, "[Fx] foo\n", sink.String())
-	})
-
 	t.Run("printf", func(t *testing.T) {
 		sink.Reset()
 		logger.Printf("foo %d", 42)


### PR DESCRIPTION
Currently, it's irritating for module owners to integration test their code - they have to use the plain `fx.App` type, which is a bit verbose for common test assertions. More importantly, `fx.App` writes verbose logs to standard error. Since Go's testing library buffers all console output and displays it when tests fail, this makes every test failure print a wall of Fx logs.

This PR exposes a `Logger` option that lets users replace an application's log destination, then adds an `fxtest.App` type that directs all output to the user's `testing.T`. Under this setup, test failures will only show the log output from that one test. Along the way, it adds `MustStart` and `MustStop` helpers.

Fixes #535.