### PR TITLE
Rename fx.Logger to fx.WithLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.0-rc3 (unreleased)
 
+- **[Breaking]** Rename `fx.Logger` to `fx.WithLogger`.
 - **[Breaking]** Rename `fx.Inject` to `fx.Extract`.
 - `fx.Extract` now supports `fx.In` tags on target structs.
 

--- a/app.go
+++ b/app.go
@@ -149,16 +149,16 @@ func (og optionGroup) String() string {
 	return fmt.Sprintf("fx.Options(%s)", strings.Join(items, ", "))
 }
 
-// Printer is the interface required by fx's logging backend. It's implemented
+// Logger is the interface required by fx's logging backend. It's implemented
 // by most loggers, including the standard library's.
-type Printer interface {
+type Logger interface {
 	Printf(string, ...interface{})
 }
 
-// Logger redirects the application's log output to the provided printer.
-func Logger(p Printer) Option {
+// WithLogger redirects the application's log output to the provided printer.
+func WithLogger(l Logger) Option {
 	return optionFunc(func(app *App) {
-		app.logger = &fxlog.Logger{Printer: p}
+		app.logger = &fxlog.Logger{Printer: l}
 		app.lifecycle = &lifecycleWrapper{lifecycle.New(app.logger)}
 	})
 }

--- a/app_test.go
+++ b/app_test.go
@@ -61,7 +61,7 @@ func TestNewApp(t *testing.T) {
 		// (e.g., logging) from changing halfway through our provides.
 
 		spy := &printerSpy{&bytes.Buffer{}}
-		app := fxtest.New(t, Provide(func() struct{} { return struct{}{} }), Logger(spy))
+		app := fxtest.New(t, Provide(func() struct{} { return struct{}{} }), WithLogger(spy))
 		defer app.MustStart().MustStop()
 		assert.Contains(t, spy.String(), "PROVIDE\tstruct {}")
 	})
@@ -165,7 +165,7 @@ func TestOptions(t *testing.T) {
 		spy := printerSpy{&bytes.Buffer{}}
 		fxtest.New(t,
 			Provide(&bytes.Buffer{}), // error, not a constructor
-			Logger(spy),
+			WithLogger(spy),
 		)
 		assert.Contains(t, spy.String(), "must provide constructor function")
 	})
@@ -343,7 +343,7 @@ func TestAppStop(t *testing.T) {
 
 func TestReplaceLogger(t *testing.T) {
 	spy := printerSpy{&bytes.Buffer{}}
-	app := fxtest.New(t, Logger(spy))
+	app := fxtest.New(t, WithLogger(spy))
 	app.MustStart().MustStop()
 	assert.Contains(t, spy.String(), "RUNNING")
 }

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -54,7 +54,7 @@ type App struct {
 // New creates a new test application.
 func New(tb TB, opts ...fx.Option) *App {
 	allOpts := make([]fx.Option, 0, len(opts)+1)
-	allOpts = append(allOpts, fx.Logger(&testPrinter{tb}))
+	allOpts = append(allOpts, fx.WithLogger(&testPrinter{tb}))
 	allOpts = append(allOpts, opts...)
 	return &App{
 		App: fx.New(allOpts...),


### PR DESCRIPTION
A "take it or leave it" followup PR for #577.

One of the things that was surprising was that options didn't begin with `With*`. 

* `fx.Provide` -> `fx.WithConstructors`
* `fx.Invoke` -> `fx.WithInvokes`
* `fx.Options` -> `fx.WithModule`
* `fx.Logger` -> `fx.WithLogger`

### Directions 

1. Read #577 first
2. Vote 👍 or 👎 on this PR
3. Discuss and comment on this PR instead of #577 

I will be scheduling a followup to go through all these so we can reject/accept.