### PR TITLE
Logging now expands types provided in fx.Out

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,19 +1,19 @@
-hash: 5653160caff03632c8436e548345bf0932f9f14172c0783ae2328fdeda1a1a03
-updated: 2017-06-21T14:31:57.234774-07:00
+hash: f1271fa018d23c5a369ab3a420a11d7ad801223f6d1205e0b6ff091c6077a845
+updated: 2017-07-19T15:31:56.646351557-07:00
 imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/dig
-  version: e579b27f15bd39d0ecf1707053999b520a826a7b
+  version: f407770ddd130b106a6c615fca31f4b040ed7b1a
 - name: go.uber.org/multierr
-  version: ef109dc7f883f3a99db2d89edc701c25cac40571
+  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/golang/lint
-  version: c5fb716d6688a859aae56d26d3e6070808df29f7
+  version: a5f4a247366d8fc436941822e14fc3eac7727015
   subpackages:
   - golint
 - name: github.com/pmezard/go-difflib
@@ -30,6 +30,6 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/tools
-  version: cd6e398dae38fb8b0b57f221b13c4b75c0a53fb9
+  version: bc6db94186c03835daa5c1c679fba599dc1f3b79
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: f1271fa018d23c5a369ab3a420a11d7ad801223f6d1205e0b6ff091c6077a845
-updated: 2017-07-19T15:31:56.646351557-07:00
+hash: 68b8eedb4fec962b983fe71047b999f5b1677abce573cde3d8f7fa20e1bb89dd
+updated: 2017-07-21T11:21:30.043814666-07:00
 imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/dig
-  version: f407770ddd130b106a6c615fca31f4b040ed7b1a
+  version: 60ffc4c6942410bacc8241123f0ec4b5809ea60d
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 68b8eedb4fec962b983fe71047b999f5b1677abce573cde3d8f7fa20e1bb89dd
-updated: 2017-07-21T11:22:39.2555765-07:00
+hash: 2b75ea4b14c13f86d6199ade18b8cdae76d865355c64c4fcffcb3d590b6417a9
+updated: 2017-07-21T11:28:44.421471117-07:00
 imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: v1.0.0-rc2
+  version: 1.0.0-rc2
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.1.4

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: master # TODO: pin to v1.0.0-rc2 when cut
+  version: v1.0.0-rc2
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.1.4

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: v1.0.0-rc1
+  version: master # TODO: pin to v1.0.0-rc2 when cut
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.1.4

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"strings"
 
 	"go.uber.org/fx/internal/fxreflect"
