### PR TITLE
Annotated: Rename Fn to Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add `fx.Annotated` to allow users to provide named values without creating a new constructor.
+- Add `fx.Annotated` to allow users to provide named values without creating a
+  new constructor.
 
 ## [1.8.0] - 2018-11-06
 ### Added

--- a/annotated.go
+++ b/annotated.go
@@ -20,33 +20,35 @@
 
 package fx
 
-// Annotated is a special provide type that specifies that all values produced by a
-// constructor should have the given name. See also In and Out documentation
-// about Named Values.
-//
-// Given,
-//
-//   func NewReadOnlyConnection(...) (*Connection, error)
-//   func NewReadWriteConnection(...) (*Connection, error)
-//
-// The following will provide two connections to the container: one under the
-// name "ro" and the other under the name "rw".
-//
-//   fx.Provide(
-//      fx.Annotated{
-//         Name: "ro",
-//         Fn: NewReadOnlyConnection,
-//      },
-//      fx.Annotated{
-//         Name: "rw",
-//         Fn: NewReadOnlyConnection,
-//      },
-//   )
-//
-// This option cannot be provided for constructors which produce result
-// objects.
-//
+// Annotated annotates a constructor provided to Fx with additional options.
+// Annotated cannot be used with constructors which produce fx.Out objects.
 type Annotated struct {
+	// If specified, this will be used as the name of the value. For more
+	// information on named values, see the documentation for the fx.Out type.
+	//
+	// The following,
+	//
+	//   func NewReadOnlyConnection(...) (*Connection, error)
+	//
+	//   fx.Provide(fx.Annotated{
+	//     Name: "ro",
+	//     Target: NewReadOnlyConnection,
+	//   })
+	//
+	// Is equivalent to,
+	//
+	//   type result struct {
+	//     fx.Out
+	//
+	//     Connection *Connection `name:"ro"`
+	//   }
+	//
+	//   fx.Provide(func(...) (Result, error) {
+	//     conn, err := NewReadOnlyConnection(...)
+	//     return Result{Connection: conn}, err
+	//   })
 	Name string
-	Fn   interface{}
+
+	// Target is the constructor being annotated with fx.Annotated.
+	Target interface{}
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -45,8 +45,8 @@ func TestAnnotated(t *testing.T) {
 		app := fxtest.New(t,
 			fx.Provide(
 				fx.Annotated{
-					Name: "foo",
-					Fn:   newA,
+					Name:   "foo",
+					Target: newA,
 				},
 			),
 			fx.Populate(&in),
@@ -76,8 +76,8 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 			fx.Provide(
 				func() fx.Annotated {
 					return fx.Annotated{
-						Name: "foo",
-						Fn:   newA,
+						Name:   "foo",
+						Target: newA,
 					}
 				},
 			),
@@ -91,7 +91,7 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 			fx.Provide(
 				fx.Annotated{
 					Name: "foo",
-					Fn: func() in {
+					Target: func() in {
 						return in{A: &a{name: "foo"}}
 					},
 				},

--- a/app.go
+++ b/app.go
@@ -483,7 +483,7 @@ func (app *App) provide(constructor interface{}) {
 	}
 
 	if a, ok := constructor.(Annotated); ok {
-		if err := app.container.Provide(a.Fn, dig.Name(a.Name)); err != nil {
+		if err := app.container.Provide(a.Target, dig.Name(a.Name)); err != nil {
 			app.err = err
 		}
 		return


### PR DESCRIPTION
This renames the Fn field to Target to account for the possibility of
wanting to provide things besides functions with `fx.Provide` and
`fx.Annotated`.

This also alters the docs for Annotated to account for value group
support in the future by decoupling them from the idea of named values.