### PR TITLE
Rename fxtest.Must* to fxtest.Require*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Rename `fxtest.Must*` to `fxtest.Require*`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/app_test.go
+++ b/app_test.go
@@ -51,7 +51,7 @@ func TestNewApp(t *testing.T) {
 			assert.NotNil(t, lc)
 			found = true
 		}))
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.True(t, found)
 	})
 
@@ -62,7 +62,7 @@ func TestNewApp(t *testing.T) {
 
 		spy := &printerSpy{&bytes.Buffer{}}
 		app := fxtest.New(t, Provide(func() struct{} { return struct{}{} }), Logger(spy))
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.Contains(t, spy.String(), "PROVIDE\tstruct {}")
 	})
 
@@ -106,7 +106,7 @@ func TestOptions(t *testing.T) {
 			n++
 		}
 		app := fxtest.New(t, Options(Provide(construct), Invoke(use)))
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.Equal(t, 2, n)
 	})
 
@@ -139,7 +139,7 @@ func TestOptions(t *testing.T) {
 			Provide(new1, new2, new3),
 			Invoke(biz),
 		)
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.Equal(t, 4, initOrder)
 	})
 
@@ -157,7 +157,7 @@ func TestOptions(t *testing.T) {
 			Provide(newBuffer, newEmpty),
 			Invoke(func(struct{}) { count++ }),
 		)
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.Equal(t, 2, count)
 	})
 
@@ -313,7 +313,7 @@ func TestAppStop(t *testing.T) {
 		app := fxtest.New(t, Invoke(func(l Lifecycle) {
 			l.Append(Hook{OnStop: block})
 		}))
-		app.MustStart()
+		app.RequireStart()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
@@ -334,7 +334,7 @@ func TestAppStop(t *testing.T) {
 			Provide(failStop),
 			Invoke(func(struct{}) {}),
 		)
-		app.MustStart()
+		app.RequireStart()
 		err := app.Stop(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "OnStop fail")
@@ -344,6 +344,6 @@ func TestAppStop(t *testing.T) {
 func TestReplaceLogger(t *testing.T) {
 	spy := printerSpy{&bytes.Buffer{}}
 	app := fxtest.New(t, Logger(spy))
-	app.MustStart().MustStop()
+	app.RequireStart().RequireStop()
 	assert.Contains(t, spy.String(), "RUNNING")
 }

--- a/extract_test.go
+++ b/extract_test.go
@@ -71,7 +71,7 @@ func TestExtract(t *testing.T) {
 			Provide(new1, new2),
 			Extract(&out),
 		)
-		app.MustStart().MustStop()
+		app.RequireStart().RequireStop()
 	})
 
 	t.Run("StructIsExtracted", func(t *testing.T) {
@@ -97,7 +97,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.T1, "T1 must not be nil")
 		assert.NotNil(t, out.T2, "T2 must not be nil")
 		assert.True(t, gave1 == out.T1, "T1 must match")
@@ -120,7 +120,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.T1, "T1 must not be nil")
 		assert.True(t, gave1 == out.T1, "T1 must match")
 	})
@@ -130,7 +130,7 @@ func TestExtract(t *testing.T) {
 		var out struct{ *type1 }
 
 		app := fxtest.New(t, Provide(new1), Extract(&out))
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 
 		// Unexported fields are left unchanged.
 		assert.Nil(t, out.type1, "type1 must be nil")
@@ -142,7 +142,7 @@ func TestExtract(t *testing.T) {
 		var out struct{ type4 }
 
 		app := fxtest.New(t, Provide(new4), Extract(&out))
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 
 		// Unexported fields are left unchanged.
 		assert.NotEqual(t, "foo", out.type4.foo)
@@ -166,7 +166,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.X, "X must not be nil")
 		assert.NotNil(t, out.Y, "Y must not be nil")
 		assert.True(t, gave == out.X, "X must match")
@@ -199,7 +199,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.T1, "T1 must not be nil")
 		assert.Nil(t, out.t2, "t2 must be nil")
 		assert.NotNil(t, out.T3, "T3 must not be nil")
