### PR TITLE
Populate: Support populating any value without requiring structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v1.4.0 (unreleased)
 
-- No changes yet.
+- Add `fx.Populate` to populate variables with values from the dependency
+  injection container without requiring intermediate structs.
 
 ## v1.3.0 (2017-11-28)
 

--- a/extract.go
+++ b/extract.go
@@ -38,9 +38,7 @@ func Extract(target interface{}) Option {
 	v := reflect.ValueOf(target)
 
 	if t := v.Type(); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
-		return Invoke(func() error {
-			return fmt.Errorf("Extract expected a pointer to a struct, got a %v", t)
-		})
+		return invokeErr(fmt.Errorf("Extract expected a pointer to a struct, got a %v", t))
 	}
 
 	v = v.Elem()

--- a/populate.go
+++ b/populate.go
@@ -25,8 +25,8 @@ import (
 	"reflect"
 )
 
-// Populate sets values with values from the dependency injection container
-// before application start. All arguments must be pointers to the values
+// Populate sets targets with values from the dependency injection container
+// before application start. All targets must be pointers to the values
 // that must be populated. Pointers to structs that embed In are supported,
 // which can be used to populate multiple values in a struct.
 func Populate(targets ...interface{}) Option {
@@ -34,11 +34,11 @@ func Populate(targets ...interface{}) Option {
 	targetTypes := make([]reflect.Type, len(targets))
 	for i, t := range targets {
 		if t == nil {
-			return invokeErr(fmt.Errorf("argument %v is nil", i+1))
+			return invokeErr(fmt.Errorf("failed to Populate: target %v is nil", i+1))
 		}
 		rt := reflect.TypeOf(t)
 		if rt.Kind() != reflect.Ptr {
-			return invokeErr(fmt.Errorf("argument %v is not a pointer type, got %T", i+1, t))
+			return invokeErr(fmt.Errorf("failed to Populate: target %v is not a pointer type, got %T", i+1, t))
 		}
 
 		targetTypes[i] = reflect.TypeOf(t).Elem()

--- a/populate.go
+++ b/populate.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Populate sets values with values from the dependency injection container
+// before application start. All arguments must be pointers to the values
+// that must be populated. Pointers to structs that embed In are supported,
+// which can be used to populate multiple values in a struct.
+func Populate(targets ...interface{}) Option {
+	// Validate all targets are non-nil pointers.
+	targetTypes := make([]reflect.Type, len(targets))
+	for i, t := range targets {
+		if t == nil {
+			return invokeErr(fmt.Errorf("argument %v is nil", i+1))
+		}
+		rt := reflect.TypeOf(t)
+		if rt.Kind() != reflect.Ptr {
+			return invokeErr(fmt.Errorf("argument %v is not a pointer type, got %T", i+1, t))
+		}
+
+		targetTypes[i] = reflect.TypeOf(t).Elem()
+	}
+
+	// Build a function that looks like:
+	//
+	// func(t1 T1, t2 T2, ...) {
+	//   *targets[0] = t1
+	//   *targets[1] = t2
+	//   [...]
+	// }
+	//
+	fnType := reflect.FuncOf(targetTypes, nil, false /* variadic */)
+	fn := reflect.MakeFunc(fnType, func(args []reflect.Value) []reflect.Value {
+		for i, arg := range args {
+			reflect.ValueOf(targets[i]).Elem().Set(arg)
+		}
+		return nil
+	})
+	return Invoke(fn.Interface())
+}
+
+func invokeErr(err error) Option {
+	return Invoke(func() error {
+		return err
+	})
+}

--- a/populate_example_test.go
+++ b/populate_example_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx_test
+
+import (
+	"fmt"
+
+	"go.uber.org/fx"
+)
+
+func ExamplePopulate() {
+	// Some external module that provides a user name.
+	type Username string
+	UserModule := fx.Provide(func() Username { return "john" })
+
+	// We want to get the user out of the dependency injection container.
+	var user Username
+	fx.New(
+		UserModule,
+
+		fx.Populate(&user),
+	)
+	fmt.Println(user)
+
+	// Output:
+	// john
+}

--- a/populate_example_test.go
+++ b/populate_example_test.go
@@ -21,6 +21,7 @@
 package fx_test
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/fx"
@@ -33,11 +34,16 @@ func ExamplePopulate() {
 
 	// We want to get the user out of the dependency injection container.
 	var user Username
-	fx.New(
+	app := fx.New(
 		UserModule,
 
 		fx.Populate(&user),
 	)
+	if err := app.Start(context.Background()); err != nil {
+		panic(err)
+	}
+	defer app.Stop(context.Background())
+
 	fmt.Println(user)
 
 	// Output:

--- a/populate_test.go
+++ b/populate_test.go
@@ -223,12 +223,12 @@ func TestPopulateErrors(t *testing.T) {
 		{
 			msg:     "invalid last argument",
 			opt:     Populate(&v, t1{}),
-			wantErr: "argument 2 is not a pointer type",
+			wantErr: "target 2 is not a pointer type",
 		},
 		{
 			msg:     "nil argument",
 			opt:     Populate(&v, nil, &v),
-			wantErr: "argument 2 is nil",
+			wantErr: "target 2 is nil",
 		},
 	}
 

--- a/populate_test.go
+++ b/populate_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx_test
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestPopulate(t *testing.T) {
+	type t1 struct{}
+	type t2 struct{}
+
+	t.Run("populate nothing", func(t *testing.T) {
+		app := fxtest.New(t,
+			Provide(func() *t1 { panic("should not be called ") }),
+			Populate(),
+		)
+		require.NoError(t, app.Err())
+	})
+
+	t.Run("populate single", func(t *testing.T) {
+		var v1 *t1
+		app := fxtest.New(t,
+			Provide(func() *t1 { return &t1{} }),
+			Populate(&v1),
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, v1, "did not populate value")
+	})
+
+	t.Run("populate interface", func(t *testing.T) {
+		var reader io.Reader
+		app := fxtest.New(t,
+			Provide(func() io.Reader { return strings.NewReader("hello world") }),
+			Populate(&reader),
+		)
+		require.NoError(t, app.Err())
+
+		bs, err := ioutil.ReadAll(reader)
+		require.NoError(t, err, "Failed to use populated io.Reader")
+		assert.Equal(t, "hello world", string(bs), "Unexpected reader")
+	})
+
+	t.Run("populate multiple inline values", func(t *testing.T) {
+		var (
+			v1 *t1
+			v2 *t2
+		)
+		app := fxtest.New(t,
+			Provide(func() *t1 { return &t1{} }),
+			Provide(func() *t2 { return &t2{} }),
+
+			Populate(&v1),
+			Populate(&v2),
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, v1, "did not populate argument 1")
+		require.NotNil(t, v2, "did not populate argument 2")
+	})
+
+	t.Run("populate fx.In struct", func(t *testing.T) {
+		targets := struct {
+			In
+
+			V1 *t1
+			V2 *t2
+		}{}
+
+		app := fxtest.New(t,
+			Provide(func() *t1 { return &t1{} }),
+			Provide(func() *t2 { return &t2{} }),
+
+			Populate(&targets),
+		)
+		require.NoError(t, app.Err())
+		require.NotNil(t, targets.V1, "did not populate field 1")
+		require.NotNil(t, targets.V2, "did not populate field 2")
+	})
+}
+
+func TestPopulateErrors(t *testing.T) {
+	type t1 struct{}
+	type container struct {
+		In
+
+		T1 t1
+	}
+	type containerNoIn struct {
+		T1 t1
+	}
+	fn := func() {}
+	var v *t1
+
+	tests := []struct {
+		msg     string
+		opt     Option
+		wantErr string
+	}{
+		{
+			msg:     "inline value",
+			opt:     Populate(t1{}),
+			wantErr: "not a pointer",
+		},
+		{
+			msg:     "container value",
+			opt:     Populate(container{}),
+			wantErr: "not a pointer",
+		},
+		{
+			msg:     "container pointer without fx.In",
+			opt:     Populate(&containerNoIn{}),
+			wantErr: "isn't in the container",
+		},
+		{
+			msg:     "function",
+			opt:     Populate(fn),
+			wantErr: "not a pointer",
+		},
+		{
+			msg:     "function pointer",
+			opt:     Populate(&fn),
+			wantErr: "isn't in the container",
+		},
+		{
+			msg:     "invalid last argument",
+			opt:     Populate(&v, t1{}),
+			wantErr: "argument 2 is not a pointer type",
+		},
+		{
+			msg:     "nil argument",
+			opt:     Populate(&v, nil, &v),
+			wantErr: "argument 2 is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		app := fxtest.New(t,
+			NopLogger,
+			Provide(func() *t1 { return &t1{} }),
+
+			tt.opt,
+		)
+		require.Error(t, app.Err())
+		assert.Contains(t, app.Err().Error(), tt.wantErr)
+	}
+}

--- a/populate_test.go
+++ b/populate_test.go
@@ -41,7 +41,7 @@ func TestPopulate(t *testing.T) {
 			Provide(func() *t1 { panic("should not be called ") }),
 			Populate(),
 		)
-		require.NoError(t, app.Err())
+		app.RequireStart().RequireStop()
 	})
 
 	t.Run("populate single", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestPopulate(t *testing.T) {
 			Provide(func() *t1 { return &t1{} }),
 			Populate(&v1),
 		)
-		require.NoError(t, app.Err())
+		app.RequireStart().RequireStop()
 		require.NotNil(t, v1, "did not populate value")
 	})
 
@@ -60,7 +60,7 @@ func TestPopulate(t *testing.T) {
 			Provide(func() io.Reader { return strings.NewReader("hello world") }),
 			Populate(&reader),
 		)
-		require.NoError(t, app.Err())
+		app.RequireStart().RequireStop()
 
 		bs, err := ioutil.ReadAll(reader)
 		require.NoError(t, err, "Failed to use populated io.Reader")
@@ -79,7 +79,8 @@ func TestPopulate(t *testing.T) {
 			Populate(&v1),
 			Populate(&v2),
 		)
-		require.NoError(t, app.Err())
+		app.RequireStart().RequireStop()
+
 		require.NotNil(t, v1, "did not populate argument 1")
 		require.NotNil(t, v2, "did not populate argument 2")
 	})
@@ -98,7 +99,8 @@ func TestPopulate(t *testing.T) {
 
 			Populate(&targets),
 		)
-		require.NoError(t, app.Err())
+		app.RequireStart().RequireStop()
+
 		require.NotNil(t, targets.V1, "did not populate field 1")
 		require.NotNil(t, targets.V2, "did not populate field 2")
 	})


### PR DESCRIPTION
Extract requires users to create a struct, but this struct does not
match the standard fx.In struct that users use when using parameters.

Populate will allow users to get values from the dependency injection
container without creating an additional struct, and expects users to
use fx.In for getting multiple values in a struct or if they want to
get named values.