### PR TITLE
app: Add fx.Error option

### DIFF
--- a/app.go
+++ b/app.go
@@ -133,23 +133,14 @@ func (io invokeOption) String() string {
 
 // Error registers any number of errors with the application to short-circuit
 // startup. If more than one error is given, the errors are combined into a
-// single error, where each of the error messages are delimited by a newline.
+// single error.
 //
-// Similar to invocations, errors are applied in order. All Provide options
-// registered after an Error option will not be applied. Similarly, no
-// invokes will be run, including those that were registered before an Error.
+// Similar to invocations, errors are applied in order. All Provide and Invoke
+// options registered before or after an Error option will not be applied.
 func Error(errs ...error) Option {
-	return errOption(errs)
-}
-
-type errOption []error
-
-func (eo errOption) apply(app *App) {
-	app.err = multierr.Append(app.err, multierr.Combine(eo...))
-}
-
-func (eo errOption) String() string {
-	return fmt.Sprintf("fx.Error(%s)", multierr.Combine(eo...).Error())
+	return optionFunc(func(app *App) {
+		app.err = multierr.Append(app.err, multierr.Combine(errs...))
+	})
 }
 
 // Options converts a collection of Options into a single Option. This allows

--- a/app.go
+++ b/app.go
@@ -131,6 +131,27 @@ func (io invokeOption) String() string {
 	return fmt.Sprintf("fx.Invoke(%s)", strings.Join(items, ", "))
 }
 
+// Error registers any number of errors with the application to short-circuit
+// startup. If more than one error is given, the errors are combined into a
+// single error, where each of the error messages are delimited by a newline.
+//
+// Similar to invocations, errors are applied in order. All Provide options
+// registered after an Error option will not be applied. Similarly, no
+// invokes will be run, including those that were registered before an Error.
+func Error(errs ...error) Option {
+	return errOption(errs)
+}
+
+type errOption []error
+
+func (eo errOption) apply(app *App) {
+	app.err = multierr.Append(app.err, multierr.Combine(eo...))
+}
+
+func (eo errOption) String() string {
+	return fmt.Sprintf("fx.Error(%s)", multierr.Combine(eo...).Error())
+}
+
 // Options converts a collection of Options into a single Option. This allows
 // packages to bundle sophisticated functionality into easy-to-use Fx modules.
 // For example, a logging package might export a simple option like this:

--- a/app_test.go
+++ b/app_test.go
@@ -112,18 +112,20 @@ func TestError(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, invoked)
 	})
+
 	t.Run("SingleErrorOption", func(t *testing.T) {
 		var invoked bool
 
 		app := fxtest.New(t,
-			Error(fmt.Errorf("module A failure")),
+			Error(errors.New("module failure")),
 			Invoke(func() { invoked = true }),
 		)
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "module A failure")
+		assert.Contains(t, err.Error(), "module failure")
 		assert.False(t, invoked)
 	})
+
 	t.Run("MultipleErrorOption", func(t *testing.T) {
 		type A struct{}
 		panicFn := func(A) { panic("do not call me") }
@@ -132,8 +134,8 @@ func TestError(t *testing.T) {
 			Provide(func() A { return A{} }),
 			Invoke(panicFn),
 			Error(
-				fmt.Errorf("module A failure"),
-				fmt.Errorf("module B failure"),
+				errors.New("module A failure"),
+				errors.New("module B failure"),
 			),
 			Provide(panicFn),
 		)
@@ -385,6 +387,7 @@ func TestAppStart(t *testing.T) {
 			Invoke(func(type1) {
 				require.FailNow(t, "module Invoke must not be called")
 			}),
+			Error(errors.New("module failure")),
 		)
 
 		app := fxtest.New(t,
@@ -397,6 +400,7 @@ func TestAppStart(t *testing.T) {
 		require.Error(t, err, "expected start failure")
 		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Provide")
 		assert.Contains(t, err.Error(), "fx.Provide received fx.Options(fx.Provide(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "fx.Error(module failure)")
 	})
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -120,7 +120,7 @@ func TestError(t *testing.T) {
 		)
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "module failure")
+		assert.Equal(t, err.Error(), "module failure")
 	})
 
 	t.Run("MultipleErrorOption", func(t *testing.T) {
@@ -142,6 +142,7 @@ func TestError(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "module A failure")
 		assert.Contains(t, err.Error(), "module B failure")
+		assert.NotContains(t, err.Error(), "fx_test.A is not in the container")
 	})
 
 	t.Run("ProvideAndInvokeErrorsAreIgnored", func(t *testing.T) {
@@ -159,7 +160,7 @@ func TestError(t *testing.T) {
 		)
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "module failure")
+		assert.Equal(t, err.Error(), "module failure")
 	})
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -106,7 +106,7 @@ func TestError(t *testing.T) {
 
 		app := fxtest.New(t,
 			Error(nil),
-			Invoke(func() { invoked = true }), // should not be called
+			Invoke(func() { invoked = true }),
 		)
 		err := app.Err()
 		require.NoError(t, err)
@@ -114,29 +114,25 @@ func TestError(t *testing.T) {
 	})
 
 	t.Run("SingleErrorOption", func(t *testing.T) {
-		var invoked bool
-
 		app := fxtest.New(t,
 			Error(errors.New("module failure")),
-			Invoke(func() { invoked = true }), // should not be called
+			Invoke(func() { t.Errorf("Invoke should not be called") }),
 		)
 		err := app.Err()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "module failure")
-		assert.False(t, invoked)
 	})
 
 	t.Run("MultipleErrorOption", func(t *testing.T) {
 		type A struct{}
-		var provided, invoked bool
 
 		app := fxtest.New(t,
-			Provide(func() A { // should not be called
-				provided = true
+			Provide(func() A {
+				t.Errorf("Provide should not be called")
 				return A{}
 			},
 			),
-			Invoke(func(A) { invoked = true }), // should not be called
+			Invoke(func(A) { t.Errorf("Invoke should not be called") }),
 			Error(
 				errors.New("module A failure"),
 				errors.New("module B failure"),
@@ -146,8 +142,6 @@ func TestError(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "module A failure")
 		assert.Contains(t, err.Error(), "module B failure")
-		assert.False(t, provided)
-		assert.False(t, invoked)
 	})
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -143,6 +143,24 @@ func TestError(t *testing.T) {
 		assert.Contains(t, err.Error(), "module A failure")
 		assert.Contains(t, err.Error(), "module B failure")
 	})
+
+	t.Run("ProvideAndInvokeErrorsAreIgnored", func(t *testing.T) {
+		type A struct{}
+		type B struct{}
+
+		app := fxtest.New(t,
+			Provide(func(b B) A {
+				t.Errorf("B is missing from the container; Provide should not be called")
+				return A{}
+			},
+			),
+			Error(errors.New("module failure")),
+			Invoke(func(A) { t.Errorf("A was not provided; Invoke should not be called") }),
+		)
+		err := app.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "module failure")
+	})
 }
 
 func TestOptions(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -120,7 +120,7 @@ func TestError(t *testing.T) {
 		)
 		err := app.Err()
 		require.Error(t, err)
-		assert.Equal(t, err.Error(), "module failure")
+		assert.EqualError(t, err, "module failure")
 	})
 
 	t.Run("MultipleErrorOption", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestError(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "module A failure")
 		assert.Contains(t, err.Error(), "module B failure")
-		assert.NotContains(t, err.Error(), "fx_test.A is not in the container")
+		assert.NotContains(t, err.Error(), "not in the container")
 	})
 
 	t.Run("ProvideAndInvokeErrorsAreIgnored", func(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -119,7 +119,6 @@ func TestError(t *testing.T) {
 			Invoke(func() { t.Errorf("Invoke should not be called") }),
 		)
 		err := app.Err()
-		require.Error(t, err)
 		assert.EqualError(t, err, "module failure")
 	})
 
