### PR TITLE
Detect Provide/Invoke on fx.Option

### DIFF
--- a/app.go
+++ b/app.go
@@ -260,7 +260,7 @@ func (app *App) provide(constructor interface{}) {
 	app.logger.PrintProvide(constructor)
 
 	if _, ok := constructor.(Option); ok {
-		app.optionErr = fmt.Errorf("cannot Provide fx.Option: %v", constructor)
+		app.optionErr = fmt.Errorf("fx.Option should be passed to fx.New directly, not to fx.Provide: fx.Provide received %v", constructor)
 		return
 	}
 
@@ -280,7 +280,7 @@ func (app *App) start(ctx context.Context) error {
 		app.logger.Printf("INVOKE\t\t%s", fxreflect.FuncName(fn))
 
 		if _, ok := fn.(Option); ok {
-			return fmt.Errorf("cannot Invoke fx.Option: %v", fn)
+			return fmt.Errorf("fx.Option should be passed to fx.New directly, not to fx.Invoke: fx.Invoke received %v", fn)
 		}
 
 		if err := app.container.Invoke(fn); err != nil {

--- a/app.go
+++ b/app.go
@@ -97,7 +97,7 @@ func (po provideOption) String() string {
 	for i, c := range po {
 		items[i] = fxreflect.FuncName(c)
 	}
-	return fmt.Sprintf("fx.Provide(%v)", strings.Join(items, ", "))
+	return fmt.Sprintf("fx.Provide(%s)", strings.Join(items, ", "))
 }
 
 // Invoke registers functions that are executed eagerly on application start.
@@ -125,7 +125,7 @@ func (io invokeOption) String() string {
 	for i, f := range io {
 		items[i] = fxreflect.FuncName(f)
 	}
-	return fmt.Sprintf("fx.Invoke(%v)", strings.Join(items, ", "))
+	return fmt.Sprintf("fx.Invoke(%s)", strings.Join(items, ", "))
 }
 
 // Options composes a collection of Options into a single Option.
@@ -146,7 +146,7 @@ func (og optionGroup) String() string {
 	for i, opt := range og {
 		items[i] = fmt.Sprint(opt)
 	}
-	return fmt.Sprintf("fx.Options(%v)", strings.Join(items, ", "))
+	return fmt.Sprintf("fx.Options(%s)", strings.Join(items, ", "))
 }
 
 // Printer is the interface required by fx's logging backend. It's implemented

--- a/app_test.go
+++ b/app_test.go
@@ -197,7 +197,7 @@ func TestAppStart(t *testing.T) {
 		assert.Contains(t, err.Error(), "can't invoke non-function")
 	})
 
-	t.Run("ProvideProvide", func(t *testing.T) {
+	t.Run("ProvidingAProvideShouldFail", func(t *testing.T) {
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
@@ -214,11 +214,11 @@ func TestAppStart(t *testing.T) {
 
 		err := app.Start(context.Background())
 		require.Error(t, err, "expected start failure")
-		assert.Contains(t, err.Error(), "cannot Provide fx.Option:")
-		assert.Contains(t, err.Error(), "fx.Provide(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Provide")
+		assert.Contains(t, err.Error(), "fx.Provide received fx.Provide(go.uber.org/fx_test.TestAppStart")
 	})
 
-	t.Run("InvokeInvoke", func(t *testing.T) {
+	t.Run("InvokingAnInvokeShouldFail", func(t *testing.T) {
 		type type1 struct{}
 
 		app := fxtest.New(t,
@@ -228,11 +228,11 @@ func TestAppStart(t *testing.T) {
 		)
 		err := app.Start(context.Background())
 		require.Error(t, err, "expected start failure")
-		assert.Contains(t, err.Error(), "cannot Invoke fx.Option:")
-		assert.Contains(t, err.Error(), "fx.Invoke(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Invoke")
+		assert.Contains(t, err.Error(), "fx.Invoke received fx.Invoke(go.uber.org/fx_test.TestAppStart")
 	})
 
-	t.Run("ProvideOptions", func(t *testing.T) {
+	t.Run("ProvidingOptionsShouldFail", func(t *testing.T) {
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
@@ -255,8 +255,8 @@ func TestAppStart(t *testing.T) {
 		)
 		err := app.Start(context.Background())
 		require.Error(t, err, "expected start failure")
-		assert.Contains(t, err.Error(), "cannot Provide fx.Option:")
-		assert.Contains(t, err.Error(), "fx.Options(fx.Provide(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Provide")
+		assert.Contains(t, err.Error(), "fx.Provide received fx.Options(fx.Provide(go.uber.org/fx_test.TestAppStart")
 	})
 }
 


### PR DESCRIPTION
It's easy to accidentally do,

    Module = fx.Provide(..)

    app := fx.New(
        fx.Provide(foo, bar, Module),
    )

Currently this results in a cryptic error message:

    can't provide fx.optionFunc: unable to collect return types of a constructor: must provide at least one non-error type

With this change, the error message will be similar to,

    cannot Provide fx.Option: fx.Provide(go.uber.org/fx_test.TestAppStart.func5.2(), go.uber.org/fx_test.TestAppStart.func5.3())

Resolves #553