### PR TITLE
Fix goroutine leaks in fxtest.Lifecycle

### DIFF
--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -90,21 +90,15 @@ var _ fx.Lifecycle = (*Lifecycle)(nil)
 // methods (and some test-specific helpers) so that unit tests can exercise
 // hooks.
 type Lifecycle struct {
-	t          TB
-	lc         *lifecycle.Lifecycle
-	ctx        context.Context
-	cancelFunc context.CancelFunc
+	t  TB
+	lc *lifecycle.Lifecycle
 }
 
 // NewLifecycle creates a new test lifecycle.
 func NewLifecycle(t TB) *Lifecycle {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	return &Lifecycle{
-		lc:         lifecycle.New(nil),
-		t:          t,
-		ctx:        ctx,
-		cancelFunc: cancel,
+		lc: lifecycle.New(nil),
+		t:  t,
 	}
 }
 
@@ -112,10 +106,13 @@ func NewLifecycle(t TB) *Lifecycle {
 // hook that doesn't succeed.
 func (l *Lifecycle) Start(ctx context.Context) error { return l.lc.Start(ctx) }
 
-// RequireStart calls Start with context.Background(), failing the test if an
+// RequireStart calls Start with context.Background() defering a cancel, failing the test if an
 // error is encountered.
 func (l *Lifecycle) RequireStart() *Lifecycle {
-	if err := l.Start(l.ctx); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := l.Start(ctx); err != nil {
 		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
 		l.t.FailNow()
 	}
@@ -130,12 +127,13 @@ func (l *Lifecycle) RequireStart() *Lifecycle {
 // returned.
 func (l *Lifecycle) Stop(ctx context.Context) error { return l.lc.Stop(ctx) }
 
-// RequireStop calls Stop and cancels the context passed in to Start, failing the test if an error
+// RequireStop calls Stop with context.Background() defering a cancel, failing the test if an error
 // is encountered.
 func (l *Lifecycle) RequireStop() {
-	defer l.cancelFunc()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	if err := l.Stop(l.ctx); err != nil {
+	if err := l.Stop(ctx); err != nil {
 		l.t.Errorf("lifecycle didn't stop cleanly: %v", err)
 		l.t.FailNow()
 	}

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -35,7 +35,6 @@ type TB interface {
 	FailNow()
 }
 
-
 // App is a wrapper around fx.App that provides some testing helpers. By
 // default, it uses the provided TB as the application's logging backend.
 type App struct {
@@ -91,15 +90,21 @@ var _ fx.Lifecycle = (*Lifecycle)(nil)
 // methods (and some test-specific helpers) so that unit tests can exercise
 // hooks.
 type Lifecycle struct {
-	t  TB
-	lc *lifecycle.Lifecycle
+	t          TB
+	lc         *lifecycle.Lifecycle
+	ctx        context.Context
+	cancelFunc context.CancelFunc
 }
 
 // NewLifecycle creates a new test lifecycle.
 func NewLifecycle(t TB) *Lifecycle {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	return &Lifecycle{
-		lc: lifecycle.New(nil),
-		t:  t,
+		lc:         lifecycle.New(nil),
+		t:          t,
+		ctx:        ctx,
+		cancelFunc: cancel,
 	}
 }
 
@@ -110,7 +115,7 @@ func (l *Lifecycle) Start(ctx context.Context) error { return l.lc.Start(ctx) }
 // RequireStart calls Start with context.Background(), failing the test if an
 // error is encountered.
 func (l *Lifecycle) RequireStart() *Lifecycle {
-	if err := l.Start(context.Background()); err != nil {
+	if err := l.Start(l.ctx); err != nil {
 		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
 		l.t.FailNow()
 	}
@@ -125,10 +130,12 @@ func (l *Lifecycle) RequireStart() *Lifecycle {
 // returned.
 func (l *Lifecycle) Stop(ctx context.Context) error { return l.lc.Stop(ctx) }
 
-// RequireStop calls Stop with context.Background(), failing the test if an error
+// RequireStop calls Stop and cancels the context passed in to Start, failing the test if an error
 // is encountered.
 func (l *Lifecycle) RequireStop() {
-	if err := l.Stop(context.Background()); err != nil {
+	defer l.cancelFunc()
+
+	if err := l.Stop(l.ctx); err != nil {
 		l.t.Errorf("lifecycle didn't stop cleanly: %v", err)
 		l.t.FailNow()
 	}

--- a/fxtest/fxtest.go
+++ b/fxtest/fxtest.go
@@ -106,7 +106,7 @@ func NewLifecycle(t TB) *Lifecycle {
 // hook that doesn't succeed.
 func (l *Lifecycle) Start(ctx context.Context) error { return l.lc.Start(ctx) }
 
-// RequireStart calls Start with context.Background() defering a cancel, failing the test if an
+// RequireStart calls Start with context.Background(), failing the test if an
 // error is encountered.
 func (l *Lifecycle) RequireStart() *Lifecycle {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -127,7 +127,7 @@ func (l *Lifecycle) RequireStart() *Lifecycle {
 // returned.
 func (l *Lifecycle) Stop(ctx context.Context) error { return l.lc.Stop(ctx) }
 
-// RequireStop calls Stop with context.Background() defering a cancel, failing the test if an error
+// RequireStop calls Stop with context.Background(), failing the test if an error
 // is encountered.
 func (l *Lifecycle) RequireStop() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 1080e596c67722028dc4e3b24defc5ac60e1a66952dc165fd446ebbfaefb5d02
-updated: 2018-09-13T13:11:57.381957-07:00
+hash: ffbe4433c17f5950ccc20db13b4cd175993666514d88ed24ba1e57e8a39b66c9
+updated: 2018-09-19T17:00:05.671949-07:00
 imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: d6ba99365e475c24e8ac02392eb3f78ccab2a6f3
+  version: 27eb30e15ef3e7f67cd86f2b65c618e3e308c104
   subpackages:
   - internal/digreflect
   - internal/dot

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 13aa480ad0954c44f966a32cc9fe562d13a7a9e4e7d3aeb10f4f722b2a175ad1
-updated: 2018-08-16T17:29:48.12008944-07:00
+hash: 418ed52a31df11f2fde890439cbba9011454f0b9c35cd03bd7d846c43db5f557
+updated: 2018-09-07T14:07:46.665507-07:00
 imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
@@ -24,6 +24,10 @@ testImports:
   subpackages:
   - assert
   - require
+- name: go.uber.org/goleak
+  version: b12bb1eedf12e90b75899bf8a73ce2d8fc4d9938
+  subpackages:
+  - internal/stack
 - name: go.uber.org/tools
   version: ce2550dad7144b81ae2f67dc5e55597643f6902b
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 418ed52a31df11f2fde890439cbba9011454f0b9c35cd03bd7d846c43db5f557
-updated: 2018-09-07T14:07:46.665507-07:00
+hash: 1080e596c67722028dc4e3b24defc5ac60e1a66952dc165fd446ebbfaefb5d02
+updated: 2018-09-13T13:11:57.381957-07:00
 imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
@@ -25,7 +25,7 @@ testImports:
   - assert
   - require
 - name: go.uber.org/goleak
-  version: b12bb1eedf12e90b75899bf8a73ce2d8fc4d9938
+  version: 1ac8aeca0a53163331564467638f6ffb639636bf
   subpackages:
   - internal/stack
 - name: go.uber.org/tools

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,4 @@ testImport:
   vcs: git
   subpackages:
   - golint
+- package: go.uber.org/goleak

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,3 +22,4 @@ testImport:
   subpackages:
   - golint
 - package: go.uber.org/goleak
+  version: ^0.10

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,4 +22,4 @@ testImport:
   subpackages:
   - golint
 - package: go.uber.org/goleak
-  version: ^0.10
+  version: ~0.10


### PR DESCRIPTION
`fxtest.Lifecycle` leaks goroutines in `RequireStart` and `RequireStop`. This PR fixes the leaks (without altering any behavior), and it adds a check for leaked goroutines to the unit test suite.

Fixes #626.