### PR TITLE
Move fx.Extract to fxmigrate.WithExtract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Move `fx.Extract` to `fxmigrate.WithExtract`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/fxmigrate/extract.go
+++ b/fxmigrate/extract.go
@@ -18,28 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package fx
+package fxmigrate
 
 import (
 	"fmt"
 	"reflect"
 	"unicode"
 	"unicode/utf8"
+
+	"go.uber.org/fx"
 )
 
-var _typeOfIn = reflect.TypeOf(In{})
+var _typeOfIn = reflect.TypeOf(fx.In{})
 
-// Extract fills the given struct with values from the dependency injection
+// WithExtract fills the given struct with values from the dependency injection
 // container on application start.
 //
 // The target MUST be a pointer to a struct. Only exported fields will be
 // filled.
-func Extract(target interface{}) Option {
+func WithExtract(target interface{}) fx.Option {
 	v := reflect.ValueOf(target)
 
 	if t := v.Type(); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
-		return Invoke(func() error {
-			return fmt.Errorf("Extract expected a pointer to a struct, got a %v", t)
+		return fx.Invoke(func() error {
+			return fmt.Errorf("WithExtract expected a pointer to a struct, got a %v", t)
 		})
 	}
 
@@ -149,7 +151,7 @@ func Extract(target interface{}) Option {
 		},
 	)
 
-	return Invoke(fn.Interface())
+	return fx.Invoke(fn.Interface())
 }
 
 // isExported reports whether the identifier is exported.

--- a/fxmigrate/reflect_go19.go
+++ b/fxmigrate/reflect_go19.go
@@ -18,12 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// +build !go1.9
+// +build go1.9
 
-package fx
+package fxmigrate
 
 import "reflect"
 
 func anonymousField(t reflect.Type) reflect.StructField {
-	return reflect.StructField{Anonymous: true, Type: t}
+	return reflect.StructField{Name: t.Name(), Anonymous: true, Type: t}
 }

--- a/fxmigrate/reflect_pre_go19.go
+++ b/fxmigrate/reflect_pre_go19.go
@@ -18,12 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// +build go1.9
+// +build !go1.9
 
-package fx
+package fxmigrate
 
 import "reflect"
 
 func anonymousField(t reflect.Type) reflect.StructField {
-	return reflect.StructField{Name: t.Name(), Anonymous: true, Type: t}
+	return reflect.StructField{Anonymous: true, Type: t}
 }


### PR DESCRIPTION
A "take it or leave it" followup PR to #577.

If we decide that we shouldn't delete `fx.Extract` #578 , then we should consider moving it to it's own package so that the top-level APIs contain only the "golden path" usage. Perhaps consider `fxmigrate.Extract` or something similar.

Also, we should rename `Extract` with `WithExtract` to match other options.

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.