### PR TITLE
fx.Run returns error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** `fx.Run` now returns an `error`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/app.go
+++ b/app.go
@@ -253,16 +253,20 @@ func (app *App) executeInvokes() error {
 // and stop timeouts.
 //
 // See Start and Stop for application lifecycle details.
-func (app *App) Run() {
+func (app *App) Run() error {
 	if err := app.Start(Timeout(DefaultTimeout)); err != nil {
-		app.logger.Fatalf("ERROR\t\tFailed to start: %v", err)
+		app.logger.Printf("ERROR\t\tFailed to start: %v", err)
+		return err
 	}
 
 	app.logger.PrintSignal(<-app.Done())
 
 	if err := app.Stop(Timeout(DefaultTimeout)); err != nil {
-		app.logger.Fatalf("ERROR\t\tFailed to stop cleanly: %v", err)
+		app.logger.Printf("ERROR\t\tFailed to stop cleanly: %v", err)
+		return err
 	}
+
+	return nil
 }
 
 // Start executes all the OnStart hooks of the resolved object graph


### PR DESCRIPTION
A "take it or leave it" followup PR to #577.

It was surprising during the exercise that Run didn't return anything, instead panicking. While I view this as a nice convenience, the following might be more regular to users:

```
app := fx.New()
if err := fx.Run(); err != nil {
    log.Fatalf(err)
}
```

I could go either way on this one - since Fx is the very top-level thing, it doesn't personally bother me that we panic in `fx.Run` and I like the brevity of the current signature.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.