### PR TITLE
Fix godoc warning

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -76,7 +76,7 @@ func Example() {
 		// Provide all the constructors we need.
 		fx.Provide(NewLogger, NewHandler, NewMux),
 		// Before starting, register the handler. This forces resolution of all
-		// the Register function depends on: *http.ServeMux and http.Handler.
+		// the types Register function depends on: *http.ServeMux and http.Handler.
 		// Since the mux is now being used, its startup hook gets registered
 		// and the application includes an HTTP server.
 		fx.Invoke(Register),

--- a/example_test.go
+++ b/example_test.go
@@ -76,9 +76,9 @@ func Example() {
 		// Provide all the constructors we need.
 		fx.Provide(NewLogger, NewHandler, NewMux),
 		// Before starting, register the handler. This forces resolution of all
-		// the types in the container. Since the mux is now being used, its
-		// startup hook gets registered and the application includes an HTTP
-		// server.
+		// the Register function depends on: *http.ServeMux and http.Handler.
+		// Since the mux is now being used, its startup hook gets registered
+		// and the application includes an HTTP server.
 		fx.Invoke(Register),
 	)
 


### PR DESCRIPTION
It previously stated that all the types of the container are now being
resolved. While it's true in the particular case, I'd rather list out to
make the connection that only the required types get resolved.