### PR TITLE
 dot graph: VisualizeError on invoke failure using ErrorHook option

### DIFF
--- a/app.go
+++ b/app.go
@@ -279,10 +279,15 @@ type App struct {
 	errorHooks   errorHookOption
 }
 
+// ErrorHook registers error handlers that implement error handling functions.
+// They are executed on invoke failures. Passing multiple ErrorHandlers appends
+// the new handlers to the application's existing list.
 func ErrorHook(funcs ...ErrorHandler) Option {
 	return errorHookOption(funcs)
 }
 
+// ErrorHandler implements HandleError. They are used as error hooks and are
+// called on invoke errors.
 type ErrorHandler interface {
 	HandleError(error)
 }
@@ -362,6 +367,7 @@ func (we wrappedErr) Error() string {
 	return we.err.Error()
 }
 
+// VisualizeError returns the visualization of the error if available.
 func VisualizeError(err error) string {
 	if e, ok := err.(isWrapped); ok {
 		return e.Graph()

--- a/app.go
+++ b/app.go
@@ -21,6 +21,7 @@
 package fx
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -275,6 +276,27 @@ type App struct {
 	logger       *fxlog.Logger
 	startTimeout time.Duration
 	stopTimeout  time.Duration
+	errorHooks   errorHookOption
+}
+
+func ErrorHook(funcs ...ErrorHandler) Option {
+	return errorHookOption(funcs)
+}
+
+type ErrorHandler interface {
+	HandleError(error)
+}
+
+type errorHookOption []ErrorHandler
+
+func (eho errorHookOption) apply(app *App) {
+	app.errorHooks = append(app.errorHooks, eho...)
+}
+
+func (eho errorHookOption) onError(err error) {
+	for _, eh := range eho {
+		eh.HandleError(err)
+	}
 }
 
 // New creates and initializes an App, immediately executing any functions
@@ -308,9 +330,43 @@ func New(opts ...Option) *App {
 
 	if err := app.executeInvokes(); err != nil {
 		app.err = err
+		var b bytes.Buffer
+
+		if dig.CanVisualizeError(err) {
+			dig.Visualize(app.container, &b, dig.VisualizeError(err))
+		}
+
+		app.errorHooks.onError(wrappedErr{
+			graph: b.String(),
+			err:   err,
+		})
 	}
 
 	return app
+}
+
+type wrappedErr struct {
+	graph string
+	err   error
+}
+
+type isWrapped interface {
+	Graph() string
+}
+
+func (we wrappedErr) Graph() string {
+	return we.graph
+}
+
+func (we wrappedErr) Error() string {
+	return we.err.Error()
+}
+
+func VisualizeError(err error) string {
+	if e, ok := err.(isWrapped); ok {
+		return e.Graph()
+	}
+	return ""
 }
 
 // Run starts the application, blocks on the signals channel, and then

--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,26 @@
-hash: 7a10fdf94a677dc1a1ed50547a734e07fc72b8d700afb23e610251a86848282f
-updated: 2018-04-24T13:30:55.82212203-07:00
+hash: b109f1605214e5820322fa162805b5eee245c3c805236f60f025d4e9b9f60892
+updated: 2018-07-17T17:31:31.587148403-07:00
 imports:
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: d100de9c8cc8358591507951141bc107713ba671
+  version: 42aa9c4a17b4f8faea42bc56688f50c5e730aebf
   subpackages:
   - internal/digreflect
+  - internal/dot
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require
@@ -28,12 +29,12 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/lint
-  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
+  version: 06c8688daad7faa9da5a0c2f163a3d14aac986ca
   repo: https://github.com/golang/lint
   vcs: git
   subpackages:
   - golint
 - name: golang.org/x/tools
-  version: 4e70a1b26a7875f00ca1916637a876b5ffaeec59
+  version: fd2d2c45eb2dff7b87eab4303a1016b4dbf95e81
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: ^1
+  version: can-visualize-error
 testImport:
 - package: github.com/stretchr/testify
   version: ^1


### PR DESCRIPTION
* Added `ErrorHook` option to `App` that registers error handlers.
* `ErrorHandler`s handle the error produced on invoke failure. The error is wrapped with a wrapper that contains the DOT format graph generated by `dig.Visualize`.