### PR TITLE
Fix an off-by-one error in Lifecycle last successful OnStart handling

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -229,7 +229,7 @@ func TestAppStart(t *testing.T) {
 		err := app.Start(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "OnStart fail")
-		assert.Contains(t, err.Error(), "OnStop fail")
+		assert.NotContains(t, err.Error(), "OnStop fail")
 	})
 
 	t.Run("InvokeNonFunction", func(t *testing.T) {


### PR DESCRIPTION
The default `Lifecycle.position` value was `0`, which made it ambigous whether Lifecycle object was just initialized, or if the first OnStart hook failed, or if the first OnStart hook succeeded. In all of these cases, `position == 0`.

I've replaced `position` with a more easy-to-understand `numStarted`, which is zero by default. Every successful OnStart increases its value, and Stop() knows exactly which hooks to stop.

The bug is illustrated by two new tests, both of which are failing on current master.

One existing test had a bug in it (!). I've corrected it and improved it to verify more properties of App.Start method.