### PR TITLE
Drop closure-based fx.Option implementation

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,6 +49,8 @@ const DefaultTimeout = 15 * time.Second
 // popularized by Rob Pike. If you're unfamiliar with this style, see
 // https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html.
 type Option interface {
+	fmt.Stringer
+
 	apply(*App)
 }
 


### PR DESCRIPTION
We have a handful of `fx.Option` implementations based on `optionFunc`
which captures value using a closure. That makes them opaque and
uninspectable.

This change drops the `optionFunc` type in favor of concrete
implementations for all `fx.Option`s. For further inspection, each such
instance includes a `String()` implementation.

Note that we've intentionally kept `fmt.Stringer` out of the `fx.Option`
interface: We don't want to commit to having options printable but it's
nicer if they are.