### PR TITLE
Fix the url-encoded dot in the package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0 (unreleased)
 
-- No changes yet.
+- Improve readability of start up logging.
 
 ## v1.0.0 (2017-07-31)
 

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/dig"
+	sample "go.uber.org/fx/internal/fxlog/sample.git"
 )
 
 type spy struct {
@@ -93,6 +94,13 @@ func TestPrint(t *testing.T) {
 		assert.Contains(t, s, "[Fx] PROVIDE\t*fxlog.A <=")
 		assert.Contains(t, s, "[Fx] PROVIDE\tfxlog.B <=")
 		assert.Contains(t, s, "[Fx] PROVIDE\tfxlog.C:foo <=")
+	})
+
+	t.Run("printHandlesDotGitCorrectly", func(t *testing.T) {
+		sink.Reset()
+		logger.PrintProvide(sample.New)
+		assert.NotContains(t, sink.String(), "%2e", "should not be url encoded")
+		assert.Contains(t, sink.String(), "sample.git", "should contain a dot")
 	})
 
 	t.Run("printOutNamedTypes", func(t *testing.T) {

--- a/internal/fxlog/sample.git/foo.go
+++ b/internal/fxlog/sample.git/foo.go
@@ -1,0 +1,6 @@
+package sample
+
+// New is a test constructor for a string
+func New() (string, error) {
+	return "Hi", nil
+}

--- a/internal/fxlog/sample.git/foo.go
+++ b/internal/fxlog/sample.git/foo.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package sample
 
 // New is a test constructor for a string

--- a/internal/fxreflect/fxreflect.go
+++ b/internal/fxreflect/fxreflect.go
@@ -136,8 +136,7 @@ func FuncName(fn interface{}) string {
 
 	// Use the stdlib to un-escape any package import paths which can happen
 	// in the case of the "dot-git" postfix. Seems like a bug in stdlib =/
-	unescaped, err := url.QueryUnescape(fnName)
-	if err == nil {
+	if unescaped, err := url.QueryUnescape(fnName); err != nil {
 		fnName = unescaped
 	}
 

--- a/internal/fxreflect/fxreflect.go
+++ b/internal/fxreflect/fxreflect.go
@@ -22,6 +22,7 @@ package fxreflect
 
 import (
 	"fmt"
+	"net/url"
 	"reflect"
 	"runtime"
 	"strings"
@@ -132,6 +133,14 @@ func FuncName(fn interface{}) string {
 	}
 
 	fnName := runtime.FuncForPC(fnV.Pointer()).Name()
+
+	// Use the stdlib to un-escape any package import paths which can happen
+	// in the case of the "dot-git" postfix. Seems like a bug in stdlib =/
+	unescaped, err := url.QueryUnescape(fnName)
+	if err == nil {
+		fnName = unescaped
+	}
+
 	return fmt.Sprintf("%s()", fnName)
 }
 

--- a/internal/fxreflect/fxreflect.go
+++ b/internal/fxreflect/fxreflect.go
@@ -136,7 +136,7 @@ func FuncName(fn interface{}) string {
 
 	// Use the stdlib to un-escape any package import paths which can happen
 	// in the case of the "dot-git" postfix. Seems like a bug in stdlib =/
-	if unescaped, err := url.QueryUnescape(fnName); err != nil {
+	if unescaped, err := url.QueryUnescape(fnName); err == nil {
 		fnName = unescaped
 	}
 


### PR DESCRIPTION
Seems more like working around a bug in the standard library more than
anything else. The fully qualified names containing dots (github.com
etc) are represented correctly, but if a package is housed in a got-git
directory, the dot gets url encoded into %2e.

The super simple solution would just be `s/%2e/.`, but seems safer
to pull in a standard package to handle that.

Fixes #538