### PR TITLE
Add fx.NopLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.0 (unreleased)
 
-- No changes yet
+- Add `fx.NopLogger` which disables the Fx application's log output.
 
 ## v1.1.0 (2017-08-22)
 

--- a/app.go
+++ b/app.go
@@ -152,9 +152,7 @@ func Logger(p Printer) Option {
 }
 
 // NopLogger disables the application's log output.
-func NopLogger() Option {
-	return Logger(nopLogger{})
-}
+var NopLogger Option = Logger(nopLogger{})
 
 type nopLogger struct{}
 

--- a/app.go
+++ b/app.go
@@ -151,15 +151,14 @@ func Logger(p Printer) Option {
 	})
 }
 
-// NoopLogger is a no-op logger that implements the Printer interface.
-// When used with the Logger option, all Fx logs will be dropped.
-//
-// An application that wants to disable Fx logs should be created like so:
-//
-// app := fx.New(fx.Logger(fx.NoopLogger{}))
-type NoopLogger struct{}
+// NopLogger disables the application's log output.
+func NopLogger() Option {
+	return Logger(nopLogger{})
+}
 
-func (l NoopLogger) Printf(string, ...interface{}) {
+type nopLogger struct{}
+
+func (l nopLogger) Printf(string, ...interface{}) {
 	return
 }
 

--- a/app.go
+++ b/app.go
@@ -152,7 +152,7 @@ func Logger(p Printer) Option {
 }
 
 // NopLogger disables the application's log output.
-var NopLogger Option = Logger(nopLogger{})
+var NopLogger = Logger(nopLogger{})
 
 type nopLogger struct{}
 

--- a/app.go
+++ b/app.go
@@ -151,6 +151,18 @@ func Logger(p Printer) Option {
 	})
 }
 
+// NoopLogger is a no-op logger that implements the Printer interface.
+// When used with the Logger option, all Fx logs will be dropped.
+//
+// An application that wants to disable Fx logs should be created like so:
+//
+// app := fx.New(fx.Logger(fx.NoopLogger{}))
+type NoopLogger struct{}
+
+func (l NoopLogger) Printf(string, ...interface{}) {
+	return
+}
+
 // An App is a modular application built around dependency injection.
 type App struct {
 	err       error

--- a/app_test.go
+++ b/app_test.go
@@ -349,6 +349,6 @@ func TestReplaceLogger(t *testing.T) {
 }
 
 func TestNoopLogger(t *testing.T) {
-	app := fxtest.New(t, Logger(NoopLogger{}))
+	app := fxtest.New(t, NopLogger())
 	app.RequireStart().RequireStop()
 }

--- a/app_test.go
+++ b/app_test.go
@@ -347,3 +347,8 @@ func TestReplaceLogger(t *testing.T) {
 	app.RequireStart().RequireStop()
 	assert.Contains(t, spy.String(), "RUNNING")
 }
+
+func TestNoopLogger(t *testing.T) {
+	app := fxtest.New(t, Logger(NoopLogger{}))
+	app.RequireStart().RequireStop()
+}

--- a/app_test.go
+++ b/app_test.go
@@ -349,6 +349,6 @@ func TestReplaceLogger(t *testing.T) {
 }
 
 func TestNoopLogger(t *testing.T) {
-	app := fxtest.New(t, NopLogger())
+	app := fxtest.New(t, NopLogger)
 	app.RequireStart().RequireStop()
 }

--- a/app_test.go
+++ b/app_test.go
@@ -348,7 +348,7 @@ func TestReplaceLogger(t *testing.T) {
 	assert.Contains(t, spy.String(), "RUNNING")
 }
 
-func TestNoopLogger(t *testing.T) {
+func TestNopLogger(t *testing.T) {
 	app := fxtest.New(t, NopLogger)
 	app.RequireStart().RequireStop()
 }


### PR DESCRIPTION
When developing an Fx CLI, I found it useful to disable the standard Fx PROVIDE/INVOKE logs. By defining a fx.NoopLogger, users won't need to implement their own no-op logger which satisfies the `fx.Printer` interface.