### PR TITLE
fx.Invoke: Fix panic if value is not a func

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -189,6 +189,13 @@ func TestAppStart(t *testing.T) {
 		assert.Contains(t, err.Error(), "OnStart fail")
 		assert.Contains(t, err.Error(), "OnStop fail")
 	})
+
+	t.Run("InvokeNonFunction", func(t *testing.T) {
+		app := fxtest.New(t, Invoke(struct{}{}))
+		err := app.Start(context.Background())
+		require.Error(t, err, "expected start failure")
+		assert.Contains(t, err.Error(), "can't invoke non-function")
+	})
 }
 
 func TestAppStop(t *testing.T) {

--- a/internal/fxreflect/fxreflect.go
+++ b/internal/fxreflect/fxreflect.go
@@ -67,7 +67,12 @@ func Caller() string {
 
 // FuncName returns a funcs formatted name
 func FuncName(fn interface{}) string {
-	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	fnV := reflect.ValueOf(fn)
+	if fnV.Kind() != reflect.Func {
+		return "n/a"
+	}
+
+	fnName := runtime.FuncForPC(fnV.Pointer()).Name()
 	return fmt.Sprintf("%s()", fnName)
 }
 

--- a/internal/fxreflect/fxreflect_test.go
+++ b/internal/fxreflect/fxreflect_test.go
@@ -71,4 +71,5 @@ func someFunc() {}
 
 func TestFuncName(t *testing.T) {
 	assert.Equal(t, "go.uber.org/fx/internal/fxreflect.someFunc()", FuncName(someFunc))
+	assert.Equal(t, "n/a", FuncName(struct{}{}))
 }


### PR DESCRIPTION
This fixes a panic on app.Start (due to logging) which occurs if the
argument to fx.Invoke was not a function.

Before:

    panic: reflect: call of reflect.Value.Pointer on struct Value

    goroutine 8 [running]:
    reflect.Value.Pointer(0x134c4a0, 0x1584f88, 0x99, 0x1584f88)
            [..]

After:

    err := app.Start()
    fmt.Println(err)
    // Output: can't invoke non-function {} (type struct {})