@@ -228,7 +228,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.T1, "T1 must not be nil")
 		assert.NotNil(t, out.t2, "t2 must not be nil")
 		assert.True(t, gave1 == out.T1, "T1 must match")
@@ -238,7 +238,7 @@ func TestExtract(t *testing.T) {
 	t.Run("TopLevelDigIn", func(t *testing.T) {
 		var out struct{ dig.In }
 		app := fxtest.New(t, Extract(&out))
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 	})
 
 	t.Run("TopLevelFxIn", func(t *testing.T) {
@@ -251,7 +251,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 	})
 
 	t.Run("NestedFxIn", func(t *testing.T) {
@@ -275,7 +275,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.Result.T1, "T1 must not be nil")
 		assert.Nil(t, out.Result.T2, "T2 must be nil")
 		assert.True(t, gave1 == out.Result.T1, "T1 must match")
@@ -296,7 +296,7 @@ func TestExtract(t *testing.T) {
 			Provide(func() int { return 42 }),
 			Extract(&out),
 		)
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.Equal(t, 42, out.B.C, "B.C must match")
 	})
 
@@ -317,7 +317,7 @@ func TestExtract(t *testing.T) {
 			Extract(&out),
 		)
 
-		defer app.MustStart().MustStop()
+		defer app.RequireStart().RequireStop()
 		assert.NotNil(t, out.T1, "T1 must not be nil")
 		assert.Nil(t, out.T2, "T2 must be nil")
 

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -62,8 +62,8 @@ func New(tb TB, opts ...fx.Option) *App {
 	}
 }
 
