### PR TITLE
Make it easier to set custom Start and Stop timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `fx.StartTimeout` and `fx.StopTimeout` to make configuring application
+  start and stop timeouts easier.
+- Export the default start and stop timeout as `fx.DefaultTimeout`.
 
-- No changes yet.
+### Fixed
+- Make `fxtest` respect the application's start and stop timeouts.
 
 ## [1.4.0] - 2017-12-07
 ### Added

--- a/app_test.go
+++ b/app_test.go
@@ -180,9 +180,10 @@ func TestTimeoutOptions(t *testing.T) {
 	var started, stopped bool
 	assertCustomContext := func(ctx context.Context, phase string) {
 		deadline, ok := ctx.Deadline()
-		require.True(t, ok, "no %s deadline", phase)
-		remaining := time.Until(deadline)
-		assert.True(t, remaining > DefaultTimeout, "didn't respect customized %s timeout", phase)
+		if assert.True(t, ok, "no %s deadline", phase) {
+			remaining := time.Until(deadline)
+			assert.True(t, remaining > DefaultTimeout, "didn't respect customized %s timeout", phase)
+		}
 	}
 	verify := func(lc Lifecycle) {
 		lc.Append(Hook{

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -64,7 +64,7 @@ func New(tb TB, opts ...fx.Option) *App {
 
 // RequireStart calls Start, failing the test if an error is encountered.
 func (app *App) RequireStart() *App {
-	startCtx, cancel := context.WithTimeout(context.Background(), app.GetStartTimeout())
+	startCtx, cancel := context.WithTimeout(context.Background(), app.StartTimeout())
 	defer cancel()
 
 	if err := app.Start(startCtx); err != nil {
@@ -76,7 +76,7 @@ func (app *App) RequireStart() *App {
 
 // RequireStop calls Stop, failing the test if an error is encountered.
 func (app *App) RequireStop() {
-	stopCtx, cancel := context.WithTimeout(context.Background(), app.GetStopTimeout())
+	stopCtx, cancel := context.WithTimeout(context.Background(), app.StopTimeout())
 	defer cancel()
 
 	if err := app.Stop(stopCtx); err != nil {

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -64,7 +64,10 @@ func New(tb TB, opts ...fx.Option) *App {
 
 // RequireStart calls Start, failing the test if an error is encountered.
 func (app *App) RequireStart() *App {
-	if err := app.Start(context.Background()); err != nil {
+	startCtx, cancel := context.WithTimeout(context.Background(), app.GetStartTimeout())
+	defer cancel()
+
+	if err := app.Start(startCtx); err != nil {
 		app.tb.Errorf("application didn't start cleanly: %v", err)
 		app.tb.FailNow()
 	}
@@ -73,7 +76,10 @@ func (app *App) RequireStart() *App {
 
 // RequireStop calls Stop, failing the test if an error is encountered.
 func (app *App) RequireStop() {
-	if err := app.Stop(context.Background()); err != nil {
+	stopCtx, cancel := context.WithTimeout(context.Background(), app.GetStopTimeout())
+	defer cancel()
+
+	if err := app.Stop(stopCtx); err != nil {
 		app.tb.Errorf("application didn't stop cleanly: %v", err)
 		app.tb.FailNow()
 	}


### PR DESCRIPTION
(Amended from @vkuzmin-uber's original summary.)

@vkuzmin-uber points out that Fx offers only two options for setting app start/stop timeouts: use the defaults or drop down to the `Start`/`Stop`/`Done` APIs directly. This PR offers a middle ground by introducing `StartTimeout` and `StopTimeout` options.

We discussed this quite a bit while designing the Fx 1.x APIs, and agreed to defer making a decision - we wanted a low-level API that let applications use contexts partially consumed by other libraries, but also reasonable behavior by default. Since it turns out that many internal applications need longer to start up but are otherwise happy with `Run`, introducing these options makes things a bit simpler for them.

As a nice bonus, this makes it possible for `fxtest` to respect the configured timeouts.