### PR TITLE
Run provides after other options

### DIFF
--- a/app.go
+++ b/app.go
@@ -82,9 +82,7 @@ func (f optionFunc) apply(app *App) { f(app) }
 // See the documentation for go.uber.org/dig for further details.
 func Provide(constructors ...interface{}) Option {
 	return optionFunc(func(app *App) {
-		for _, c := range constructors {
-			app.provide(c)
-		}
+		app.provides = append(app.provides, constructors...)
 	})
 }
 
@@ -132,6 +130,7 @@ type App struct {
 	optionErr error
 	container *dig.Container
 	lifecycle *lifecycleWrapper
+	provides  []interface{}
 	invokes   []interface{}
 	logger    *fxlog.Logger
 }
@@ -152,6 +151,9 @@ func New(opts ...Option) *App {
 		opt.apply(app)
 	}
 
+	for _, p := range app.provides {
+		app.provide(p)
+	}
 	app.provide(func() Lifecycle { return app.lifecycle })
 	return app
 }

--- a/app_test.go
+++ b/app_test.go
@@ -49,6 +49,23 @@ func TestNewApp(t *testing.T) {
 		require.NoError(t, app.Start(context.Background()))
 		assert.True(t, found)
 	})
+
+	t.Run("OptionsHappensBeforeProvides", func(t *testing.T) {
+		optionRun := false
+
+		p := func() struct{} {
+			assert.True(t, optionRun, "Option must run before provides")
+			return struct{}{}
+		}
+		inv := func(struct{}) {}
+
+		anOption := optionFunc(func(app *App) {
+			optionRun = true
+		})
+
+		app := New(Provide(p), Invoke(inv), anOption)
+		app.Start(Timeout(1 * time.Second))
+	})
 }
 
 func TestOptions(t *testing.T) {


### PR DESCRIPTION
This removes positional dependence of options like fx.Logger()
Fixes #552