### PR TITLE
Implement struct fx.Annotated to inject named values without relying on fx.Out

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -20,5 +20,7 @@
 
 package fx
 
-// Version is exported for runtime compatibility checks.
-const Version = "1.8.0"
+type Annotated struct {
+	Name string
+	Fn   interface{}
+}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1,0 +1,39 @@
+package fx_test
+
+import (
+	"testing"
+	"go.uber.org/fx/fxtest"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+)
+
+func TestAnnotated(t *testing.T) {
+	type a struct {
+		name string
+	}
+
+	type in struct {
+		fx.In
+
+		A *a `name:"foo"`
+	}
+	newA := func() *a {
+		return &a{name: "foo"}
+	}
+
+	t.Run("Provided", func(t *testing.T) {
+		app := fxtest.New(t,
+			fx.Provide(
+				fx.Annotated{
+					Name: "foo",
+					Fn:   newA,
+				},
+			),
+			fx.Invoke(func(in in) {
+				assert.NotNil(t, in.A, "expected in.A to be injected")
+				assert.Equal(t, "foo", in.A.name, "expected to get a type 'a' of name 'foo'")
+			}),
+		)
+		app.RequireStart().RequireStop()
+	})
+}

--- a/app.go
+++ b/app.go
@@ -404,6 +404,13 @@ func (app *App) provide(constructor interface{}) {
 		return
 	}
 
+	if a, ok := constructor.(Annotated); ok {
+		if err := app.container.Provide(a.Fn, dig.Name(a.Name)); err != nil {
+			app.err = err
+		}
+		return
+	}
+
 	if err := app.container.Provide(constructor); err != nil {
 		app.err = err
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 7a10fdf94a677dc1a1ed50547a734e07fc72b8d700afb23e610251a86848282f
-updated: 2018-04-24T13:30:55.82212203-07:00
+hash: b99527165f13dc8e1ff49f6a3e02c7596fcf175eb3e4fb97c7b8525ea5f0275f
+updated: 2018-07-20T23:01:08.787543+02:00
 imports:
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: d100de9c8cc8358591507951141bc107713ba671
+  version: 45540ff1846c207f109bbb7de2f2748f7198ca21
   subpackages:
   - internal/digreflect
 - name: go.uber.org/multierr
@@ -19,7 +19,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: ^1
+  version: master
 testImport:
 - package: github.com/stretchr/testify
   version: ^1


### PR DESCRIPTION
See: https://github.com/uber-go/fx/issues/610

This is a version for review, there are a few things I  would like to receive feedback.

- I am not familiar with the codebase, so, I am not sure if the implementation in the *app is the best possible implementation;
- I needed to update dig to use master, because of the dig.Name was not released yet;
- I still need to add documentation;
- There are a couple of questions, how to deal with Optional dependencies? and How to implement groups?
