### PR TITLE
Add canonical import path directive

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -36,4 +36,4 @@
 // To test functions that use the Lifecycle type or to write end-to-end tests
 // of your Fx application, use the helper functions and types provided by the
 // go.uber.org/fx/fxtest package.
-package fx
+package fx // import "go.uber.org/fx"


### PR DESCRIPTION
Installing Fx only works if you use the vanity import path `go.uber.org/fx`.
PR #683 highlighted that not only did we not have a canonical import
path directive, but our README listed the wrong import path for
installation with Go modules.

This adds a canonical import path directive, pointing to the vanity import
path, to fix this issue.