### PR TITLE
Add ErrorHook option to handle errors on invoke failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-- No changes yet.
+### Added
+- Add `fx.ErrorHook` option to allow users to provide `ErrorHandler`s on invoke
+  failures.
+- `VisualizeError` returns the visualization wrapped in the error if available.
 
 ## [1.6.0] - 2018-06-12
 ### Added

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 06ebd74b2928b92936b45c3d9ff7674d145fd9b61396ec8476d885037565edac
-updated: 2018-08-15T16:14:32.18027381-07:00
+hash: 13aa480ad0954c44f966a32cc9fe562d13a7a9e4e7d3aeb10f4f722b2a175ad1
+updated: 2018-08-16T17:29:48.12008944-07:00
 imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: 8060c505c14c1f7ff4312261315cadaaba746b10
+  version: d6ba99365e475c24e8ac02392eb3f78ccab2a6f3
   subpackages:
   - internal/digreflect
   - internal/dot

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: b109f1605214e5820322fa162805b5eee245c3c805236f60f025d4e9b9f60892
-updated: 2018-07-17T17:31:31.587148403-07:00
+hash: 06ebd74b2928b92936b45c3d9ff7674d145fd9b61396ec8476d885037565edac
+updated: 2018-08-15T16:14:32.18027381-07:00
 imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: 42aa9c4a17b4f8faea42bc56688f50c5e730aebf
+  version: 8060c505c14c1f7ff4312261315cadaaba746b10
   subpackages:
   - internal/digreflect
   - internal/dot
@@ -35,6 +35,6 @@ testImports:
   subpackages:
   - golint
 - name: golang.org/x/tools
-  version: fd2d2c45eb2dff7b87eab4303a1016b4dbf95e81
+  version: 4e70a1b26a7875f00ca1916637a876b5ffaeec59
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,26 @@
-hash: 7a10fdf94a677dc1a1ed50547a734e07fc72b8d700afb23e610251a86848282f
-updated: 2018-04-24T13:30:55.82212203-07:00
+hash: b109f1605214e5820322fa162805b5eee245c3c805236f60f025d4e9b9f60892
+updated: 2018-07-17T17:31:31.587148403-07:00
 imports:
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: d100de9c8cc8358591507951141bc107713ba671
+  version: 42aa9c4a17b4f8faea42bc56688f50c5e730aebf
   subpackages:
   - internal/digreflect
+  - internal/dot
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require
@@ -28,12 +29,12 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/lint
-  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
+  version: 06c8688daad7faa9da5a0c2f163a3d14aac986ca
   repo: https://github.com/golang/lint
   vcs: git
   subpackages:
   - golint
 - name: golang.org/x/tools
-  version: 4e70a1b26a7875f00ca1916637a876b5ffaeec59
+  version: fd2d2c45eb2dff7b87eab4303a1016b4dbf95e81
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: ^1
+  version: can-visualize-error
 testImport:
 - package: github.com/stretchr/testify
   version: ^1

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: feature/graphviz
+  version: ^1.4
 testImport:
 - package: github.com/stretchr/testify
   version: ^1

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: can-visualize-error
+  version: feature/graphviz
 testImport:
 - package: github.com/stretchr/testify
   version: ^1


### PR DESCRIPTION
This PR includes changes to use the new features in `go.uber.org/dig`. On invoke failures, the error returned are passed to registered error handlers provided by users. This allows users to get a DOT format graph representation of dependency relation of types in the application and what error types are causing the invoke failures. The users can then process the information accordingly (eg.  print to log or write to file).

This is currently pinned to the `feature/graphviz` branch in `go.uber.org/dig`. Once the feature branch is merged, we can move the pin back and merge this.