### PR TITLE
Verify App.Run

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -233,11 +233,9 @@ func TestAppRun(t *testing.T) {
 		go func() {
 			app.Run()
 		}()
-
 		// 100ms sleep makes sure that app is in RUNNING state
 		time.Sleep(100 * time.Millisecond)
 	}
-
 	t.Run("BlocksOnSignals", func(t *testing.T) {
 		app := New()
 
@@ -249,7 +247,6 @@ func TestAppRun(t *testing.T) {
 
 		run(app)
 		assert.NoError(t, proc.Signal(syscall.SIGTERM), "Could not send syscall.SIGTERM")
-
 	})
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -25,6 +25,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -223,6 +225,31 @@ func TestAppStop(t *testing.T) {
 		err := app.Stop(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "OnStop fail")
+	})
+}
+
+func TestAppRun(t *testing.T) {
+	run := func(app *App) {
+		go func() {
+			app.Run()
+		}()
+
+		// 100ms sleep makes sure that app is in RUNNING state
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Run("BlocksOnSignals", func(t *testing.T) {
+		app := New()
+
+		proc, err := os.FindProcess(os.Getpid())
+		assert.NoError(t, err, "Could not find process")
+
+		run(app)
+		assert.NoError(t, proc.Signal(os.Interrupt), "Could not send os.Interrupt")
+
+		run(app)
+		assert.NoError(t, proc.Signal(syscall.SIGTERM), "Could not send syscall.SIGTERM")
+
 	})
 }
 


### PR DESCRIPTION
This integration test shamelessly verifies that sending `os.Interrupt` or `syscall.SIGTERM` does indeed cause `App.Run` to stop blocking.

I say shamelessly because it introduces a 100ms sleep and cannot be run concurrently.

That being said, it's nice to have some sort of verification that this does what it says, and gets us above 90% CC.