### PR TITLE
Rename fx.Options to fx.WithModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Rename `fx.Options` to `fx.WithModule`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/app.go
+++ b/app.go
@@ -128,8 +128,8 @@ func (io invokeOption) String() string {
 	return fmt.Sprintf("fx.Invoke(%s)", strings.Join(items, ", "))
 }
 
-// Options composes a collection of Options into a single Option.
-func Options(opts ...Option) Option {
+// WithModule composes a collection of Options into a single Option.
+func WithModule(opts ...Option) Option {
 	return optionGroup(opts)
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -95,8 +95,8 @@ func TestInvokes(t *testing.T) {
 	})
 }
 
-func TestOptions(t *testing.T) {
-	t.Run("OptionsComposition", func(t *testing.T) {
+func TestWithModule(t *testing.T) {
+	t.Run("WithModuleComposition", func(t *testing.T) {
 		var n int
 		construct := func() struct{} {
 			n++
@@ -105,7 +105,7 @@ func TestOptions(t *testing.T) {
 		use := func(struct{}) {
 			n++
 		}
-		app := fxtest.New(t, Options(Provide(construct), Invoke(use)))
+		app := fxtest.New(t, WithModule(Provide(construct), Invoke(use)))
 		defer app.MustStart().MustStop()
 		assert.Equal(t, 2, n)
 	})
@@ -284,7 +284,7 @@ func TestAppStart(t *testing.T) {
 		type type2 struct{}
 		type type3 struct{}
 
-		module := Options(
+		module := WithModule(
 			Provide(
 				func() type1 { return type1{} },
 				func() type2 { return type2{} },


### PR DESCRIPTION
A "take it or leave it" followup PR to #577.

If the primary use for fx.Options is to define a module, then we should consider renaming it to fx.WithModule. In other words, it's easier to teach and recall concepts when we name things after how they are used, instead of what they are. I argued this point with the fx.Inject to fx.Extract rename.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.