### PR TITLE
Show in the README.md how go mod can be used instead of glide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ We recommend locking to [SemVer](http://semver.org/) range `^1` using [Glide](ht
 glide get 'go.uber.org/fx#^1'
 ```
 
+Alternatively you can add it as a dependency using [go mod](https://github.com/golang/go/wiki/Modules):
+
+```
+go get github.com/uber-go/fx@v1
+```
+
 ## Stability
 
 This library is `v1` and follows [SemVer](http://semver.org/) strictly.


### PR DESCRIPTION
As `glide` is now _unmantained_ I'd like to show the alternative of using `go mod` in the `README.md`