### PR TITLE
Improve documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -18,6 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package fx is a modular service framework that makes it easy to create
-// services and re-usable, composable modules.
+// Package fx is a framework that makes it easy to build applications out of
+// reusable, composable modules.
+//
+// Fx applications use dependency injection to eliminate globals without the
+// tedium of manually wiring together function calls. Unlike other approaches
+// to dependency injection, Fx works with plain Go functions: you don't need
+// to use struct tags or embed special types, so Fx automatically works well
+// with most Go packages.
+//
+// Basic usage is explained in the package-level example below. If you're new
+// to Fx, start there! Advanced features, including named instances, optional
+// parameters, and value groups, are explained under the In and Out types.
+//
+// Testing Fx Applications
+//
+// To test functions that use the Lifecycle type or to write end-to-end tests
+// of your Fx application, use the helper functions and types provided by the
+// go.uber.org/fx/fxtest package.
 package fx

--- a/example_test.go
+++ b/example_test.go
@@ -30,31 +30,119 @@ import (
 	"go.uber.org/fx"
 )
 
+// NewLogger constructs a logger. It's just a regular Go function, without any
+// special relationship to Fx.
+//
+// Since it returns a *log.Logger, Fx will treat NewLogger as the constructor
+// function for the standard library's logger. (We'll see how to integrate
+// NewLogger into an Fx application in the main function.) Since NewLogger
+// doesn't have any parameters, Fx will infer that loggers don't depend on any
+// other types - we can create them from thin air.
+//
+// Fx calls constructors lazily, so NewLogger will only be called only if some
+// other function needs a logger. Once instantiated, the logger is cached and
+// reused - within the application, it's effectively a singleton.
+//
+// By default, Fx applications only allow one constructor for each type. See
+// the documentation of the In and Out types for ways around this restriction.
 func NewLogger() *log.Logger {
-	logger := log.New(os.Stdout, "[Example] " /* prefix */, 0 /* flags */)
+	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
 	logger.Print("Executing NewLogger.")
 	return logger
 }
 
-func NewHandler(logger *log.Logger) http.Handler {
+// NewHandler constructs a simple HTTP handler. Since it returns an
+// http.Handler, Fx will treat NewHandler as the constructor for the
+// http.Handler type.
+//
+// Like many Go functions, NewHander also returns an error. If the error is
+// non-nil, Go convention tells the caller to assume that NewHandler failed
+// and the other returned values aren't safe to use. Fx understands this
+// idiom, and assumes that any function whose last return value is an error
+// follows this convention.
+//
+// Unlike NewLogger, NewHandler has formal parameters. Fx will interpret these
+// parameters as dependencies: in order to construct an HTTP handler,
+// NewHandler needs a logger. If the application has access to a *log.Logger
+// constructor (like NewLogger above), it will use that constructor or its
+// cached output and supply a logger to NewHandler. If the application doesn't
+// know how to construct a logger and needs an HTTP handler, it will fail to
+// start.
+//
+// Functions may also return multiple objects. For example, we could combine
+// NewHandler and NewLogger into a single function:
+//
+//   func NewHandlerAndLogger() (*log.Logger, http.Handler, error)
+//
+// Fx also understands this idiom, and would treat NewHandlerAndLogger as the
+// constructor for both the *log.Logger and http.Handler types.
+func NewHandler(logger *log.Logger) (http.Handler, error) {
 	logger.Print("Executing NewHandler.")
 	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		logger.Print("Got a request.")
-	})
+	}), nil
 }
 
+// NewMux constructs an HTTP mux. Like NewHandler, it depends on *log.Logger.
+// However, it also depends on the Fx-specific Lifecycle interface.
+//
+// A Lifecycle is available in every Fx application. It lets objects hook into
+// the application's start and stop phases. In a non-Fx application, the main
+// function often includes blocks like this:
+//
+//   srv, err := NewServer() // some long-running network server
+//   if err != nil {
+//     log.Fatalf("failed to construct server: %v", err)
+//   }
+//   // Construct other objects as necessary.
+//   go srv.Start()
+//   defer srv.Stop()
+//
+// In this example, the programmer explicitly constructs a bunch of objects,
+// crashing the program if any of the constructors encounter unrecoverable
+// errors. Once all the objects are constructed, we start any background
+// goroutines and defer cleanup functions.
+//
+// Fx removes the manual object construction with dependency injection. It
+// replaces the inline goroutine spawning and deferred cleanups with the
+// Lifecycle type.
+//
+// Here, NewMux makes an HTTP mux available to other functions. Since
+// constructors are called lazily, we know that NewMux won't be called unless
+// some other function wants to register a handler. This makes it easy to use
+// Fx's Lifecycle to start an HTTP server only if we have handlers registered.
 func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
 	logger.Print("Executing NewMux.")
