### PR TITLE
Change UberFx to Fx throughout repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Developing UberFx
+# Developing Fx
 
-This doc is intended for contributors to UberFx (hopefully that's you!).
+This doc is intended for contributors to Fx (hopefully that's you!).
 
 ## Development environment
 
@@ -9,7 +9,7 @@ This doc is intended for contributors to UberFx (hopefully that's you!).
 
 * **[overcommit](https://github.com/brigade/overcommit)**, a git hook manager.
   Install `overcommit` into your path with `sudo gem install overcommit`.
-  Enable it on the UberFx repo with `overcommit --install`.
+  Enable it on the Fx repo with `overcommit --install`.
   We use overcommit to enforce a variety of style, semantic, and legal things
   (for example, license headers on all source files).
 
@@ -85,7 +85,7 @@ go get -u gopkg.in/matm/v1/gocov-html
 
 ## Package documentation
 
-UberFx uses [md-to-godoc](https://github.com/sectioneight/md-to-godoc) to
+Fx uses [md-to-godoc](https://github.com/sectioneight/md-to-godoc) to
 generate `doc.go` package documentation from `README.md` Markdown syntax. This
 means that all package-level documentation is viewable both on GitHub and
 [godoc.org](https://godoc.org/go.uber.org/fx).
@@ -98,3 +98,4 @@ Note that changes to documentation may take a while to propagate to godoc.org.
 If you check in a change to package documentation, you can manually trigger a
 refresh by scrolling to the bottom of the page on godoc.org and clicking
 "Refresh Now."
+Fx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,20 +82,3 @@ You'll need to have [gocov-html](https://github.com/matm/gocov-html) installed:
 ```bash
 go get -u gopkg.in/matm/v1/gocov-html
 ```
-
-## Package documentation
-
-Fx uses [md-to-godoc](https://github.com/sectioneight/md-to-godoc) to
-generate `doc.go` package documentation from `README.md` Markdown syntax. This
-means that all package-level documentation is viewable both on GitHub and
-[godoc.org](https://godoc.org/go.uber.org/fx).
-
-To document a new package, create a `README.md` in the package directory.
-Once you're satisfied with its contents, run `make gendoc` from the root of the
-project to rebuild the `doc.go` files.
-
-Note that changes to documentation may take a while to propagate to godoc.org.
-If you check in a change to package documentation, you can manually trigger a
-refresh by scrolling to the bottom of the page on godoc.org and clicking
-"Refresh Now."
-Fx

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# UberFx Service Framework
+# Fx Service Framework
 
 [![GoDoc][doc-img]][doc]
 [![Coverage Status][cov-img]][cov]
 [![Build Status][ci-img]][ci]
 [![Report Card][report-card-img]][report-card]
 
-UberFx is a flexible, modularized framework for building robust and performant
+Fx is a flexible, modularized framework for building robust and performant
 services. It takes care of the boilerplate code and lets you focus on your
 application logic.
 
@@ -16,7 +16,7 @@ for more.
 
 ## Compatibility
 
-UberFx is compatible with Go 1.7 and above.
+Fx is compatible with Go 1.7 and above.
 
 ## License
 


### PR DESCRIPTION
Since we're attempting to keep the internal collection of opinionated modules distinct from the open-source framework, replace all uses of `UberFx` with `Fx` here.