### PR TITLE
Add fx.In and fx.Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 ## v1.0.0-rc2 (unreleased)
 
-- Add a `Logger` option, which allows users to send Fx's logs to different
-  sink.
-- Add `fxtest.App`, which redirects log output to the user's `testing.TB` and
-  provides some lifecycle helpers.
 - **[Breaking]** Alter lifecycle hooks to accept a context.
+- Add `fx.In` and `fx.Out` which exposes optional and named types.
+  Modules should embed these types instead of relying on `dig.In` and `dig.Out`.
 - Add an `Err` method to retrieve the underlying errors during the dependency
   graph construction. The same error is also returned from `Start`.
 - Graph resolution now happens as part of `fx.New`, rather than at the beginning
   of `app.Start`. This allows inspection of the graph errors through `app.Err()`
   before the decision to start the app.
+- Add a `Logger` option, which allows users to send Fx's logs to different
+  sink.
+- Add `fxtest.App`, which redirects log output to the user's `testing.TB` and
+  provides some lifecycle helpers.
 
 ## v1.0.0-rc1 (20 Jun 2017)
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,19 +1,19 @@
-hash: 5653160caff03632c8436e548345bf0932f9f14172c0783ae2328fdeda1a1a03
-updated: 2017-06-21T14:31:57.234774-07:00
+hash: 04e2701a657e80069bfe993db8be1dbe820e08e1333485eb29aa0e05bc262926
+updated: 2017-07-20T12:59:34.157229674-07:00
 imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/dig
-  version: e579b27f15bd39d0ecf1707053999b520a826a7b
+  version: f407770ddd130b106a6c615fca31f4b040ed7b1a
 - name: go.uber.org/multierr
-  version: ef109dc7f883f3a99db2d89edc701c25cac40571
+  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/golang/lint
-  version: c5fb716d6688a859aae56d26d3e6070808df29f7
+  version: a5f4a247366d8fc436941822e14fc3eac7727015
   subpackages:
   - golint
 - name: github.com/pmezard/go-difflib
@@ -30,6 +30,6 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/tools
-  version: cd6e398dae38fb8b0b57f221b13c4b75c0a53fb9
+  version: bc6db94186c03835daa5c1c679fba599dc1f3b79
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/dig
-  version: f407770ddd130b106a6c615fca31f4b040ed7b1a
+  version: 7a1b19ea9358a95d389397b4e494e891db3adee6
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: v1.0.0-rc1
+  version: f407770ddd130b106a6c615fca31f4b040ed7b1a # TODO 1.0.0-rc2
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.1.4

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: f407770ddd130b106a6c615fca31f4b040ed7b1a # TODO 1.0.0-rc2
+  version: 7a1b19ea9358a95d389397b4e494e891db3adee6 # TODO 1.0.0-rc2
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.1.4

--- a/inout.go
+++ b/inout.go
@@ -8,9 +8,7 @@ import "go.uber.org/dig"
 // Modules should take a single param struct that embeds an In
 // in order to provide a forwards-compatible API where additional
 // optional properties can be added without breaking.
-type In struct {
-	dig.In
-}
+type In struct{ dig.In }
 
 // Out can be embedded in return structs in order to
 // name types and provide
@@ -18,6 +16,4 @@ type In struct {
 // Modules should return a single results struct that embeds
 // an Out in order to provide a forwards-compatible API where
 // additional types can be provided over time without breaking.
-type Out struct {
-	dig.Out
-}
+type Out struct{ dig.Out }

--- a/inout.go
+++ b/inout.go
@@ -11,7 +11,7 @@ import "go.uber.org/dig"
 type In struct{ dig.In }
 
 // Out can be embedded in return structs in order to
-// name types and provide
+// provide named types.
 //
 // Modules should return a single results struct that embeds
 // an Out in order to provide a forwards-compatible API where

--- a/inout.go
+++ b/inout.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fx
 
 import "go.uber.org/dig"

--- a/inout.go
+++ b/inout.go
@@ -1,0 +1,23 @@
+package fx
+
+import "go.uber.org/dig"
+
+// In can be embedded in a constructor's param struct
+// in order to take advantage of named and optional types.
+//
+// Modules should take a single param struct that embeds an In
+// in order to provide a forwards-compatible API where additional
+// optional properties can be added without breaking.
+type In struct {
+	dig.In
+}
+
+// Out can be embedded in return structs in order to
+// name types and provide
+//
+// Modules should return a single results struct that embeds
+// an Out in order to provide a forwards-compatible API where
+// additional types can be provided over time without breaking.
+type Out struct {
+	dig.Out
+}

--- a/inout.go
+++ b/inout.go
@@ -27,7 +27,7 @@ import "go.uber.org/dig"
 //
 // Modules should take a single param struct that embeds an In
 // in order to provide a forwards-compatible API where additional
-// optional properties can be added without breaking.
+// optional fields can be added without breaking.
 type In struct{ dig.In }
 
 // Out can be embedded in return structs in order to

--- a/inout_test.go
+++ b/inout_test.go
@@ -89,7 +89,7 @@ func TestNamedTypes(t *testing.T) {
 		}
 	}
 
