### PR TITLE
Add App.Execute for CLI use case

### DIFF
--- a/fxtest/fxtest_test.go
+++ b/fxtest/fxtest_test.go
@@ -70,7 +70,7 @@ func TestApp(t *testing.T) {
 		New(spy).RequireStart().RequireStop()
 
 		assert.Zero(t, spy.failures, "App didn't start and stop cleanly.")
-		assert.Contains(t, spy.logs.String(), "RUNNING", "Expected to write logs to TB.")
+		assert.Contains(t, spy.logs.String(), "STARTED", "Expected to write logs to TB.")
 	})
 
 	t.Run("StartFailure", func(t *testing.T) {


### PR DESCRIPTION
This enables `fx.App` to be used more cleanly for CLI applications, e.g.
```go
func main() {
	if os.Args[1] == "foo" {
		newApp().Execute(func(foo Foo) {
			foo.Thing()
		})
	} else {
		newApp().Execute(func(bar Bar) {
			bar.Thing()
		})
	}
}
```

Instead of resorting to workarounds like:
```go
func main() {
	if os.Args[1] == "foo" {
		var foo Foo
		app := fx.App(
			// ... options
			fx.Invoke(func(f Foo) {
				foo = f
			}),
		)
		app.Start()
		foo.Thing()
		app.Stop()
	} else {
		var bar Bar
		app := fx.App(
			// ... options
			fx.Invoke(func(b Bar) {
				bar = b
			}),
		)
		app.Start()
		bar.Thing()
		app.Stop()
	}
}
```