### PR TITLE
fx.Annotated: Support Value Groups

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -21,33 +21,43 @@
 package fx
 
 // Annotated annotates a constructor provided to Fx with additional options.
+//
+// For example,
+//
+//   func NewReadOnlyConnection(...) (*Connection, error)
+//
+//   fx.Provide(fx.Annotated{
+//     Name: "ro",
+//     Target: NewReadOnlyConnection,
+//   })
+//
+// Is equivalent to,
+//
+//   type result struct {
+//     fx.Out
+//
+//     Connection *Connection `name:"ro"`
+//   }
+//
+//   fx.Provide(func(...) (Result, error) {
+//     conn, err := NewReadOnlyConnection(...)
+//     return Result{Connection: conn}, err
+//   })
+//
 // Annotated cannot be used with constructors which produce fx.Out objects.
 type Annotated struct {
-	// If specified, this will be used as the name of the value. For more
-	// information on named values, see the documentation for the fx.Out type.
+	// If specified, this will be used as the name for all non-error values returned
+	// by the constructor. For more information on named values, see the documentation
+	// for the fx.Out type.
 	//
-	// The following,
-	//
-	//   func NewReadOnlyConnection(...) (*Connection, error)
-	//
-	//   fx.Provide(fx.Annotated{
-	//     Name: "ro",
-	//     Target: NewReadOnlyConnection,
-	//   })
-	//
-	// Is equivalent to,
-	//
-	//   type result struct {
-	//     fx.Out
-	//
-	//     Connection *Connection `name:"ro"`
-	//   }
-	//
-	//   fx.Provide(func(...) (Result, error) {
-	//     conn, err := NewReadOnlyConnection(...)
-	//     return Result{Connection: conn}, err
-	//   })
+	// A name option may not be provided if a group option is provided.
 	Name string
+
+	// If specified, this will be used as the group name for all non-error values returned
+	// by the constructor. For more information on value groups, see the package documentation.
+	//
+	// A group option may not be provided if a name option is provided.
+	Group string
 
 	// Target is the constructor being annotated with fx.Annotated.
 	Target interface{}

--- a/app.go
+++ b/app.go
@@ -482,8 +482,8 @@ func (app *App) provide(constructor interface{}) {
 		return
 	}
 
-	var opts []dig.ProvideOption
 	if a, ok := constructor.(Annotated); ok {
+		var opts []dig.ProvideOption
 		switch {
 		case len(a.Group) > 0 && len(a.Name) > 0:
 			app.err = fmt.Errorf("fx.Annotate may not specify both name and group for %v", constructor)

--- a/app.go
+++ b/app.go
@@ -483,8 +483,17 @@ func (app *App) provide(constructor interface{}) {
 	}
 
 	if a, ok := constructor.(Annotated); ok {
-		if err := app.container.Provide(a.Target, dig.Name(a.Name)); err != nil {
-			app.err = err
+		switch {
+		case len(a.Group) > 0 && len(a.Name) > 0:
+			app.err = fmt.Errorf("fx.Annotate may not specify both name and group for %v", constructor)
+		case len(a.Name) > 0:
+			if err := app.container.Provide(a.Target, dig.Name(a.Name)); err != nil {
+				app.err = err
+			}
+		case len(a.Group) > 0:
+			if err := app.container.Provide(a.Target, dig.Group(a.Group)); err != nil {
+				app.err = err
+			}
 		}
 		return
 	}

--- a/app.go
+++ b/app.go
@@ -482,18 +482,21 @@ func (app *App) provide(constructor interface{}) {
 		return
 	}
 
+	var opts []dig.ProvideOption
 	if a, ok := constructor.(Annotated); ok {
 		switch {
 		case len(a.Group) > 0 && len(a.Name) > 0:
 			app.err = fmt.Errorf("fx.Annotate may not specify both name and group for %v", constructor)
+			return
 		case len(a.Name) > 0:
-			if err := app.container.Provide(a.Target, dig.Name(a.Name)); err != nil {
-				app.err = err
-			}
+			opts = append(opts, dig.Name(a.Name))
 		case len(a.Group) > 0:
-			if err := app.container.Provide(a.Target, dig.Group(a.Group)); err != nil {
-				app.err = err
-			}
+			opts = append(opts, dig.Group(a.Group))
+
+		}
+
+		if err := app.container.Provide(a.Target, opts...); err != nil {
+			app.err = err
 		}
 		return
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -112,9 +112,11 @@ func TestNewApp(t *testing.T) {
 		type B struct {
 			In
 
-			Foo A `name:"foo"`
-			Bar A `name:"bar"`
+			Foo  A   `name:"foo"`
+			Bar  A   `name:"bar"`
+			Foos []A `group:"foo"`
 		}
+
 		app := fxtest.New(t,
 			Provide(
 				Annotated{
@@ -125,11 +127,42 @@ func TestNewApp(t *testing.T) {
 					Target: func() A { return A{} },
 					Name:   "bar",
 				},
+				Annotated{
+					Target: func() A { return A{} },
+					Group:  "foo",
+				},
 			),
 			Invoke(
 				func(b B) {
 					assert.NotNil(t, b.Foo)
 					assert.NotNil(t, b.Bar)
+					assert.Len(t, b.Foos, 1)
+				},
+			),
+		)
+
+		defer app.RequireStart().RequireStop()
+		require.NoError(t, app.Err())
+	})
+
+	t.Run("ProvidesWithEmptyAnnotate", func(t *testing.T) {
+		type A struct{}
+
+		type B struct {
+			In
+
+			Foo A
+		}
+
+		app := fxtest.New(t,
+			Provide(
+				Annotated{
+					Target: func() A { return A{} },
+				},
+			),
+			Invoke(
+				func(b B) {
+					assert.NotNil(t, b.Foo)
 				},
 			),
 		)

--- a/glide.lock
+++ b/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/dig
-  version: 27eb30e15ef3e7f67cd86f2b65c618e3e308c104
+  version: 7ff117f761a3f1b3eb521945c17a1091438eb6de
   subpackages:
   - internal/digreflect
   - internal/dot

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: go.uber.org/multierr
   version: ^1
 - package: go.uber.org/dig
-  version: ^1.5 # At least version 1.5 is required for the DeferAcyclicVerification functionality.
+  version: ^1.7 # At least version 1.7 is required for fx/dig `Group` support.
 testImport:
 - package: github.com/stretchr/testify
   version: ^1


### PR DESCRIPTION
This adds support for value groups to fx.Annotated, passing the
relevant Dig ProvideOption if the `Group` field is set. The new option
was added in Dig 1.7 so this also raises the lower version constraint
for Dig.

See also #610.