### PR TITLE
Move top-level tests into black-box package

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -33,13 +33,6 @@ import (
 )
 
 func TestNewApp(t *testing.T) {
-	t.Run("InitializesFields", func(t *testing.T) {
-		app := New()
-		assert.NotNil(t, app.container)
-		assert.NotNil(t, app.lifecycle)
-		assert.NotNil(t, app.logger)
-	})
-
 	t.Run("ProvidesLifecycle", func(t *testing.T) {
 		found := false
 		app := New(Invoke(func(lc Lifecycle) {


### PR DESCRIPTION
Virtually all of Fx's unit tests exercise the code through the public
API. That means that they can't use `fxtest` without introducing a
circular dependency. In turn, that means that a single test failure
prints an unusable wall of output, since all the test apps are logging
to standard error.

This PR drops a useless test and refactors one test using unexported
APIs, then moves all tests into an `fx_test` black-box package. This
lets us use `fxtest` helpers, which dries up the unit tests and makes
the failure output readable.

Before:

```
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestNewApp.func2.1()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	struct {} <= go.uber.org/fx.TestNewApp.func3.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestNewApp.func3.2()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	struct {} <= go.uber.org/fx.TestOptions.func1.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestOptions.func1.2()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	fx.type1 <= go.uber.org/fx.TestOptions.func2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.type2 <= go.uber.org/fx.TestOptions.func2.2()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.type3 <= go.uber.org/fx.TestOptions.func2.3()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestOptions.func2.4()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*bytes.Buffer <= go.uber.org/fx.TestOptions.func3.1()
2017/07/10 15:01:32 [Fx] PROVIDE	struct {} <= go.uber.org/fx.TestOptions.func3.2()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestOptions.func3.3()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestAppStart.func1.1()
2017/07/10 15:01:32 [Fx] PROVIDE	struct {} <= go.uber.org/fx.TestAppStart.func2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestAppStart.func2.2()
2017/07/10 15:01:32 [Fx] START		go.uber.org/fx.TestAppStart.func2.1()
2017/07/10 15:01:32 [Fx] ERROR		Start failed, rolling back: OnStart fail
2017/07/10 15:01:32 [Fx] PROVIDE	struct {} <= go.uber.org/fx.TestAppStart.func3.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestAppStart.func3.2()
2017/07/10 15:01:32 [Fx] START		go.uber.org/fx.TestAppStart.func3.1()
2017/07/10 15:01:32 [Fx] ERROR		Start failed, rolling back: OnStart fail
2017/07/10 15:01:32 [Fx] STOP		go.uber.org/fx.TestAppStart.func3.1()
2017/07/10 15:01:32 [Fx] ERROR		Couldn't rollback cleanly: OnStop fail
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestAppStop.func1.2()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] STOP		go.uber.org/fx.TestAppStop.func1.2()
2017/07/10 15:01:32 [Fx] PROVIDE	struct {} <= go.uber.org/fx.TestAppStop.func2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.TestAppStop.func2.2()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] STOP		go.uber.org/fx.TestAppStop.func2.1()
--- FAIL: TestReplaceLogger (0.00s)
        Error Trace:    app_test.go:243
	Error:		"[Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
			[Fx] RUNNING
			" does not contain "RRRRUNNING"

2017/07/10 15:01:32 [Fx] PROVIDE	*bytes.Buffer <= go.uber.org/fx.TestInject.func1.2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.Inject.func1()
2017/07/10 15:01:32 [Fx] PROVIDE	*bytes.Buffer <= go.uber.org/fx.TestInject.func1.2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.Inject.func1()
2017/07/10 15:01:32 [Fx] PROVIDE	*bytes.Buffer <= go.uber.org/fx.TestInject.func1.2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.Inject.func1()
2017/07/10 15:01:32 [Fx] PROVIDE	*bytes.Buffer <= go.uber.org/fx.TestInject.func1.2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx.Inject.func1()
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func2.1()
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type2 <= go.uber.org/fx.TestInject.func2.2()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func3.1()
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type2 <= go.uber.org/fx.TestInject.func3.2()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.T1 <= go.uber.org/fx.TestInject.func4.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func5.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func6.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func7.1()
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type2 <= go.uber.org/fx.TestInject.func7.2()
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type3 <= go.uber.org/fx.TestInject.func7.3()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func8.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func9.1()
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type2 <= go.uber.org/fx.TestInject.func9.2()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*fx.type1 <= go.uber.org/fx.TestInject.func10.1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*log.Logger <= go.uber.org/fx.ExampleInject.func1()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] PROVIDE	*log.Logger <= go.uber.org/fx_test.NewLogger()
2017/07/10 15:01:32 [Fx] PROVIDE	http.Handler <= go.uber.org/fx_test.NewHandler()
2017/07/10 15:01:32 [Fx] PROVIDE	*http.ServeMux <= go.uber.org/fx_test.NewMux()
2017/07/10 15:01:32 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:01:32 [Fx] INVOKE		go.uber.org/fx_test.Register()
2017/07/10 15:01:32 [Fx] START		go.uber.org/fx_test.NewMux()
2017/07/10 15:01:32 [Fx] RUNNING
2017/07/10 15:01:32 [Fx] STOP		go.uber.org/fx_test.NewMux()
FAIL
FAIL	go.uber.org/fx	0.019s
```

After:

```
--- FAIL: TestReplaceLogger (0.00s)
        Error Trace:    app_test.go:232
	Error:		"[Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
			[Fx] RUNNING
			" does not contain "RRRRUNNING"

2017/07/10 15:02:48 [Fx] PROVIDE	*log.Logger <= go.uber.org/fx_test.NewLogger()
2017/07/10 15:02:48 [Fx] PROVIDE	http.Handler <= go.uber.org/fx_test.NewHandler()
2017/07/10 15:02:48 [Fx] PROVIDE	*http.ServeMux <= go.uber.org/fx_test.NewMux()
2017/07/10 15:02:48 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:02:48 [Fx] INVOKE		go.uber.org/fx_test.Register()
2017/07/10 15:02:48 [Fx] START		go.uber.org/fx_test.NewMux()
2017/07/10 15:02:48 [Fx] RUNNING
2017/07/10 15:02:48 [Fx] STOP		go.uber.org/fx_test.NewMux()
2017/07/10 15:02:48 [Fx] PROVIDE	*log.Logger <= go.uber.org/fx_test.ExampleInject.func1()
2017/07/10 15:02:48 [Fx] PROVIDE	fx.Lifecycle <= go.uber.org/fx.New.func1()
2017/07/10 15:02:48 [Fx] INVOKE		reflect.makeFuncStub()
2017/07/10 15:02:48 [Fx] RUNNING
FAIL
FAIL	go.uber.org/fx	0.020s
```
--


