### PR TITLE
Update Travis build for glue-dig-b3 branch

### DIFF
--- a/.build/lint.mk
+++ b/.build/lint.mk
@@ -34,7 +34,3 @@ lint:
 	$(ECHO_V)DRY_RUN=1 $(_THIS_DIR)/license.sh | tee -a $(LINT_LOG)
 	@echo "Checking for imports of log package"
 	$(ECHO_V)go list -f '{{ .ImportPath }}: {{ .Imports }}' $(shell glide nv) | grep -e "\blog\b" | $(FILTER_LOG) | tee -a $(LINT_LOG)
-	@echo "Ensuring generated doc.go are up to date"
-	$(ECHO_V)$(MAKE) gendoc
-	$(ECHO_V)[ -z "$(shell git status --porcelain | grep '\bdoc.go$$')" ] || echo "Commit updated doc.go changes" | tee -a $(LINT_LOG)
-	$(ECHO_V)[ ! -s $(LINT_LOG) ]

--- a/.build/lint.mk
+++ b/.build/lint.mk
@@ -32,3 +32,4 @@ lint:
 	$(ECHO_V)git grep -i fixme | grep -v -e vendor -e $(_THIS_MAKEFILE) -e CONTRIBUTING.md | tee -a $(LINT_LOG)
 	@echo "Checking for imports of log package"
 	$(ECHO_V)go list -f '{{ .ImportPath }}: {{ .Imports }}' $(shell glide nv) | grep -e "\blog\b" | $(FILTER_LOG) | tee -a $(LINT_LOG)
+	$(ECHO_V)[ ! -s $(LINT_LOG) ]

--- a/.build/lint.mk
+++ b/.build/lint.mk
@@ -30,7 +30,5 @@ lint:
 	$(ECHO_V)errcheck $(ERRCHECK_FLAGS) $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a $(LINT_LOG)
 	@echo "Checking for unresolved FIXMEs..."
 	$(ECHO_V)git grep -i fixme | grep -v -e vendor -e $(_THIS_MAKEFILE) -e CONTRIBUTING.md | tee -a $(LINT_LOG)
-	@echo "Checking for license headers..."
-	$(ECHO_V)DRY_RUN=1 $(_THIS_DIR)/license.sh | tee -a $(LINT_LOG)
 	@echo "Checking for imports of log package"
 	$(ECHO_V)go list -f '{{ .ImportPath }}: {{ .Imports }}' $(shell glide nv) | grep -e "\blog\b" | $(FILTER_LOG) | tee -a $(LINT_LOG)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
   directories:
     - .cache/docker
 env:
-  - DOCKER_GO_VERSION=1.7
-  - DOCKER_GO_VERSION=1.8 CI_TEST_CMD=coveralls
+  - DOCKER_GO_VERSION=1.9
+  - DOCKER_GO_VERSION=1.10 CI_TEST_CMD=coveralls
 before_install:
   - make dockerload
 script:

--- a/Dockerfile.1.10
+++ b/Dockerfile.1.10
@@ -1,4 +1,4 @@
-FROM golang:1.8.0
+FROM golang:1.10.1
 
 WORKDIR /go/src/go.uber.org/fx
 ADD .build/deps.mk /go/src/go.uber.org/fx/.build/

--- a/Dockerfile.1.9
+++ b/Dockerfile.1.9
@@ -1,4 +1,4 @@
-FROM golang:1.7.5
+FROM golang:1.9.5
 
 WORKDIR /go/src/go.uber.org/fx
 ADD .build/deps.mk /go/src/go.uber.org/fx/.build/


### PR DESCRIPTION
We're still backporting fixes to this ancient branch, but the the build is unnecessarily finicky. Now that this isn't the mainline development branch, we can remove some checks.

This also updates to the latest Go releases that we support.