### PR TITLE
Take a context in lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   sink.
 - Add `fxtest.App`, which redirects log output to the user's `testing.TB` and
   provides some lifecycle helpers.
+- Alter lifecycle hook signatures to accept a context.
 
 ## v1.0.0-rc1 (20 Jun 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   sink.
 - Add `fxtest.App`, which redirects log output to the user's `testing.TB` and
   provides some lifecycle helpers.
-- Alter lifecycle hook signatures to accept a context.
+- **[Breaking]** Alter lifecycle hooks to accept a context.
 
 ## v1.0.0-rc1 (20 Jun 2017)
 

--- a/app_test.go
+++ b/app_test.go
@@ -159,7 +159,7 @@ func TestAppStart(t *testing.T) {
 
 	t.Run("StartError", func(t *testing.T) {
 		failStart := func(lc Lifecycle) struct{} {
-			lc.Append(Hook{OnStart: func() error {
+			lc.Append(Hook{OnStart: func(context.Context) error {
 				return errors.New("OnStart fail")
 			}})
 			return struct{}{}
@@ -176,8 +176,8 @@ func TestAppStart(t *testing.T) {
 	t.Run("StartAndStopErrors", func(t *testing.T) {
 		fail := func(lc Lifecycle) struct{} {
 			lc.Append(Hook{
-				OnStart: func() error { return errors.New("OnStart fail") },
-				OnStop:  func() error { return errors.New("OnStop fail") },
+				OnStart: func(context.Context) error { return errors.New("OnStart fail") },
+				OnStop:  func(context.Context) error { return errors.New("OnStop fail") },
 			})
 			return struct{}{}
 		}
@@ -194,7 +194,7 @@ func TestAppStart(t *testing.T) {
 
 func TestAppStop(t *testing.T) {
 	t.Run("Timeout", func(t *testing.T) {
-		block := func() error { select {} }
+		block := func(context.Context) error { select {} }
 		app := New(Invoke(func(l Lifecycle) {
 			l.Append(Hook{OnStop: block})
 		}))
@@ -210,7 +210,7 @@ func TestAppStop(t *testing.T) {
 
 	t.Run("StopError", func(t *testing.T) {
 		failStop := func(lc Lifecycle) struct{} {
-			lc.Append(Hook{OnStop: func() error {
+			lc.Append(Hook{OnStop: func(context.Context) error {
 				return errors.New("OnStop fail")
 			}})
 			return struct{}{}

--- a/example_test.go
+++ b/example_test.go
@@ -21,6 +21,7 @@
 package fx_test
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -52,14 +53,14 @@ func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
 	// If NewMux is called, we know that someone is using the mux. In that case,
 	// start up and shut down an HTTP server with the application.
 	lc.Append(fx.Hook{
-		OnStart: func() error {
+		OnStart: func(context.Context) error {
 			logger.Print("Starting HTTP server.")
 			go server.ListenAndServe()
 			return nil
 		},
-		OnStop: func() error {
+		OnStop: func(ctx context.Context) error {
 			logger.Print("Stopping HTTP server.")
-			return server.Close()
+			return server.Shutdown(ctx)
 		},
 	})
 

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -99,11 +99,12 @@ func NewLifecycle(t TB) *Lifecycle {
 
 // Start executes all registered OnStart hooks in order, halting at the first
 // hook that doesn't succeed.
-func (l *Lifecycle) Start() error { return l.lc.Start() }
+func (l *Lifecycle) Start(ctx context.Context) error { return l.lc.Start(ctx) }
 
-// MustStart calls Start, failing the test if an error is encountered.
+// MustStart calls Start with context.Background(), failing the test if an
+// error is encountered.
 func (l *Lifecycle) MustStart() *Lifecycle {
-	if err := l.Start(); err != nil {
+	if err := l.Start(context.Background()); err != nil {
 		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
 		l.t.FailNow()
 	}
@@ -116,11 +117,12 @@ func (l *Lifecycle) MustStart() *Lifecycle {
 // If any hook returns an error, execution continues for a best-effort
 // cleanup. Any errors encountered are collected into a single error and
 // returned.
-func (l *Lifecycle) Stop() error { return l.lc.Stop() }
+func (l *Lifecycle) Stop(ctx context.Context) error { return l.lc.Stop(ctx) }
 
-// MustStop calls Stop, failing the test if an error is encountered.
+// MustStop calls Stop with context.Background(), failing the test if an error
+// is encountered.
 func (l *Lifecycle) MustStop() {
-	if err := l.Stop(); err != nil {
+	if err := l.Stop(context.Background()); err != nil {
 		l.t.Errorf("lifecycle didn't stop cleanly: %v", err)
 		l.t.FailNow()
 	}

--- a/fxtest/fxtest_test.go
+++ b/fxtest/fxtest_test.go
@@ -22,6 +22,7 @@ package fxtest
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -88,7 +89,7 @@ func TestApp(t *testing.T) {
 		spy.Reset()
 
 		construct := func(lc fx.Lifecycle) struct{} {
-			lc.Append(fx.Hook{OnStop: func() error { return errors.New("fail") }})
+			lc.Append(fx.Hook{OnStop: func(context.Context) error { return errors.New("fail") }})
 			return struct{}{}
 		}
 		New(
@@ -111,8 +112,8 @@ func TestLifecycle(t *testing.T) {
 		n := 0
 		lc := NewLifecycle(spy)
 		lc.Append(fx.Hook{
-			OnStart: func() error { n++; return nil },
-			OnStop:  func() error { n++; return nil },
+			OnStart: func(context.Context) error { n++; return nil },
+			OnStop:  func(context.Context) error { n++; return nil },
 		})
 		lc.MustStart().MustStop()
 
@@ -123,7 +124,7 @@ func TestLifecycle(t *testing.T) {
 	t.Run("StartFailure", func(t *testing.T) {
 		spy.Reset()
 		lc := NewLifecycle(spy)
-		lc.Append(fx.Hook{OnStart: func() error { return errors.New("fail") }})
+		lc.Append(fx.Hook{OnStart: func(context.Context) error { return errors.New("fail") }})
 
 		lc.MustStart()
 		assert.Equal(t, 1, spy.failures, "Expected lifecycle start to fail.")
@@ -135,7 +136,7 @@ func TestLifecycle(t *testing.T) {
 	t.Run("StopFailure", func(t *testing.T) {
 		spy.Reset()
 		lc := NewLifecycle(spy)
-		lc.Append(fx.Hook{OnStop: func() error { return errors.New("fail") }})
+		lc.Append(fx.Hook{OnStop: func(context.Context) error { return errors.New("fail") }})
 
 		lc.MustStart()
 		assert.Equal(t, 0, spy.failures, "Expected lifecycle start to succeed.")

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -20,7 +20,11 @@
 
 package fx
 
-import "go.uber.org/fx/internal/lifecycle"
+import (
+	"context"
+
+	"go.uber.org/fx/internal/lifecycle"
+)
 
 // Lifecycle allows constructors to register callbacks that are executed on
 // application start and stop.
@@ -33,8 +37,8 @@ type Lifecycle interface {
 // failure short-circuited application start), its OnStop callback won't be
 // executed.
 type Hook struct {
-	OnStart func() error
-	OnStop  func() error
+	OnStart func(context.Context) error
+	OnStop  func(context.Context) error
 }
 
 type lifecycleWrapper struct{ *lifecycle.Lifecycle }


### PR DESCRIPTION
Lifecycle hooks are often trying to make RPCs, shut down a server
gracefully, or perform other operations that take a timeout.
Idiomatically, timeouts are passed using the `context.Context` type, so we
should pass a context into our hooks.

Note that this *immediately* makes the package-level example more realistic.