### PR TITLE
Apply the function path cleanup to the hook output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.0 (unreleased)
 
-- No changes yet
+- Improve readability of hook logging in addition to provide and invoke.
 
 ## v1.1.0 (2017-08-22)
 

--- a/internal/fxreflect/fxreflect_test.go
+++ b/internal/fxreflect/fxreflect_test.go
@@ -73,3 +73,32 @@ func TestFuncName(t *testing.T) {
 	assert.Equal(t, "go.uber.org/fx/internal/fxreflect.someFunc()", FuncName(someFunc))
 	assert.Equal(t, "n/a", FuncName(struct{}{}))
 }
+
+func TestSanitizeFuncNames(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			"url encoding",
+			"go.uber.org/fx/sample%2egit/someFunc",
+			"go.uber.org/fx/sample.git/someFunc",
+		},
+		{
+			"vendor removal",
+			"go.uber.org/fx/vendor/github.com/some/lib.SomeFunc",
+			"vendor/github.com/some/lib.SomeFunc",
+		},
+		{
+			"package happens to be named vendor is untouched",
+			"go.uber.org/fx/foovendor/someFunc",
+			"go.uber.org/fx/foovendor/someFunc",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, sanitize(c.input))
+		})
+	}
+}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -82,11 +82,12 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	var errs []error
 	// Run backward from last successful OnStart.
 	for i := l.position; i >= 0; i-- {
-		if l.hooks[i].OnStop == nil {
+		hook := l.hooks[i]
+		if hook.OnStop == nil {
 			continue
 		}
-		l.logger.Printf("STOP\t\t%s()", l.hooks[i].caller)
-		if err := l.hooks[i].OnStop(ctx); err != nil {
+		l.logger.Printf("STOP\t\t%s()", hook.caller)
+		if err := hook.OnStop(ctx); err != nil {
 			// For best-effort cleanup, keep going after errors.
 			errs = append(errs, err)
 		}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 
 	"go.uber.org/fx/internal/fxlog"
-	"go.uber.org/multierr"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
 )
 
 func TestLifecycleStart(t *testing.T) {


### PR DESCRIPTION
It's quite difficult to actually test end-to-end through providing a
custom sink logger and starting the app, mostly because we skip any and
all frames that contain `go.uber.org/fx` so our internal refactors don't
pollute the service stacktrace output. After a while of trial and error
I settled for just unit testing the newly added function (the e2e tests
for logging provide/invoke remain).

Fixes #593