### PR TITLE
Return an error when attempting to shutdown without any Done channels

### DIFF
--- a/shutdown.go
+++ b/shutdown.go
@@ -21,12 +21,14 @@
 package fx
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
 
 // Shutdowner provides a method that can manually trigger the shutdown of the
-// application by sending a signal to all open Done channels. Shutdowner works
+// application by sending a signal to all open Done channels. If no Done channels
+// have been opened, calling Shutdown will return an error. The Shutdowner works
 // on applications using Run as well as Start, Done, and Stop. The Shutdowner is
 // provided to all Fx applications.
 type Shutdowner interface {
@@ -57,6 +59,10 @@ func (app *App) shutdowner() Shutdowner {
 }
 
 func (app *App) broadcastSignal(signal os.Signal) error {
+	if len(app.dones) < 1 {
+		return errors.New("attempted to shutdown without any Done channels")
+	}
+
 	app.donesMu.RLock()
 	defer app.donesMu.RUnlock()
 

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -65,4 +65,15 @@ func TestShutdown(t *testing.T) {
 			"unexpected error returned when shutdown is called with a blocked channel")
 		assert.NotNil(t, <-done, "done channel did not receive signal")
 	})
+
+	t.Run("ErrorOnNoDoneChannels", func(t *testing.T) {
+		var s fx.Shutdowner
+		app := fxtest.New(
+			t,
+			fx.Populate(&s),
+		)
+		defer app.RequireStart().RequireStop()
+
+		assert.EqualError(t, s.Shutdown(), "attempted to shutdown without any Done channels")
+	})
 }


### PR DESCRIPTION
If `Shutdowner.Shutdown()` is called before any Done channels have been opened — say in an `fx.Invoke` option when using `Run()` — the Shutdowner will silently fail to initiate the `App.Stop` process. 

Change the Shutdowner to return an error if no Done channels yet exist; this will cause the app initialization to fail if `Shutdown()` is called in an Invoke and will also return a legible error to users. 