@@ -54,10 +53,6 @@ func (l *Logger) Printf(format string, v ...interface{}) {
 
 // PrintProvide logs a type provided into the dig.Container.
 func (l *Logger) PrintProvide(t interface{}) {
-	if reflect.TypeOf(t).Kind() != reflect.Func {
-		// Invalid provide, will be logged as an error.
-		return
-	}
 	for _, rtype := range fxreflect.ReturnTypes(t) {
 		l.Printf("PROVIDE\t%s <= %s", rtype, fxreflect.FuncName(t))
 	}

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -75,7 +75,7 @@ func TestPrint(t *testing.T) {
 		assert.Equal(t, "[Fx] PROVIDE\t*bytes.Buffer <= bytes.NewBuffer()\n", sink.String())
 	})
 
-	t.Run("printOutProvideTypesSeparately", func(t *testing.T) {
+	t.Run("printExpandsTypesInOut", func(t *testing.T) {
 		sink.Reset()
 
 		type A struct{}

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/dig"
 )
 
 type spy struct {
@@ -72,6 +73,45 @@ func TestPrint(t *testing.T) {
 		sink.Reset()
 		logger.PrintProvide(bytes.NewBuffer)
 		assert.Equal(t, "[Fx] PROVIDE\t*bytes.Buffer <= bytes.NewBuffer()\n", sink.String())
+	})
+
+	t.Run("printOutProvideTypesSeparately", func(t *testing.T) {
+		sink.Reset()
+
+		type A struct{}
+		type B struct{}
+		type C struct{}
+		type Ret struct {
+			dig.Out
+			*A
+			B `optional:"true"`
+			C `name:"foo"`
+		}
+		logger.PrintProvide(func() Ret { return Ret{} })
+
+		s := sink.String()
+		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A <=")
+		assert.Contains(t, s, "[Fx] PROVIDE\t~fxlog.B <=")
+	})
+
+	t.Run("printOutNamedTypes", func(t *testing.T) {
+		sink.Reset()
+
+		type A struct{}
+		type B struct{}
+		type Ret struct {
+			dig.Out
+			*B `name:"foo"`
+
+			A1 *A `name:"primary"`
+			A2 *A `name:"secondary" optional:"true"`
+		}
+		logger.PrintProvide(func() Ret { return Ret{} })
+
+		s := sink.String()
+		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A:primary <=")
+		assert.Contains(t, s, "[Fx] PROVIDE\t~*fxlog.A:secondary <=")
+		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.B:foo <=")
 	})
 
 	t.Run("printProvideInvalid", func(t *testing.T) {

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -92,6 +92,7 @@ func TestPrint(t *testing.T) {
 		s := sink.String()
 		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A <=")
 		assert.Contains(t, s, "[Fx] PROVIDE\t~fxlog.B <=")
+		assert.Contains(t, s, "[Fx] PROVIDE\tfxlog.C:foo <=")
 	})
 
 	t.Run("printOutNamedTypes", func(t *testing.T) {

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -84,14 +84,14 @@ func TestPrint(t *testing.T) {
 		type Ret struct {
 			dig.Out
 			*A
-			B `optional:"true"`
+			B
 			C `name:"foo"`
 		}
 		logger.PrintProvide(func() Ret { return Ret{} })
 
 		s := sink.String()
 		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A <=")
-		assert.Contains(t, s, "[Fx] PROVIDE\t~fxlog.B <=")
+		assert.Contains(t, s, "[Fx] PROVIDE\tfxlog.B <=")
 		assert.Contains(t, s, "[Fx] PROVIDE\tfxlog.C:foo <=")
 	})
 
@@ -105,13 +105,13 @@ func TestPrint(t *testing.T) {
 			*B `name:"foo"`
 
 			A1 *A `name:"primary"`
-			A2 *A `name:"secondary" optional:"true"`
+			A2 *A `name:"secondary"`
 		}
 		logger.PrintProvide(func() Ret { return Ret{} })
 
 		s := sink.String()
 		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A:primary <=")
-		assert.Contains(t, s, "[Fx] PROVIDE\t~*fxlog.A:secondary <=")
+		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A:secondary <=")
 		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.B:foo <=")
 	})
 

--- a/internal/fxreflect/fxreflect.go
+++ b/internal/fxreflect/fxreflect.go
@@ -76,7 +76,7 @@ func traverseOuts(k key, f func(s string)) {
 
 	// call funtion on non-Out types
 	if dig.IsOut(k.t) {
-		// keep recursing down on field memebers in case they are ins
+		// keep recursing down on field members in case they are ins
 		for i := 0; i < k.t.NumField(); i++ {
 			field := k.t.Field(i)
 			ft := field.Type


### PR DESCRIPTION
This PR expands the dig.Out types in the logs to provide a much better
logging experience.

:feelsbadman: Unfortunately, I had to re-implement a bunch of things
about the dig internals: naming conventions for optionals and named
types, and how to parse struct tags. I added a TODO that expands on
another TODO talking about exporting some of the dig internals. Probably
a topic for a conversation. I'd like to land this as is and then think
through the clean up and how dig APIs can make this experience nicer.
Any change would be pretty radical and affect `Provide` and possibly
even `Invoke`.

On the plus side, the logging is now much nicer.