### PR TITLE
Added Annotate Provide Option to inject named values without relying on Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add `fx.Annotated` to allow users to provide named values without creating a new constructor.
+
 ## [1.8.0] - 2018-11-06
 ### Added
 - Provide DOT graph of dependencies in the container.

--- a/annotated.go
+++ b/annotated.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx
+
+// Annotated is a special provide type that specifies that all values produced by a
+// constructor should have the given name. See also In and Out documentation
+// about Named Values.
+//
+// Given,
+//
+//   func NewReadOnlyConnection(...) (*Connection, error)
+//   func NewReadWriteConnection(...) (*Connection, error)
+//
+// The following will provide two connections to the container: one under the
+// name "ro" and the other under the name "rw".
+//
+//   fx.Provide(
+//      fx.Annotated{
+//         Name: "ro",
+//         Fn: NewReadOnlyConnection,
+//      },
+//      fx.Annotated{
+//         Name: "rw",
+//         Fn: NewReadOnlyConnection,
+//      },
+//   )
+//
+// This option cannot be provided for constructors which produce result
+// objects.
+//
+type Annotated struct {
+	Name string
+	Fn   interface{}
+}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -83,7 +83,7 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 			),
 			fx.Populate(&in),
 		)
-		assert.Contains(t, app.Err().Error(), "fx.Annotated should be passed to fx.Provide directly, it should not be returned by the constructor")
+		assert.Contains(t, app.Err().Error(), "fx.Annotated should be passed to fx.Provide directly", "expected error when return types were annotated")
 	})
 
 	t.Run("Result Type", func(t *testing.T) {
@@ -97,6 +97,6 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 				},
 			),
 		)
-		assert.Contains(t, app.Err().Error(), "embeds a dig.In")
+		assert.Contains(t, app.Err().Error(), "embeds a dig.In", "expected error when result types were annotated")
 	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -68,7 +68,7 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 		return &a{name: "foo"}
 	}
 
-	t.Run("Provided", func(t *testing.T) {
+	t.Run("In Constructor", func(t *testing.T) {
 		var in in
 		app := fx.New(
 			fx.Provide(
@@ -82,5 +82,19 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 			fx.Populate(&in),
 		)
 		assert.Error(t, app.Err(), "expected to return an error for wrong usage")
+	})
+
+	t.Run("Result Type", func(t *testing.T) {
+		app := fx.New(
+			fx.Provide(
+				fx.Annotated{
+					Name: "foo",
+					Fn: func() in {
+						return in{A: &a{name: "foo"}}
+					},
+				},
+			),
+		)
+		assert.Error(t, app.Err(), "expected error when return types were annotated")
 	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -34,6 +34,7 @@ func TestAnnotated(t *testing.T) {
 	}
 	type in struct {
 		fx.In
+
 		A *a `name:"foo"`
 	}
 	newA := func() *a {
@@ -62,6 +63,7 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 	}
 	type in struct {
 		fx.In
+
 		A *a `name:"foo"`
 	}
 	newA := func() *a {
@@ -81,7 +83,7 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 			),
 			fx.Populate(&in),
 		)
-		assert.Error(t, app.Err(), "expected to return an error for wrong usage")
+		assert.Contains(t, app.Err().Error(), "fx.Annotated should be passed to fx.Provide directly, it should not be returned by the constructor")
 	})
 
 	t.Run("Result Type", func(t *testing.T) {
@@ -95,6 +97,6 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 				},
 			),
 		)
-		assert.Error(t, app.Err(), "expected error when return types were annotated")
+		assert.Contains(t, app.Err().Error(), "embeds a dig.In")
 	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestAnnotated(t *testing.T) {
+	type a struct {
+		name string
+	}
+	type in struct {
+		fx.In
+		A *a `name:"foo"`
+	}
+	newA := func() *a {
+		return &a{name: "foo"}
+	}
+	t.Run("Provided", func(t *testing.T) {
+		var in in
+		app := fxtest.New(t,
+			fx.Provide(
+				fx.Annotated{
+					Name: "foo",
+					Fn:   newA,
+				},
+			),
+			fx.Populate(&in),
+		)
+		defer app.RequireStart().RequireStop()
+		assert.NotNil(t, in.A, "expected in.A to be injected")
+		assert.Equal(t, "foo", in.A.name, "expected to get a type 'a' of name 'foo'")
+	})
+}
+
+func TestAnnotatedWrongUsage(t *testing.T) {
+	type a struct {
+		name string
+	}
+	type in struct {
+		fx.In
+		A *a `name:"foo"`
+	}
+	newA := func() *a {
+		return &a{name: "foo"}
+	}
+
+	t.Run("Provided", func(t *testing.T) {
+		var in in
+		app := fx.New(
+			fx.Provide(
+				func() fx.Annotated {
+					return fx.Annotated{
+						Name: "foo",
+						Fn:   newA,
+					}
+				},
+			),
+			fx.Populate(&in),
+		)
+		assert.Error(t, app.Err(), "expected to return an error for wrong usage")
+	})
+}


### PR DESCRIPTION
Picking off where #633 was left out for #610. I believe once this is implemented #653 can be reasoned about in a better way.

I've also tried to incorporate all code review comments from #633 and also added some documentation.