### PR TITLE
Remove fx.App.Done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Remove `fx.App.Done`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/app.go
+++ b/app.go
@@ -258,7 +258,9 @@ func (app *App) Run() {
 		app.logger.Fatalf("ERROR\t\tFailed to start: %v", err)
 	}
 
-	app.logger.PrintSignal(<-app.Done())
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	app.logger.PrintSignal(<-signals)
 
 	if err := app.Stop(Timeout(DefaultTimeout)); err != nil {
 		app.logger.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
@@ -294,14 +296,6 @@ func (app *App) Start(ctx context.Context) error {
 // some fail.
 func (app *App) Stop(ctx context.Context) error {
 	return withTimeout(ctx, app.lifecycle.Stop)
-}
-
-// Done returns a channel of signals to block on after starting the
-// application.
-func (app *App) Done() <-chan os.Signal {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	return c
 }
 
 func (app *App) provide(constructor interface{}) {


### PR DESCRIPTION
A "take it or leave it" followup PR for #577.

This is a convenience function we could survive without. Most customers will call `fx.Run`, which should be good enough for now. If signal handling becomes something many apps need to do manually, then we can consider adding this back. Until then - it represents a function we'll need to explain/teach, adds extra weight to godoc, and we won't be able to delete it.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.