### PR TITLE
Remove fx.Timeout and fx.DefaultTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Remove `fx.Timeout` and `fx.DefaultTimeout`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/example_test.go
+++ b/example_test.go
@@ -84,14 +84,18 @@ func Example() {
 
 	// In a real application, we could just use app.Run() here. Since we don't
 	// want this example to run forever, we'll use Start and Stop.
-	if err := app.Start(fx.Timeout(time.Second)); err != nil {
+	startCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
 		log.Fatal(err)
 	}
 
 	// Normally, we'd block here with <-app.Done().
 	http.Get("http://localhost:8080/")
 
-	if err := app.Stop(fx.Timeout(time.Second)); err != nil {
+	stopCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := app.Stop(stopCtx); err != nil {
 		log.Fatal(err)
 	}
 	// Output:


### PR DESCRIPTION
A "take it or leave it" followup PR for #577.

This helper is useful in testing, but it looks like we can ship without it. We should consider killing this func for that reason alone. The `fx.Start` and `fx.Stop` methods could even set the default timeout on a `context.Background()` if one wasn't attached already.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.