@@ -159,8 +158,7 @@ func TestError(t *testing.T) {
 			Invoke(func(A) { t.Errorf("A was not provided; Invoke should not be called") }),
 		)
 		err := app.Err()
-		require.Error(t, err)
-		assert.Equal(t, err.Error(), "module failure")
+		assert.EqualError(t, err, "module failure")
 	})
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -131,11 +131,10 @@ func TestError(t *testing.T) {
 		var provided, invoked bool
 
 		app := fxtest.New(t,
-			Provide(
-				func() A { // should not be called
-					provided = true
-					return A{}
-				},
+			Provide(func() A { // should not be called
+				provided = true
+				return A{}
+			},
 			),
 			Invoke(func(A) { invoked = true }), // should not be called
 			Error(

--- a/error_example_test.go
+++ b/error_example_test.go
@@ -36,7 +36,7 @@ func ExampleError() {
 	newHTTPServer := func() fx.Option {
 		port := os.Getenv("PORT")
 		if port == "" {
-			return fx.Error(errors.New("failed to build module: $PORT is not set"))
+			return fx.Error(errors.New("$PORT is not set"))
 		}
 		return fx.Provide(&http.Server{
 			Addr: fmt.Sprintf(":%s", port),
@@ -51,5 +51,5 @@ func ExampleError() {
 	fmt.Println(app.Err())
 
 	// Output:
-	// failed to build module: $PORT is not set
+	// $PORT is not set
 }

--- a/error_example_test.go
+++ b/error_example_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx_test
+
+import (
+	"errors"
+	"fmt"
+
+	"go.uber.org/fx"
+)
+
+func ExampleError() {
+	// A function that panics is both provided and invoked,
+	// but neither of these options will be called in the
+	// presence of an fx.Error.
+	panicFn := func() { panic("should not be called") }
+
+	app := fx.New(
+		fx.Provide(panicFn),
+		// An fx.Error option was registered with the application,
+		// so none of the Provide or Invoke options will be run.
+		fx.Error(errors.New("failed to build module")),
+		fx.Invoke(panicFn),
+	)
+
+	fmt.Println(app.Err())
+
+	// Output:
+	// failed to build module
+}


### PR DESCRIPTION
It's often useful for libraries to create an `Option` that is added to user `App`s. If creating an `Option` depends on any sort of error-prone logic, there currently isn't a way to signal to the `App` that we failed to create an `Option`. In these cases, the library can ungracefully panic to prevent application startup, but this is less than ideal. 

For example,

```
type Foo struct{
  Bar string
}

func newOption(f Foo) Option {
  if f.Bar == "" {
    panic("%T does not have Bar set", f)
  }
  ...
}
```

It'd be useful to support an `Error` `Option` for this purpose specifically. The above example would change to:

```
func newOption(f Foo) Option {
  if f.Bar == "" {
    return Error(fmt.Errorf("%T does not have Bar set", f)
  }
  ...
}
```