### PR TITLE
Inject: Support dig.In tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
-- `fx.Inject` now supports `fx.In` tags on destination structs.
+- `fx.Inject` now supports `fx.In` tags on target structs.
 
 ## v1.0.0-rc2 (21 Jul 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
-- No changes yet.
+- `fx.Inject` now supports `fx.In` tags on destination structs.
 
 ## v1.0.0-rc2 (21 Jul 2017)
 

--- a/inject.go
+++ b/inject.go
@@ -44,11 +44,11 @@ func Inject(target interface{}) Option {
 	v = v.Elem()
 	t := v.Type()
 
-	// We generate a function which accepts a single dig.In struct as an
+	// We generate a function which accepts a single fx.In struct as an
 	// argument. This struct contains all exported fields of the target
 	// struct.
 
-	// Fields of the generated dig.In struct.
+	// Fields of the generated fx.In struct.
 	fields := make([]reflect.StructField, 0, t.NumField()+1)
 
 	// The fix for https://github.com/golang/go/issues/18780 requires that
@@ -73,7 +73,7 @@ func Inject(target interface{}) Option {
 	// The generated struct has the shape,
 	//
 	// 	struct {
-	// 		dig.In
+	// 		fx.In
 	// 		F0 io.Reader
 	// 		F2 io.Writer
 	// 	}
@@ -108,7 +108,7 @@ func Inject(target interface{}) Option {
 
 	// Equivalent to,
 	//
-	// 	func(r struct{dig.In; F1 Foo; F2 Bar}) {
+	// 	func(r struct{fx.In; F1 Foo; F2 Bar}) {
 	// 		target.Foo = r.F1
 	// 		target.Bar = r.F2
 	// 	}

--- a/inject.go
+++ b/inject.go
@@ -76,6 +76,7 @@ func Inject(target interface{}) Option {
 	//
 	// 	struct {
 	// 		fx.In
+	//
 	// 		F0 io.Reader
 	// 		F2 io.Writer
 	// 	}
@@ -123,7 +124,12 @@ func Inject(target interface{}) Option {
 
 	// Equivalent to,
 	//
-	// 	func(r struct{fx.In; F1 Foo; F2 Bar}) {
+	// 	func(r struct {
+	// 		fx.In
+	//
+	// 		F1 Foo
+	// 		F2 Bar
+	// 	}) {
 	// 		target.Foo = r.F1
 	// 		target.Bar = r.F2
 	// 	}

--- a/inject.go
+++ b/inject.go
@@ -88,8 +88,8 @@ func Inject(target interface{}) Option {
 	// 		target.Field(2),  // Baz io.Writer
 	// 	]
 	//
-	// As we iterate through the fields of the generated struct, we can simply
-	// copy the value into the corresponding value in the targets list.
+	// As we iterate through the fields of the generated struct, we can copy
+	// the value into the corresponding value in the targets list.
 	targets := make([]reflect.Value, 0, t.NumField())
 
 	for i := 0; i < t.NumField(); i++ {

--- a/inject_test.go
+++ b/inject_test.go
@@ -126,22 +126,26 @@ func TestInject(t *testing.T) {
 	})
 
 	t.Run("EmbeddedUnexportedField", func(t *testing.T) {
-		var gave1 *type1
-		new1 := func() *type1 {
-			gave1 = &type1{}
-			return gave1
-		}
-
+		new1 := func() *type1 { return &type1{} }
 		var out struct{ *type1 }
 
-		app := fxtest.New(t,
-			Provide(new1),
-			Inject(&out),
-		)
-
+		app := fxtest.New(t, Provide(new1), Inject(&out))
 		defer app.MustStart().MustStop()
-		assert.NotNil(t, out.type1, "type1 must not be nil")
-		assert.True(t, gave1 == out.type1, "type1 must match")
+
+		// Unexported fields are left unchanged.
+		assert.Nil(t, out.type1, "type1 must be nil")
+	})
+
+	t.Run("EmbeddedUnexportedFieldValue", func(t *testing.T) {
+		type type4 struct{ foo string }
+		new4 := func() type4 { return type4{"foo"} }
+		var out struct{ type4 }
+
+		app := fxtest.New(t, Provide(new4), Inject(&out))
+		defer app.MustStart().MustStop()
+
+		// Unexported fields are left unchanged.
+		assert.NotEqual(t, "foo", out.type4.foo)
 	})
 
 	t.Run("DuplicateFields", func(t *testing.T) {

--- a/reflect_go19.go
+++ b/reflect_go19.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.9
+
+package fx
+
+import "reflect"
+
+func anonymousField(t reflect.Type) reflect.StructField {
+	return reflect.StructField{Name: t.Name(), Anonymous: true, Type: t}
+}

--- a/reflect_pre_go19.go
+++ b/reflect_pre_go19.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build !go1.9
+
+package fx
+
+import "reflect"
+
+func anonymousField(t reflect.Type) reflect.StructField {
+	return reflect.StructField{Anonymous: true, Type: t}
+}


### PR DESCRIPTION
This changes fx.Inject to respect dig.In struct tags on target structs.
That is, the following code is now valid.

    var x struct{ Foo io.Reader `optional:"true"` }
    fx.New(fx.Inject(&x))

Resolves #564.