### PR TITLE
README: Remove "Supported Go Versions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ This library is `v1` and follows [SemVer](http://semver.org/) strictly.
 
 No breaking changes will be made to exported APIs before `v2.0.0`.
 
-**Supported Go versions: 1.9, 1.10**
-
 This project follows the [Go Release Policy][release-policy]. Each major
 version of Go is supported until there are two newer major releases.
 


### PR DESCRIPTION
This removes the "Supported Go Versions" section of the README because
it was inaccurate and keeping it in sync with the .travis.yml or new Go
releases is unnecessary. Especially since right below that we mention
that we follow the Go Release Policy for Go version support.