### PR TITLE
Update Go versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 
 go_import_path: go.uber.org/fx
 go:
-  - "1.9"
-  - "1.10"
+  - "1.10.4"
+  - "1.11"
   - tip
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PKG_FILES ?= *.go
 # stable release.
 GO_VERSION := $(shell go version | cut -d " " -f 3)
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 9
+LINTABLE_MINOR_VERSIONS := 11
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif


### PR DESCRIPTION
Start testing on Go 1.11 and drop Go 1.9.