-// MustStart calls Start, failing the test if an error is encountered.
-func (app *App) MustStart() *App {
+// RequireStart calls Start, failing the test if an error is encountered.
+func (app *App) RequireStart() *App {
 	if err := app.Start(context.Background()); err != nil {
 		app.tb.Errorf("application didn't start cleanly: %v", err)
 		app.tb.FailNow()
@@ -71,8 +71,8 @@ func (app *App) MustStart() *App {
 	return app
 }
 
-// MustStop calls Stop, failing the test if an error is encountered.
-func (app *App) MustStop() {
+// RequireStop calls Stop, failing the test if an error is encountered.
+func (app *App) RequireStop() {
 	if err := app.Stop(context.Background()); err != nil {
 		app.tb.Errorf("application didn't stop cleanly: %v", err)
 		app.tb.FailNow()
@@ -101,9 +101,9 @@ func NewLifecycle(t TB) *Lifecycle {
 // hook that doesn't succeed.
 func (l *Lifecycle) Start(ctx context.Context) error { return l.lc.Start(ctx) }
 
-// MustStart calls Start with context.Background(), failing the test if an
+// RequireStart calls Start with context.Background(), failing the test if an
 // error is encountered.
-func (l *Lifecycle) MustStart() *Lifecycle {
+func (l *Lifecycle) RequireStart() *Lifecycle {
 	if err := l.Start(context.Background()); err != nil {
 		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
 		l.t.FailNow()
@@ -119,9 +119,9 @@ func (l *Lifecycle) MustStart() *Lifecycle {
 // returned.
 func (l *Lifecycle) Stop(ctx context.Context) error { return l.lc.Stop(ctx) }
 
-// MustStop calls Stop with context.Background(), failing the test if an error
+// RequireStop calls Stop with context.Background(), failing the test if an error
 // is encountered.
-func (l *Lifecycle) MustStop() {
+func (l *Lifecycle) RequireStop() {
 	if err := l.Stop(context.Background()); err != nil {
 		l.t.Errorf("lifecycle didn't stop cleanly: %v", err)
 		l.t.FailNow()

--- a/fxtest/fxtest_test.go
+++ b/fxtest/fxtest_test.go
@@ -67,7 +67,7 @@ func TestApp(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		spy.Reset()
 
-		New(spy).MustStart().MustStop()
+		New(spy).RequireStart().RequireStop()
 
 		assert.Zero(t, spy.failures, "App didn't start and stop cleanly.")
 		assert.Contains(t, spy.logs.String(), "RUNNING", "Expected to write logs to TB.")
@@ -79,7 +79,7 @@ func TestApp(t *testing.T) {
 		New(
 			spy,
 			fx.Invoke(func() error { return errors.New("fail") }),
-		).MustStart()
+		).RequireStart()
 
 		assert.Equal(t, 1, spy.failures, "Expected app to error on start.")
 		assert.Contains(t, spy.errors.String(), "didn't start cleanly", "Expected to write errors to TB.")
@@ -96,7 +96,7 @@ func TestApp(t *testing.T) {
 			spy,
 			fx.Provide(construct),
 			fx.Invoke(func(struct{}) {}),
-		).MustStart().MustStop()
+		).RequireStart().RequireStop()
 
 		assert.Equal(t, 1, spy.failures, "Expected Stop to fail.")
 		assert.Contains(t, spy.errors.String(), "didn't stop cleanly", "Expected to write errors to TB.")
@@ -115,7 +115,7 @@ func TestLifecycle(t *testing.T) {
 			OnStart: func(context.Context) error { n++; return nil },
 			OnStop:  func(context.Context) error { n++; return nil },
 		})
-		lc.MustStart().MustStop()
+		lc.RequireStart().RequireStop()
 
 		assert.Zero(t, spy.failures, "Lifecycle start/stop failed.")
 		assert.Equal(t, 2, n, "Didn't run start and stop hooks.")
@@ -126,10 +126,10 @@ func TestLifecycle(t *testing.T) {
 		lc := NewLifecycle(spy)
 		lc.Append(fx.Hook{OnStart: func(context.Context) error { return errors.New("fail") }})
 
-		lc.MustStart()
+		lc.RequireStart()
 		assert.Equal(t, 1, spy.failures, "Expected lifecycle start to fail.")
 
-		lc.MustStop()
+		lc.RequireStop()
 		assert.Equal(t, 1, spy.failures, "Expected lifecycle stop to succeed.")
 	})
 
@@ -138,10 +138,10 @@ func TestLifecycle(t *testing.T) {
 		lc := NewLifecycle(spy)
 		lc.Append(fx.Hook{OnStop: func(context.Context) error { return errors.New("fail") }})
 
-		lc.MustStart()
+		lc.RequireStart()
 		assert.Equal(t, 0, spy.failures, "Expected lifecycle start to succeed.")
 
-		lc.MustStop()
+		lc.RequireStop()
 		assert.Equal(t, 1, spy.failures, "Expected lifecycle stop to fail.")
 	})
 }

--- a/inout_test.go
+++ b/inout_test.go
@@ -64,7 +64,7 @@ func TestOptionalTypes(t *testing.T) {
 			assert.Nil(t, in.Bar, "bar was optional and not provided, expected nil")
 			ran = true
 		}))
-		app.MustStart().MustStop()
+		app.RequireStart().RequireStop()
 		assert.True(t, ran, "expected invoke to run")
 	})
 
@@ -75,7 +75,7 @@ func TestOptionalTypes(t *testing.T) {
 			assert.NotNil(t, in.Bar, "bar was optional and provided, expected not nil")
 			ran = true
 		}))
-		app.MustStart().MustStop()
+		app.RequireStart().RequireStop()
 		assert.True(t, ran, "expected invoke to run")
 	})
 }
@@ -126,6 +126,6 @@ func TestNamedTypes(t *testing.T) {
 
 		ran = true
 	}))
-	app.MustStart().MustStop()
+	app.RequireStart().RequireStop()
 	assert.True(t, ran, "expected invoke to run")
 }


### PR DESCRIPTION
A "take it or leave it" followup PR for #577.

The `Must*` terminology implies that the func will panic, which is inaccurate here - we're calling into a `testing.T` to fail the test instead. Other testing libs seems to have adopted a `Require*` naming convention to indicate this - we should consider doing the same.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.