### PR TITLE
Drop 1.10 and tip, add 1.12 go. Swap to go lint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 
 go_import_path: go.uber.org/fx
 go:
-  - "1.10.4"
   - "1.11"
-  - tip
+  - "1.12"
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifdef SHOULD_LINT
 	@echo "Installing test dependencies for vet..."
 	@go test -i $(PKGS)
 	@echo "Checking vet..."
-	@$(foreach dir,$(PKG_FILES),go tool vet $(VET_RULES) $(dir) 2>&1 | tee -a lint.log;)
+	@go vet ./...| tee -a lint.log
 	@echo "Checking lint..."
 	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."


### PR DESCRIPTION
Tip takes forever and this matches versions with dig.

Mirrors https://github.com/uber-go/dig/pull/234