### PR TITLE
dot graph: VisualizeError on invoke failure using ErrorHook option

### DIFF
--- a/app.go
+++ b/app.go
@@ -352,6 +352,7 @@ func New(opts ...Option) *App {
 	return app
 }
 
+// DotGraph is a Graphviz DOT format graph.
 type DotGraph string
 
 type errWithGraph interface {

--- a/app.go
+++ b/app.go
@@ -290,7 +290,7 @@ func ErrorHook(funcs ...ErrorHandler) Option {
 // ErrorHandler implements Handle. They are used as error hooks and are called
 // on invoke errors.
 type ErrorHandler interface {
-	Handle(error)
+	HandleError(error)
 }
 
 type errorHookOption []ErrorHandler
@@ -301,7 +301,7 @@ func (eho errorHookOption) apply(app *App) {
 
 func (eho errorHookOption) onError(err error) {
 	for _, eh := range eho {
-		eh.Handle(err)
+		eh.HandleError(err)
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -506,8 +506,7 @@ func (we testErrorWithGraph) Error() string {
 
 func TestVisualizeError(t *testing.T) {
 	t.Run("NotWrappedError", func(t *testing.T) {
-		graph, err := VisualizeError(errors.New("great sadness"))
-		assert.Empty(t, graph)
+		_, err := VisualizeError(errors.New("great sadness"))
 		require.Error(t, err)
 	})
 
@@ -528,19 +527,16 @@ func TestErrorHook(t *testing.T) {
 	t.Run("UnvisualizableError", func(t *testing.T) {
 		type A struct{}
 
-		var errStr, graphStr string
+		var graphErr error
 		h := errHandlerFunc(func(err error) {
-			errStr = err.Error()
-			graphStr, _ = VisualizeError(err)
+			_, graphErr = VisualizeError(err)
 		})
 		fxtest.New(t,
 			Provide(func() A { return A{} }),
-			Invoke(func(A) error { return fmt.Errorf("great sadness") }),
+			Invoke(func(A) error { return errors.New("great sadness") }),
 			ErrorHook(h),
 		)
-		assert.Equal(t, "great sadness", errStr)
-		assert.Empty(t, graphStr)
-
+		assert.Equal(t, errors.New("unable to visualize error"), graphErr)
 	})
 
 	t.Run("GraphWithError", func(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -88,7 +88,7 @@ type testErrHandler struct {
 	count int
 }
 
-func (eh *testErrHandler) Handle(err error) {
+func (eh *testErrHandler) HandleError(err error) {
 	eh.count++
 }
 
@@ -529,7 +529,7 @@ type graphErrHandler struct {
 	graphStr string
 }
 
-func (eh *graphErrHandler) Handle(err error) {
+func (eh *graphErrHandler) HandleError(err error) {
 	eh.errStr = err.Error()
 	eh.graphStr, _ = VisualizeError(err)
 }

--- a/app_test.go
+++ b/app_test.go
@@ -559,6 +559,7 @@ func TestErrorHook(t *testing.T) {
 			Invoke(func(A) {}),
 			ErrorHook(&h),
 		)
+		assert.Contains(t, errStr, "great sadness")
 		assert.Contains(t, graphStr, `"fx_test.B" [color=red];`)
 		assert.Contains(t, graphStr, `"fx_test.A" [color=orange];`)
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,26 @@
-hash: 7a10fdf94a677dc1a1ed50547a734e07fc72b8d700afb23e610251a86848282f
-updated: 2018-04-24T13:30:55.82212203-07:00
+hash: b109f1605214e5820322fa162805b5eee245c3c805236f60f025d4e9b9f60892
+updated: 2018-07-17T17:31:31.587148403-07:00
 imports:
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: d100de9c8cc8358591507951141bc107713ba671
+  version: 42aa9c4a17b4f8faea42bc56688f50c5e730aebf
   subpackages:
   - internal/digreflect
+  - internal/dot
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require
@@ -28,12 +29,12 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/lint
-  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
+  version: 06c8688daad7faa9da5a0c2f163a3d14aac986ca
   repo: https://github.com/golang/lint
   vcs: git
   subpackages:
   - golint
 - name: golang.org/x/tools
-  version: 4e70a1b26a7875f00ca1916637a876b5ffaeec59
+  version: fd2d2c45eb2dff7b87eab4303a1016b4dbf95e81
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: ^1
+  version: can-visualize-error
 testImport:
 - package: github.com/stretchr/testify
   version: ^1


### PR DESCRIPTION
This PR includes changes to fx to use the new features in the `feature/graphviz` branch in `uber-go/dig`. On `Invoke` failures, we pass the error to the registered error handlers provided by users through `fx.ErrorHook`. This allows users to get a graph representation on what's causing the invoke failure. The error handlers can then process the information accordingly (eg. print to log or write to file).
* Updated `glide.yaml` and `glide.lock` to use `go.uber.org/dig` feature branch.
* Added `ErrorHook` option to `App` to register error handlers.
* `ErrorHandler`s handle the error produced on invoke failure. The error is wrapped in a wrapper that also contains the DOT format graph generated by `dig.Visualize`.