+	// First, we construct the mux and server. We don't want to start the server
+	// until all handlers are registered.
 	mux := http.NewServeMux()
 	server := &http.Server{
 		Addr:    ":8080",
 		Handler: mux,
 	}
-	// If NewMux is called, we know that someone is using the mux. In that case,
-	// start up and shut down an HTTP server with the application.
+	// If NewMux is called, we know that another function is using the mux. In
+	// that case, we'll use the Lifecycle type to register a Hook that starts
+	// and stops our HTTP server.
+	//
+	// Hooks are executed in dependency order. At startup, NewLogger's hooks run
+	// before NewMux's. On shutdown, the order is reversed.
+	//
+	// Returning an error from OnStart hooks interrupts application startup. Fx
+	// immediately runs the OnStop portions of any successfully-executed OnStart
+	// hooks (so that types which started cleanly can also shut down cleanly),
+	// then exits.
+	//
+	// Returning an error from OnStop hooks logs a warning, but Fx continues to
+	// run the remaining hooks.
 	lc.Append(fx.Hook{
+		// To mitigate the impact of deadlocks in application startup and
+		// shutdown, Fx imposes a time limit on OnStart and OnStop hooks. By
+		// default, hooks have a total of 30 seconds to complete. Timeouts are
+		// passed via Go's usual context.Context.
 		OnStart: func(context.Context) error {
 			logger.Print("Starting HTTP server.")
+			// In production, we'd want to separate the Listen and Serve phases for
+			// better error-handling.
 			go server.ListenAndServe()
 			return nil
 		},
@@ -67,30 +155,56 @@ func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
 	return mux
 }
 
+// Register mounts our HTTP handler on the mux.
+//
+// Register is a typical top-level application function: it takes a generic
+// type like ServeMux, which typically comes from a third-party library, and
+// introduces it to a type that contains our application logic. In this case,
+// that introduction consists of registering an HTTP handler. Other typical
+// examples include registering RPC procedures and starting queue consumers.
+//
+// Fx calls these functions invocations, and they're treated differently from
+// the constructor functions above. Their arguments are still supplied via
+// dependency injection and they may still return an error to indicate
+// failure, but any other return values are ignored.
+//
+// Unlike constructors, invocations are called eagerly. See the main function
+// below for details.
 func Register(mux *http.ServeMux, h http.Handler) {
 	mux.Handle("/", h)
 }
 
 func Example() {
 	app := fx.New(
-		// Provide all the constructors we need.
-		fx.Provide(NewLogger, NewHandler, NewMux),
-		// Before starting, register the handler. This forces resolution of all
-		// the types Register function depends on: *http.ServeMux and http.Handler.
-		// Since the mux is now being used, its startup hook gets registered
-		// and the application includes an HTTP server.
+		// Provide all the constructors we need, which teaches Fx how we'd like to
+		// construct the *log.Logger, http.Handler, and *http.ServeMux types.
+		// Remember that constructors are called lazily, so this block doesn't do
+		// anything on its own.
+		fx.Provide(
+			NewLogger,
+			NewHandler,
+			NewMux,
+		),
+		// Since constructors are called lazily, we need some invocations to
+		// kick-start our application. In this case, we'll use Register. Since it
+		// depends on an http.Handler and *http.ServeMux, calling it requires Fx
+		// to build those types using the constructors above. Since we call
+		// NewMux, we also register Lifecycle hooks to start and stop an HTTP
+		// server.
 		fx.Invoke(Register),
 	)
 
-	// In a real application, we could just use app.Run() here. Since we don't
-	// want this example to run forever, we'll use Start and Stop.
+	// In a typical application, we could just use app.Run() here. Since we
+	// don't want this example to run forever, we'll use the more-explicit Start
+	// and Stop.
 	startCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	if err := app.Start(startCtx); err != nil {
 		log.Fatal(err)
 	}
 
-	// Normally, we'd block here with <-app.Done().
+	// Normally, we'd block here with <-app.Done(). Instead, we'll make an HTTP
+	// request to demonstrate that our server is running.
 	http.Get("http://localhost:8080/")
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -98,11 +212,12 @@ func Example() {
 	if err := app.Stop(stopCtx); err != nil {
 		log.Fatal(err)
 	}
+
 	// Output:
-	// [Example] Executing NewLogger.
-	// [Example] Executing NewMux.
-	// [Example] Executing NewHandler.
-	// [Example] Starting HTTP server.
-	// [Example] Got a request.
-	// [Example] Stopping HTTP server.
+	// Executing NewLogger.
+	// Executing NewMux.
+	// Executing NewHandler.
+	// Starting HTTP server.
+	// Got a request.
+	// Stopping HTTP server.
 }

--- a/example_test.go
+++ b/example_test.go
@@ -75,7 +75,10 @@ func NewLogger() *log.Logger {
 //   func NewHandlerAndLogger() (*log.Logger, http.Handler, error)
 //
 // Fx also understands this idiom, and would treat NewHandlerAndLogger as the
-// constructor for both the *log.Logger and http.Handler types.
+// constructor for both the *log.Logger and http.Handler types. Just like
+// constructors for a single type, NewHandlerAndLogger would be called at most
+// once, and both the handler and the logger would be cached and reused as
+// necessary.
 func NewHandler(logger *log.Logger) (http.Handler, error) {
 	logger.Print("Executing NewHandler.")
 	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -179,7 +182,7 @@ func Example() {
 		// Provide all the constructors we need, which teaches Fx how we'd like to
 		// construct the *log.Logger, http.Handler, and *http.ServeMux types.
 		// Remember that constructors are called lazily, so this block doesn't do
-		// anything on its own.
+		// much on its own.
 		fx.Provide(
 			NewLogger,
 			NewHandler,

--- a/extract.go
+++ b/extract.go
@@ -30,10 +30,11 @@ import (
 var _typeOfIn = reflect.TypeOf(In{})
 
 // Extract fills the given struct with values from the dependency injection
-// container on application start.
+// container on application initialization. The target MUST be a pointer to a
+// struct. Only exported fields will be filled.
 //
-// The target MUST be a pointer to a struct. Only exported fields will be
-// filled.
+// Extract will be deprecated soon: use Populate instead, which doesn't
+// require defining a container struct.
 func Extract(target interface{}) Option {
 	v := reflect.ValueOf(target)
 

--- a/extract_test.go
+++ b/extract_test.go
@@ -24,8 +24,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
-	"os"
 	"testing"
 
 	. "go.uber.org/fx"
@@ -323,24 +321,4 @@ func TestExtract(t *testing.T) {
 
 		assert.True(t, gave1 == out.T1, "T1 must match")
 	})
-}
-
-func ExampleExtract() {
-	var target struct {
-		Logger *log.Logger
-	}
-
-	app := New(
-		Provide(func() *log.Logger { return log.New(os.Stdout, "", 0) }),
-		Extract(&target),
-	)
-
-	if err := app.Start(context.Background()); err != nil {
-		log.Fatal(err)
-	}
-
-	target.Logger.Print("Extracted!")
-
-	// Output:
-	// Extracted!
 }

--- a/inout.go
+++ b/inout.go
@@ -22,18 +22,216 @@ package fx
 
 import "go.uber.org/dig"
 
-// In can be embedded in a constructor's param struct
-// in order to take advantage of named and optional types.
+// In can be embedded in a constructor's parameter struct to take advantage of
+// advanced dependency injection features.
 //
-// Modules should take a single param struct that embeds an In
-// in order to provide a forwards-compatible API where additional
-// optional fields can be added without breaking.
+// Modules should take a single parameter struct that embeds an In in order to
+// provide a forward-compatible API: since adding fields to a struct is
+// backward-compatible, modules can then add optional dependencies in minor
+// releases.
+//
+// Parameter Structs
+//
+// Fx constructors declare their dependencies as function parameters. This can
+// quickly become unreadable if the constructor has a lot of dependencies.
+//
+//   func NewHandler(users *UserGateway, comments *CommentGateway, posts *PostGateway, votes *VoteGateway, authz *AuthZGateway) *Handler {
+//     // ...
+//   }
+//
+// To improve the readability of constructors like this, create a struct that
+// lists all the dependencies as fields and change the function to accept that
+// struct instead. The new struct is called a parameter struct.
+//
+// Fx has first class support for parameter structs: any struct embedding
+// fx.In gets treated as a parameter struct, so the individual fields in the
+// struct are supplied via dependency injection. Using a parameter struct, we
+// can make the constructor above much more readable:
+//
+//   type HandlerParams struct {
+//     fx.In
+//
+//     Users    *UserGateway
+//     Comments *CommentGateway
+//     Posts    *PostGateway
+//     Votes    *VoteGateway
+//     AuthZ    *AuthZGateway
+//   }
+//
+//   func NewHandler(p HandlerParams) *Handler {
+//     // ...
+//   }
+//
+// Though it's rarely a good idea, constructors can receive any combination of
+// parameter structs and parameters.
+//
+//   func NewHandler(p HandlerParams, l *log.Logger) *Handler {
+//     // ...
+//   }
+//
+// Optional Dependencies
+//
+// Constructors often have soft dependencies on some types: if those types are
+// missing, they can operate in a degraded state. Fx supports optional
+// dependencies via the `optional:"true"` tag to fields on parameter structs.
+//
+//   type UserGatewayParams struct {
+//     fx.In
+//
+//     Conn  *sql.DB
+//     Cache *redis.Client `optional:"true"`
+//   }
+//
+// If an optional field isn't available in the container, the constructor
+// receives the field's zero value.
+//
+//   func NewUserGateway(p UserGatewayParams, log *log.Logger) (*UserGateway, error) {
+//     if p.Cache != nil {
+//       log.Print("Logging disabled")
+//     }
+//     // ...
+//   }
+//
+// Constructors that declare optional dependencies MUST gracefully handle
+// situations in which those dependencies are absent.
+//
+// The optional tag also allows adding new dependencies without breaking
+// existing consumers of the constructor.
+//
+// Named Values
+//
+// Some use cases call for multiple values of the same type. Fx will allow
+// multiple values of the same type in an application's dependency injection
+// container via `name:".."` tags parameter and result structs.
+//
+// A constructor that produces a result struct can tag any field with
+// `name:".."` to have the corresponding value added to the graph under the
+// specified name.
+//
+//   type ConnectionResult struct {
+//     fx.Out
+//
+//     ReadWrite *sql.DB `name:"rw"`
+//     ReadOnly  *sql.DB `name:"ro"`
+//   }
+//
+//   func ConnectToDatabase(...) (ConnectionResult, error) {
+//     // ...
+//     return ConnectionResult{ReadWrite: rw, ReadOnly:  ro}, nil
+//   }
+//
+// Another constructor can consume these values by adding fields to a
+// parameter struct with the same name AND type.
+//
+//   type GatewayParams struct {
+//     fx.In
+//
+//     WriteToConn  *sql.DB `name:"rw"`
+//     ReadFromConn *sql.DB `name:"ro"`
+//   }
+//
+// The name tag may be combined with the optional tag to declare the
+// dependency optional.
+//
+//   type GatewayParams struct {
+//     fx.In
+//
+//     WriteToConn  *sql.DB `name:"rw"`
+//     ReadFromConn *sql.DB `name:"ro" optional:"true"`
+//   }
+//
+//   func NewCommentGateway(p GatewayParams, log *log.Logger) (*CommentGateway, error) {
+//     if p.ReadFromConn == nil {
+//       log.Print("Warning: Using RW connection for reads")
+//       p.ReadFromConn = p.WriteToConn
+//     }
+//     // ...
+//   }
+//
+// Value Groups
+//
+// To make it easier to produce and consume many values of the same type, Fx
+// supports value groups. Value groups allow constructors to send values to a
+// named, unordered collection in the container. Other constructors can
+// request all values in this collection as a slice.
+//
+// Constructors can send values into value groups by returning a result struct
+// tagged with `group:".."`.
+//
+//   type HandlerResult struct {
+//     fx.Out
+//
+//     Handler Handler `group:"server"`
+//   }
+//
+//   func NewHelloHandler() HandlerResult {
+//     // ...
+//   }
+//
+//   func NewEchoHandler() HandlerResult {
+//     // ...
+//   }
+//
+// Any number of constructors may provide values to this named collection.
+// Other constructors can depend on this collection by requesting a slice
+// tagged with `group:".."`. This will execute all constructors that provide a
+// value to that group in an unspecified order.
+//
+//   type ServerParams struct {
+//     fx.In
+//
+//     Handlers []Handler `group:"server"`
+//   }
+//
+//   func NewServer(p ServerParams) *Server {
+//     server := newServer()
+//     for _, h := range p.Handlers {
+//       server.Register(h)
+//     }
+//     return server
+//   }
+//
+// Note that values in a value group are unordered. Fx makes no guarantees
+// about the order in which these values will be produced.
 type In struct{ dig.In }
 
-// Out can be embedded in return structs in order to
-// provide named types.
+// Out is the inverse of In: it can be embedded in result structs to take
+// advantage of advanced features.
 //
-// Modules should return a single results struct that embeds
-// an Out in order to provide a forwards-compatible API where
-// additional types can be provided over time without breaking.
+// Modules should return a single result struct that embeds an Out in order to
+// provide a forward-compatible API: since adding fields to a struct is
+// backward-compatible, minor releases can provide additional types.
+//
+// Result structs
+//
+// Result structs are the inverse of parameter structs (discussed in the In
+// documentation). These structs represent multiple outputs from a
+// single function as fields. Fx treats all structs embedding fx.Out as result
+// structs, so other constructors can rely on the result struct's fields
+// directly.
+//
+// Without result structs, we sometimes have function definitions like this:
+//
+//   func SetupGateways(conn *sql.DB) (*UserGateway, *CommentGateway, *PostGateway, error) {
+//     // ...
+//   }
+//
+// With result structs, we can make this both more readable and easier to
+// modify in the future:
+//
+//  type Gateways struct {
+//    fx.Out
+//
+//    Users    *UserGateway
+//    Comments *CommentGateway
+//    Posts    *PostGateway
+//  }
+//
+//  func SetupGateways(conn *sql.DB) (Gateways, error) {
+//    // ...
+//  }
+//
+// Named Values and Value Groups
+//
+// See the documentation of the In type.
 type Out struct{ dig.Out }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -27,14 +27,15 @@ import (
 )
 
 // Lifecycle allows constructors to register callbacks that are executed on
-// application start and stop.
+// application start and stop. See the documentation for App for details on Fx
+// applications' initialization, startup, and shutdown logic.
 type Lifecycle interface {
 	Append(Hook)
 }
 
 // A Hook is a pair of start and stop callbacks, either of which can be nil.
 // If a Hook's OnStart callback isn't executed (because a previous OnStart
-// failure short-circuited application start), its OnStop callback won't be
+// failure short-circuited application startup), its OnStop callback won't be
 // executed.
 type Hook struct {
 	OnStart func(context.Context) error

--- a/populate.go
+++ b/populate.go
@@ -26,9 +26,13 @@ import (
 )
 
 // Populate sets targets with values from the dependency injection container
-// before application start. All targets must be pointers to the values
-// that must be populated. Pointers to structs that embed In are supported,
-// which can be used to populate multiple values in a struct.
+// during application initialization. All targets must be pointers to the
+// values that must be populated. Pointers to structs that embed In are
+// supported, which can be used to populate multiple values in a struct.
+//
+// This is most helpful in unit tests: it lets tests leverage Fx's automatic
+// constructor wiring to build a few structs, but then extract those structs
+// for further testing.
 func Populate(targets ...interface{}) Option {
 	// Validate all targets are non-nil pointers.
 	targetTypes := make([]reflect.Type, len(targets))

--- a/populate_example_test.go
+++ b/populate_example_test.go
@@ -32,7 +32,11 @@ func ExamplePopulate() {
 	type Username string
 	UserModule := fx.Provide(func() Username { return "john" })
 
-	// We want to get the user out of the dependency injection container.
+	// We want to use Fx to wire up our constructors, but don't actually want to
+	// run the application - we just want to yank out the user name.
+	//
+	// This is common in unit tests, and is even easier with the fxtest
+	// package's RequireStart and RequireStop helpers.
 	var user Username
 	app := fx.New(
 		UserModule,


### PR DESCRIPTION
Make a variety of improvements to Fx's documentation:

* Clarify and expand the docs for most types and methods, removing
  references to "dependency injection containers" from all types except
  `In` and `Out`.
* Migrate our internal getting started example to a package-level
  example. This sacrifices the step-by-step walkthrough, but makes the
  example much easier to find and validates its correctness in unit tests.
* Remove the example for `Extract`, since users should now prefer
  `Populate`. I've also added a note that we plan to deprecate Extract,
  but haven't actually added an official `staticcheck`-compatible
  deprecation.
* Fully document the advanced features offered by the `In` and `Out`
  types. This moves the docs for an important set of features to the
  our users' entry point. In a follow-up diff, I plan to replace the
  now-duplicate dig docs with a pointer to Fx's documentation.