-	// another constructor that returns the type a with name "bar"
+	// another constructor that returns the same type a with name "bar"
 	type barOut struct {
 		fx.Out
 		A *a `name:"bar"`
@@ -100,10 +100,10 @@ func TestNamedTypes(t *testing.T) {
 		}
 	}
 
-	t.Run("InjectFoo", func(t *testing.T) {
+	t.Run("ResolveFoo", func(t *testing.T) {
 		t.Parallel()
 
-		// an invoke expects to get type a with name "foo"
+		// an invoke that resolves type a of name "foo"
 		type fooIn struct {
 			fx.In
 
@@ -120,10 +120,10 @@ func TestNamedTypes(t *testing.T) {
 
 	})
 
-	t.Run("InjectBar", func(t *testing.T) {
+	t.Run("ResolveBar", func(t *testing.T) {
 		t.Parallel()
 
-		// another expects to get type a with name "bar"
+		// another invoke that resolves the same type a of name "bar"
 		type barIn struct {
 			fx.In
 

--- a/inout_test.go
+++ b/inout_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func TestIn(t *testing.T) {
-	t.Parallel()
-
 	type in struct {
 		fx.In
 	}
@@ -40,8 +38,6 @@ func TestIn(t *testing.T) {
 }
 
 func TestOut(t *testing.T) {
-	t.Parallel()
-
 	type out struct {
 		fx.Out
 	}
@@ -49,8 +45,6 @@ func TestOut(t *testing.T) {
 }
 
 func TestOptionalTypes(t *testing.T) {
-	t.Parallel()
-
 	type foo struct{}
 	newFoo := func() *foo { return &foo{} }
 
@@ -65,8 +59,6 @@ func TestOptionalTypes(t *testing.T) {
 	}
 
 	t.Run("NotProvided", func(t *testing.T) {
-		t.Parallel()
-
 		ran := false
 		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
@@ -78,8 +70,6 @@ func TestOptionalTypes(t *testing.T) {
 	})
 
 	t.Run("Provided", func(t *testing.T) {
-		t.Parallel()
-
 		ran := false
 		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
@@ -92,8 +82,6 @@ func TestOptionalTypes(t *testing.T) {
 }
 
 func TestNamedTypes(t *testing.T) {
-	t.Parallel()
-
 	type a struct {
 		name string
 	}
@@ -121,8 +109,6 @@ func TestNamedTypes(t *testing.T) {
 	}
 
 	t.Run("ResolveFoo", func(t *testing.T) {
-		t.Parallel()
-
 		// an invoke that resolves type a of name "foo"
 		type fooIn struct {
 			fx.In
@@ -139,8 +125,6 @@ func TestNamedTypes(t *testing.T) {
 	})
 
 	t.Run("ResolveBar", func(t *testing.T) {
-		t.Parallel()
-
 		// another invoke that resolves the same type a of name "bar"
 		type barIn struct {
 			fx.In

--- a/inout_test.go
+++ b/inout_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fx_test
 
 import (

--- a/inout_test.go
+++ b/inout_test.go
@@ -21,7 +21,6 @@
 package fx_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,14 +33,14 @@ func TestIn(t *testing.T) {
 	type in struct {
 		fx.In
 	}
-	assert.True(t, dig.IsIn(reflect.TypeOf(in{})), "Expected dig.In to work with fx.In")
+	assert.True(t, dig.IsIn(in{}), "Expected dig.In to work with fx.In")
 }
 
 func TestOut(t *testing.T) {
 	type out struct {
 		fx.Out
 	}
-	assert.True(t, dig.IsOut(reflect.TypeOf(out{})), "expected dig.Out to work with fx.Out")
+	assert.True(t, dig.IsOut(out{}), "expected dig.Out to work with fx.Out")
 }
 
 func TestOptionalTypes(t *testing.T) {

--- a/inout_test.go
+++ b/inout_test.go
@@ -11,70 +11,67 @@ import (
 )
 
 func TestIn(t *testing.T) {
-	t.Run("IsDigIn", func(t *testing.T) {
-		t.Parallel()
+	t.Parallel()
 
-		type in struct {
-			fx.In
-		}
-		assert.True(t, dig.IsIn(reflect.TypeOf(in{})), "Expected dig.In to work with fx.In")
-	})
-	t.Run("Optionals", func(t *testing.T) {
-		t.Parallel()
-
-		type foo struct{}
-		newFoo := func() *foo { return &foo{} }
-
-		type bar struct{}
-		newBar := func() *bar { return &bar{} }
-
-		type params struct {
-			fx.In
-
-			Foo *foo
-			Bar *bar `optional:"true"`
-		}
-
-		t.Run("NotProvided", func(t *testing.T) {
-			t.Parallel()
-
-			ran := false
-			app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(params params) {
-				assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
-				assert.Nil(t, params.Bar, "bar was optional and not provided, expected nil")
-				ran = true
-			}))
-			app.MustStart().MustStop()
-			assert.True(t, ran, "expected invoke to run")
-		})
-
-		t.Run("Provided", func(t *testing.T) {
-			t.Parallel()
-
-			ran := false
-			app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(params params) {
-				assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
-				assert.NotNil(t, params.Bar, "bar was optional and provided, expected not nil")
-				ran = true
-			}))
-			app.MustStart().MustStop()
-			assert.True(t, ran, "expected invoke to run")
-		})
-	})
+	type in struct {
+		fx.In
+	}
+	assert.True(t, dig.IsIn(reflect.TypeOf(in{})), "Expected dig.In to work with fx.In")
 }
 
 func TestOut(t *testing.T) {
-	t.Run("IsDigOut", func(t *testing.T) {
+	t.Parallel()
+
+	type out struct {
+		fx.Out
+	}
+	assert.True(t, dig.IsOut(reflect.TypeOf(out{})), "expected dig.Out to work with fx.Out")
+}
+
+func TestOptionalTypes(t *testing.T) {
+	t.Parallel()
+
+	type foo struct{}
+	newFoo := func() *foo { return &foo{} }
+
+	type bar struct{}
+	newBar := func() *bar { return &bar{} }
+
+	type params struct {
+		fx.In
+
+		Foo *foo
+		Bar *bar `optional:"true"`
+	}
+
+	t.Run("NotProvided", func(t *testing.T) {
 		t.Parallel()
 
-		type out struct {
-			fx.Out
-		}
-		assert.True(t, dig.IsOut(reflect.TypeOf(out{})), "expected dig.Out to work with fx.Out")
+		ran := false
+		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(params params) {
+			assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
+			assert.Nil(t, params.Bar, "bar was optional and not provided, expected nil")
+			ran = true
+		}))
+		app.MustStart().MustStop()
+		assert.True(t, ran, "expected invoke to run")
+	})
+
+	t.Run("Provided", func(t *testing.T) {
+		t.Parallel()
+
+		ran := false
+		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(params params) {
+			assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
+			assert.NotNil(t, params.Bar, "bar was optional and provided, expected not nil")
+			ran = true
+		}))
+		app.MustStart().MustStop()
+		assert.True(t, ran, "expected invoke to run")
 	})
 }
 
-func TestNamed(t *testing.T) {
+func TestNamedTypes(t *testing.T) {
 	t.Parallel()
 
 	type a struct {

--- a/inout_test.go
+++ b/inout_test.go
@@ -1,0 +1,144 @@
+package fx_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/dig"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestIn(t *testing.T) {
+	t.Run("IsDigIn", func(t *testing.T) {
+		t.Parallel()
+
+		type in struct {
+			fx.In
+		}
+		assert.True(t, dig.IsIn(reflect.TypeOf(in{})), "Expected dig.In to work with fx.In")
+	})
+	t.Run("Optionals", func(t *testing.T) {
+		t.Parallel()
+
+		type foo struct{}
+		newFoo := func() *foo { return &foo{} }
+
+		type bar struct{}
+		newBar := func() *bar { return &bar{} }
+
+		type params struct {
+			fx.In
+
+			Foo *foo
+			Bar *bar `optional:"true"`
+		}
+
+		t.Run("NotProvided", func(t *testing.T) {
+			t.Parallel()
+
+			ran := false
+			app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(params params) {
+				assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
+				assert.Nil(t, params.Bar, "bar was optional and not provided, expected nil")
+				ran = true
+			}))
+			app.MustStart().MustStop()
+			assert.True(t, ran, "expected invoke to run")
+		})
+
+		t.Run("Provided", func(t *testing.T) {
+			t.Parallel()
+
+			ran := false
+			app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(params params) {
+				assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
+				assert.NotNil(t, params.Bar, "bar was optional and provided, expected not nil")
+				ran = true
+			}))
+			app.MustStart().MustStop()
+			assert.True(t, ran, "expected invoke to run")
+		})
+	})
+}
+
+func TestOut(t *testing.T) {
+	t.Run("IsDigOut", func(t *testing.T) {
+		t.Parallel()
+
+		type out struct {
+			fx.Out
+		}
+		assert.True(t, dig.IsOut(reflect.TypeOf(out{})), "expected dig.Out to work with fx.Out")
+	})
+}
+
+func TestNamed(t *testing.T) {
+	t.Parallel()
+
+	type a struct {
+		name string
+	}
+
+	// a constructor that returns the type a with name "foo"
+	type fooOut struct {
+		fx.Out
+		A *a `name:"foo"`
+	}
+	newFoo := func() fooOut {
+		return fooOut{
+			A: &a{name: "foo"},
+		}
+	}
+
+	// another constructor that returns the type a with name "bar"
+	type barOut struct {
+		fx.Out
+		A *a `name:"bar"`
+	}
+	newBar := func() barOut {
+		return barOut{
+			A: &a{name: "bar"},
+		}
+	}
+
+	t.Run("InjectFoo", func(t *testing.T) {
+		t.Parallel()
+
+		// an invoke expects to get type a with name "foo"
+		type fooIn struct {
+			fx.In
+
+			A *a `name:"foo"`
+		}
+		ran := false
+		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in fooIn) {
+			assert.NotNil(t, in.A, "expected in.a to be injected")
+			assert.Equal(t, "foo", in.A.name, "expected to get type a of name foo")
+			ran = true
+		}))
+		app.MustStart().MustStop()
+		assert.True(t, ran, "expected invoke to run")
+
+	})
+
+	t.Run("InjectBar", func(t *testing.T) {
+		t.Parallel()
+
+		// another expects to get type a with name "bar"
+		type barIn struct {
+			fx.In
+
+			A *a `name:"bar"`
+		}
+		ran := false
+		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in barIn) {
+			assert.NotNil(t, in.A, "expected in.a to be injected")
+			assert.Equal(t, "bar", in.A.name, "expected to get type a of name bar")
+			ran = true
+		}))
+		app.MustStart().MustStop()
+		assert.True(t, ran, "expected invoke to run")
+	})
+}

--- a/inout_test.go
+++ b/inout_test.go
@@ -37,7 +37,7 @@ func TestOptionalTypes(t *testing.T) {
 	type bar struct{}
 	newBar := func() *bar { return &bar{} }
 
-	type params struct {
+	type in struct {
 		fx.In
 
 		Foo *foo
@@ -48,9 +48,9 @@ func TestOptionalTypes(t *testing.T) {
 		t.Parallel()
 
 		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(params params) {
-			assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
-			assert.Nil(t, params.Bar, "bar was optional and not provided, expected nil")
+		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(in in) {
+			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
+			assert.Nil(t, in.Bar, "bar was optional and not provided, expected nil")
 			ran = true
 		}))
 		app.MustStart().MustStop()
@@ -61,9 +61,9 @@ func TestOptionalTypes(t *testing.T) {
 		t.Parallel()
 
 		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(params params) {
-			assert.NotNil(t, params.Foo, "foo was not optional and provided, expected not nil")
-			assert.NotNil(t, params.Bar, "bar was optional and provided, expected not nil")
+		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
+			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
+			assert.NotNil(t, in.Bar, "bar was optional and provided, expected not nil")
 			ran = true
 		}))
 		app.MustStart().MustStop()

--- a/inout_test.go
+++ b/inout_test.go
@@ -109,14 +109,15 @@ func TestNamedTypes(t *testing.T) {
 		}
 	}
 
-	type fooIn struct {
+	// invoke with an fx.In that resolves both named types
+	type in struct {
 		fx.In
 
 		Foo *a `name:"foo"`
 		Bar *a `name:"bar"`
 	}
 	ran := false
-	app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in fooIn) {
+	app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
 		assert.NotNil(t, in.Foo, "expected in.Foo to be injected")
 		assert.Equal(t, "foo", in.Foo.name, "expected to get type 'a' of name 'foo'")
 

--- a/inout_test.go
+++ b/inout_test.go
@@ -88,6 +88,7 @@ func TestNamedTypes(t *testing.T) {
 	// a constructor that returns the type a with name "foo"
 	type fooOut struct {
 		fx.Out
+
 		A *a `name:"foo"`
 	}
 	newFoo := func() fooOut {
@@ -99,6 +100,7 @@ func TestNamedTypes(t *testing.T) {
 	// another constructor that returns the same type a with name "bar"
 	type barOut struct {
 		fx.Out
+
 		A *a `name:"bar"`
 	}
 	newBar := func() barOut {
@@ -107,35 +109,22 @@ func TestNamedTypes(t *testing.T) {
 		}
 	}
 
-	t.Run("ResolveFoo", func(t *testing.T) {
-		// an invoke that resolves type a of name "foo"
-		type fooIn struct {
-			fx.In
-			A *a `name:"foo"`
-		}
-		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in fooIn) {
-			assert.NotNil(t, in.A, "expected in.a to be injected")
-			assert.Equal(t, "foo", in.A.name, "expected to get type a of name foo")
-			ran = true
-		}))
-		app.MustStart().MustStop()
-		assert.True(t, ran, "expected invoke to run")
-	})
+	type fooIn struct {
+		fx.In
 
-	t.Run("ResolveBar", func(t *testing.T) {
-		// another invoke that resolves the same type a of name "bar"
-		type barIn struct {
-			fx.In
-			A *a `name:"bar"`
-		}
-		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in barIn) {
-			assert.NotNil(t, in.A, "expected in.a to be injected")
-			assert.Equal(t, "bar", in.A.name, "expected to get type a of name bar")
-			ran = true
-		}))
-		app.MustStart().MustStop()
-		assert.True(t, ran, "expected invoke to run")
-	})
+		Foo *a `name:"foo"`
+		Bar *a `name:"bar"`
+	}
+	ran := false
+	app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in fooIn) {
+		assert.NotNil(t, in.Foo, "expected in.Foo to be injected")
+		assert.Equal(t, "foo", in.Foo.name, "expected to get type 'a' of name 'foo'")
+
+		assert.NotNil(t, in.Bar, "expected in.Bar to be injected")
+		assert.Equal(t, "bar", in.Bar.name, "expected to get a type 'a' of name 'bar'")
+
+		ran = true
+	}))
+	app.MustStart().MustStop()
+	assert.True(t, ran, "expected invoke to run")
 }

--- a/inout_test.go
+++ b/inout_test.go
@@ -126,7 +126,6 @@ func TestNamedTypes(t *testing.T) {
 		// an invoke that resolves type a of name "foo"
 		type fooIn struct {
 			fx.In
-
 			A *a `name:"foo"`
 		}
 		ran := false
@@ -145,7 +144,6 @@ func TestNamedTypes(t *testing.T) {
 		// another invoke that resolves the same type a of name "bar"
 		type barIn struct {
 			fx.In
-
 			A *a `name:"bar"`
 		}
 		ran := false

--- a/inout_test.go
+++ b/inout_test.go
@@ -117,7 +117,6 @@ func TestNamedTypes(t *testing.T) {
 		}))
 		app.MustStart().MustStop()
 		assert.True(t, ran, "expected invoke to run")
-
 	})
 
 	t.Run("ResolveBar", func(t *testing.T) {


### PR DESCRIPTION
Modules should use this directly instead of relying on dig.In and dig.Out.

Resolves #558.