### PR TITLE
Rename fx.Invoke to fx.WithInvokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Rename `fx.Invoke` to `fx.WithInvokes`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/app.go
+++ b/app.go
@@ -100,7 +100,7 @@ func (po provideOption) String() string {
 	return fmt.Sprintf("fx.Provide(%s)", strings.Join(items, ", "))
 }
 
-// Invoke registers functions that are executed eagerly on application start.
+// WithInvokes registers functions that are executed eagerly on application start.
 // Arguments for these functions are provided from the application's
 // dependency injection container.
 //
@@ -110,7 +110,7 @@ func (po provideOption) String() string {
 // success indicator. All other returned values are discarded.
 //
 // See the documentation for go.uber.org/dig for further details.
-func Invoke(funcs ...interface{}) Option {
+func WithInvokes(funcs ...interface{}) Option {
 	return invokeOption(funcs)
 }
 
@@ -125,7 +125,7 @@ func (io invokeOption) String() string {
 	for i, f := range io {
 		items[i] = fxreflect.FuncName(f)
 	}
-	return fmt.Sprintf("fx.Invoke(%s)", strings.Join(items, ", "))
+	return fmt.Sprintf("fx.WithInvokes(%s)", strings.Join(items, ", "))
 }
 
 // Options composes a collection of Options into a single Option.
@@ -234,7 +234,7 @@ func (app *App) executeInvokes() error {
 		app.logger.Printf("INVOKE\t\t%s", fname)
 
 		if _, ok := fn.(Option); ok {
-			err = fmt.Errorf("fx.Option should be passed to fx.New directly, not to fx.Invoke: fx.Invoke received %v", fn)
+			err = fmt.Errorf("fx.Option should be passed to fx.New directly, not to fx.WithInvokes: received %v", fn)
 		} else {
 			err = app.container.Invoke(fn)
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -79,7 +79,7 @@ func Example() {
 		// the types in the container. Since the mux is now being used, its
 		// startup hook gets registered and the application includes an HTTP
 		// server.
-		fx.Invoke(Register),
+		fx.WithInvokes(Register),
 	)
 
 	// In a real application, we could just use app.Run() here. Since we don't

--- a/extract.go
+++ b/extract.go
@@ -38,7 +38,7 @@ func Extract(target interface{}) Option {
 	v := reflect.ValueOf(target)
 
 	if t := v.Type(); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
-		return Invoke(func() error {
+		return WithInvokes(func() error {
 			return fmt.Errorf("Extract expected a pointer to a struct, got a %v", t)
 		})
 	}
@@ -149,7 +149,7 @@ func Extract(target interface{}) Option {
 		},
 	)
 
-	return Invoke(fn.Interface())
+	return WithInvokes(fn.Interface())
 }
 
 // isExported reports whether the identifier is exported.

--- a/fxtest/fxtest_test.go
+++ b/fxtest/fxtest_test.go
@@ -78,7 +78,7 @@ func TestApp(t *testing.T) {
 
 		New(
 			spy,
-			fx.Invoke(func() error { return errors.New("fail") }),
+			fx.WithInvokes(func() error { return errors.New("fail") }),
 		).MustStart()
 
 		assert.Equal(t, 1, spy.failures, "Expected app to error on start.")
@@ -95,7 +95,7 @@ func TestApp(t *testing.T) {
 		New(
 			spy,
 			fx.Provide(construct),
-			fx.Invoke(func(struct{}) {}),
+			fx.WithInvokes(func(struct{}) {}),
 		).MustStart().MustStop()
 
 		assert.Equal(t, 1, spy.failures, "Expected Stop to fail.")

--- a/inout_test.go
+++ b/inout_test.go
@@ -59,7 +59,7 @@ func TestOptionalTypes(t *testing.T) {
 
 	t.Run("NotProvided", func(t *testing.T) {
 		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(in in) {
+		app := fxtest.New(t, fx.Provide(newFoo), fx.WithInvokes(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
 			assert.Nil(t, in.Bar, "bar was optional and not provided, expected nil")
 			ran = true
@@ -70,7 +70,7 @@ func TestOptionalTypes(t *testing.T) {
 
 	t.Run("Provided", func(t *testing.T) {
 		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
+		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.WithInvokes(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
 			assert.NotNil(t, in.Bar, "bar was optional and provided, expected not nil")
 			ran = true
@@ -117,7 +117,7 @@ func TestNamedTypes(t *testing.T) {
 		Bar *a `name:"bar"`
 	}
 	ran := false
-	app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
+	app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.WithInvokes(func(in in) {
 		assert.NotNil(t, in.Foo, "expected in.Foo to be injected")
 		assert.Equal(t, "foo", in.Foo.name, "expected to get type 'a' of name 'foo'")
 


### PR DESCRIPTION
A "take it or leave it" followup PR to #577.

One of the things that was surprising was that options didn't begin with `With*`. 

* `fx.Provide` -> `fx.WithConstructors`
* `fx.Invoke` -> `fx.WithInvokes`

I was pleasantly surprised how refreshing I found `fx.WithConstructors`, which is more verbose but much much easier to understand, and so will be better for end-users. I also found that the `With*` convention better matched the idea that these things aren't necessarily happening immediately, that instead you are instructing the `fx.App` to use these when it does it's thing.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.