### PR TITLE
Error reporting: Include Provide/Invoke stack traces

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -20,6 +20,13 @@
 
 package fx
 
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/fx/internal/fxreflect"
+)
+
 // Annotated annotates a constructor provided to Fx with additional options.
 //
 // For example,
@@ -61,4 +68,18 @@ type Annotated struct {
 
 	// Target is the constructor being annotated with fx.Annotated.
 	Target interface{}
+}
+
+func (a Annotated) String() string {
+	var fields []string
+	if len(a.Name) > 0 {
+		fields = append(fields, fmt.Sprintf("Name: %q", a.Name))
+	}
+	if len(a.Group) > 0 {
+		fields = append(fields, fmt.Sprintf("Group: %q", a.Group))
+	}
+	if a.Target != nil {
+		fields = append(fields, fmt.Sprintf("Target: %v", fxreflect.FuncName(a.Target)))
+	}
+	return fmt.Sprintf("fx.Annotated{%v}", strings.Join(fields, ", "))
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 )
@@ -83,7 +84,20 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 			),
 			fx.Populate(&in),
 		)
-		assert.Contains(t, app.Err().Error(), "fx.Annotated should be passed to fx.Provide directly", "expected error when return types were annotated")
+
+		err := app.Err()
+		require.Error(t, err)
+
+		// Example:
+		// fx.Annotated should be passed to fx.Provide directly, it should not be returned by the constructor: fx.Provide received go.uber.org/fx_test.TestAnnotatedWrongUsage.func2.1() from:
+		// go.uber.org/fx_test.TestAnnotatedWrongUsage.func2
+		//         /.../fx/annotated_test.go:76
+		// testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
+		assert.Contains(t, err.Error(), "fx.Annotated should be passed to fx.Provide directly, it should not be returned by the constructor")
+		assert.Contains(t, err.Error(), "fx.Provide received go.uber.org/fx_test.TestAnnotatedWrongUsage")
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestAnnotatedWrongUsage")
+		assert.Contains(t, err.Error(), "/fx/annotated_test.go")
 	})
 
 	t.Run("Result Type", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -100,3 +100,58 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 		assert.Contains(t, app.Err().Error(), "embeds a dig.In", "expected error when result types were annotated")
 	})
 }
+
+func TestAnnotatedString(t *testing.T) {
+	tests := []struct {
+		desc string
+		give fx.Annotated
+		want string
+	}{
+		{
+			desc: "empty",
+			give: fx.Annotated{},
+			want: "fx.Annotated{}",
+		},
+		{
+			desc: "name",
+			give: fx.Annotated{Name: "foo"},
+			want: `fx.Annotated{Name: "foo"}`,
+		},
+		{
+			desc: "group",
+			give: fx.Annotated{Group: "foo"},
+			want: `fx.Annotated{Group: "foo"}`,
+		},
+		{
+			desc: "name and group",
+			give: fx.Annotated{Name: "foo", Group: "bar"},
+			want: `fx.Annotated{Name: "foo", Group: "bar"}`,
+		},
+		{
+			desc: "target",
+			give: fx.Annotated{Target: func() {}},
+			want: "fx.Annotated{Target: go.uber.org/fx_test.TestAnnotatedString.func1()}",
+		},
+		{
+			desc: "name and target",
+			give: fx.Annotated{Name: "foo", Target: func() {}},
+			want: `fx.Annotated{Name: "foo", Target: go.uber.org/fx_test.TestAnnotatedString.func2()}`,
+		},
+		{
+			desc: "group and target",
+			give: fx.Annotated{Group: "foo", Target: func() {}},
+			want: `fx.Annotated{Group: "foo", Target: go.uber.org/fx_test.TestAnnotatedString.func3()}`,
+		},
+		{
+			desc: "name, group and target",
+			give: fx.Annotated{Name: "foo", Group: "bar", Target: func() {}},
+			want: `fx.Annotated{Name: "foo", Group: "bar", Target: go.uber.org/fx_test.TestAnnotatedString.func4()}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.give.String())
+		})
+	}
+}

--- a/app.go
+++ b/app.go
@@ -622,7 +622,7 @@ func (app *App) provide(p provide) {
 	}
 
 	if err := app.container.Provide(constructor); err != nil {
-		app.err = err
+		app.err = fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", fxreflect.FuncName(constructor), p.Stack, err)
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -615,7 +615,11 @@ func (app *App) provide(p provide) {
 			t := ft.Out(i)
 
 			if t == reflect.TypeOf(Annotated{}) {
-				app.err = fmt.Errorf("fx.Annotated should be passed to fx.Provide directly, it should not be returned by the constructor: fx.Provide received %v", constructor)
+				app.err = fmt.Errorf(
+					"fx.Annotated should be passed to fx.Provide directly, "+
+						"it should not be returned by the constructor: "+
+						"fx.Provide received %v from:\n%+v",
+					fxreflect.FuncName(constructor), p.Stack)
 				return
 			}
 		}

--- a/app.go
+++ b/app.go
@@ -644,7 +644,7 @@ func (app *App) executeInvokes() error {
 		}
 
 		if err != nil {
-			app.logger.Printf("Error during %q invoke: %v", fname, err)
+			app.logger.Printf("fx.Invoke(%v) called from:\n%+vFailed: %v", fname, i.Stack, err)
 			return err
 		}
 	}

--- a/app.go
+++ b/app.go
@@ -587,20 +587,22 @@ func (app *App) provide(p provide) {
 		return
 	}
 
-	if a, ok := constructor.(Annotated); ok {
+	if ann, ok := constructor.(Annotated); ok {
 		var opts []dig.ProvideOption
 		switch {
-		case len(a.Group) > 0 && len(a.Name) > 0:
-			app.err = fmt.Errorf("fx.Annotate may not specify both name and group for %v", constructor)
+		case len(ann.Group) > 0 && len(ann.Name) > 0:
+			app.err = fmt.Errorf(
+				"fx.Annotated may specify only one of Name or Group: received %v from:\n%+v",
+				ann, p.Stack)
 			return
-		case len(a.Name) > 0:
-			opts = append(opts, dig.Name(a.Name))
-		case len(a.Group) > 0:
-			opts = append(opts, dig.Group(a.Group))
+		case len(ann.Name) > 0:
+			opts = append(opts, dig.Name(ann.Name))
+		case len(ann.Group) > 0:
+			opts = append(opts, dig.Group(ann.Group))
 
 		}
 
-		if err := app.container.Provide(a.Target, opts...); err != nil {
+		if err := app.container.Provide(ann.Target, opts...); err != nil {
 			app.err = err
 		}
 		return

--- a/app.go
+++ b/app.go
@@ -581,7 +581,9 @@ func (app *App) provide(p provide) {
 	app.logger.PrintProvide(constructor)
 
 	if _, ok := constructor.(Option); ok {
-		app.err = fmt.Errorf("fx.Option should be passed to fx.New directly, not to fx.Provide: fx.Provide received %v", constructor)
+		app.err = fmt.Errorf("fx.Option should be passed to fx.New directly, "+
+			"not to fx.Provide: fx.Provide received %v from:\n%+v",
+			constructor, p.Stack)
 		return
 	}
 

--- a/app.go
+++ b/app.go
@@ -603,7 +603,7 @@ func (app *App) provide(p provide) {
 		}
 
 		if err := app.container.Provide(ann.Target, opts...); err != nil {
-			app.err = err
+			app.err = fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", ann, p.Stack, err)
 		}
 		return
 	}

--- a/app.go
+++ b/app.go
@@ -638,7 +638,9 @@ func (app *App) executeInvokes() error {
 
 		var err error
 		if _, ok := fn.(Option); ok {
-			err = fmt.Errorf("fx.Option should be passed to fx.New directly, not to fx.Invoke: fx.Invoke received %v", fn)
+			err = fmt.Errorf("fx.Option should be passed to fx.New directly, "+
+				"not to fx.Invoke: fx.Invoke received %v from:\n%+v",
+				fn, i.Stack)
 		} else {
 			err = app.container.Invoke(fn)
 		}

--- a/app_test.go
+++ b/app_test.go
@@ -223,6 +223,23 @@ func TestNewApp(t *testing.T) {
 		assert.Contains(t, err.Error(), "fx/app_test.go")
 		assert.Contains(t, err.Error(), "Failed: must provide constructor function")
 	})
+
+	t.Run("ErrorProviding", func(t *testing.T) {
+		err := NewForTest(t, Provide(42)).Err()
+		require.Error(t, err)
+
+		// Example:
+		// fx.Provide(..) from:
+		//     go.uber.org/fx_test.TestNewApp.func8
+		//         /.../fx/app_test.go:206
+		//     testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
+		//     Failed: must provide constructor function, got 42 (type int)
+		assert.Contains(t, err.Error(), "fx.Provide(42) from:")
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestNewApp")
+		assert.Contains(t, err.Error(), "fx/app_test.go")
+		assert.Contains(t, err.Error(), "Failed: must provide constructor function")
+	})
 }
 
 type errHandlerFunc func(error)

--- a/app_test.go
+++ b/app_test.go
@@ -586,8 +586,16 @@ func TestAppStart(t *testing.T) {
 		require.Error(t, err, "expected start failure")
 		assert.Equal(t, err, newErr, "start should return the same error fx.New encountered")
 
+		// Example
+		// fx.Option should be passed to fx.New directly, not to fx.Invoke: fx.Invoke received fx.Invoke(go.uber.org/fx_test.TestAppStart.func6.2()) from:
+		// go.uber.org/fx_test.TestAppStart.func6
+		//         /.../fx/app_test.go:579
+		// testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
 		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Invoke")
 		assert.Contains(t, err.Error(), "fx.Invoke received fx.Invoke(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "/fx/app_test.go")
 	})
 
 	t.Run("ProvidingOptionsShouldFail", func(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -190,6 +190,16 @@ func TestNewApp(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err)
+
+		// fx.Annotated may specify only one of Name or Group: received fx.Annotated{Name: "foo", Group: "bar", Target: go.uber.org/fx_test.TestAnnotatedWithGroupAndName.func1()} from:
+		// go.uber.org/fx_test.TestAnnotatedWithGroupAndName
+		//         /.../fx/annotated_test.go:164
+		// testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
+		assert.Contains(t, err.Error(), "fx.Annotated may specify only one of Name or Group:")
+		assert.Contains(t, err.Error(), `received fx.Annotated{Name: "foo", Group: "bar", Target: go.uber.org/fx_test.TestNewApp`)
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestNewApp")
+		assert.Contains(t, err.Error(), "fx/app_test.go")
 	})
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -520,10 +520,25 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("InvokeNonFunction", func(t *testing.T) {
-		app := NewForTest(t, Invoke(struct{}{}))
+		spy := printerSpy{&bytes.Buffer{}}
+
+		app := New(Logger(spy), Invoke(struct{}{}))
 		err := app.Err()
 		require.Error(t, err, "expected start failure")
 		assert.Contains(t, err.Error(), "can't invoke non-function")
+
+		// Example
+		// fx.Invoke({}) called from:
+		// go.uber.org/fx_test.TestAppStart.func4
+		//         /.../fx/app_test.go:525
+		// testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
+		// Failed: can't invoke non-function {} (type struct {})
+		output := spy.String()
+		assert.Contains(t, output, "fx.Invoke({}) called from:")
+		assert.Contains(t, output, "go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, output, "fx/app_test.go")
+		assert.Contains(t, output, "Failed: can't invoke non-function")
 	})
 
 	t.Run("ProvidingAProvideShouldFail", func(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -201,6 +201,28 @@ func TestNewApp(t *testing.T) {
 		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestNewApp")
 		assert.Contains(t, err.Error(), "fx/app_test.go")
 	})
+
+	t.Run("ErrorProvidingAnnotated", func(t *testing.T) {
+		app := NewForTest(t, Provide(Annotated{
+			Target: 42, // not a constructor
+			Name:   "foo",
+		}))
+
+		err := app.Err()
+		require.Error(t, err)
+
+		// Example:
+		// fx.Provide(fx.Annotated{...}) from:
+		//     go.uber.org/fx_test.TestNewApp.func8
+		//         /.../fx/app_test.go:206
+		//     testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
+		//     Failed: must provide constructor function, got 42 (type int)
+		assert.Contains(t, err.Error(), `fx.Provide(fx.Annotated{Name: "foo", Target: 42}) from:`)
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestNewApp")
+		assert.Contains(t, err.Error(), "fx/app_test.go")
+		assert.Contains(t, err.Error(), "Failed: must provide constructor function")
+	})
 }
 
 type errHandlerFunc func(error)

--- a/app_test.go
+++ b/app_test.go
@@ -494,8 +494,17 @@ func TestAppStart(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err, "expected start failure")
+
+		// Example:
+		// fx.Option should be passed to fx.New directly, not to fx.Provide: fx.Provide received fx.Provide(go.uber.org/fx_test.TestAppStart.func5.2(), go.uber.org/fx_test.TestAppStart.func5.3()) from:
+		// go.uber.org/fx_test.TestAppStart.func5
+		//         /.../fx/app_test.go:550
+		// testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
 		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Provide")
 		assert.Contains(t, err.Error(), "fx.Provide received fx.Provide(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "fx/app_test.go")
 	})
 
 	t.Run("InvokingAnInvokeShouldFail", func(t *testing.T) {
@@ -540,8 +549,17 @@ func TestAppStart(t *testing.T) {
 		)
 		err := app.Err()
 		require.Error(t, err, "expected start failure")
+
+		// Example:
+		// fx.Annotated should be passed to fx.Provide directly, it should not be returned by the constructor: fx.Provide received go.uber.org/fx_test.TestAnnotatedWrongUsage.func2.1() from:
+		// go.uber.org/fx_test.TestAnnotatedWrongUsage.func2
+		//         /.../fx/annotated_test.go:76
+		// testing.tRunner
+		//         /.../go/1.13.3/libexec/src/testing/testing.go:909
 		assert.Contains(t, err.Error(), "fx.Option should be passed to fx.New directly, not to fx.Provide")
 		assert.Contains(t, err.Error(), "fx.Provide received fx.Options(fx.Provide(go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "go.uber.org/fx_test.TestAppStart")
+		assert.Contains(t, err.Error(), "fx/app_test.go")
 	})
 }
 


### PR DESCRIPTION
A number of errors we report during start up are fairly opaque because
they only reference the target function, not where the bad invocation
was made.

This is extra problematic if the target function was generated via
reflection. For example, @klnusbaum reported the following error which
was impossible to debug with just Fx.

    fx.Option should be passed to fx.New directly, not to fx.Provide:
    fx.Provide received fx.Provide(reflect.makeFuncStub())

To help debug issues like this, this PR changes Fx to capture a call
stack whenever `fx.Provide` or `fx.Invoke` are called. These stack
traces are later reported in the error messages for various errors
thrown during program startup.

With this change, the error above becomes similar to the following.

    fx.Option should be passed to fx.New directly, not to fx.Provide:
    fx.Provide received fx.Provide(reflect.makeFuncStub()) from:
    path/to/my/module.init
            /.../my/module.go:50
    path/to/your/app.main
            /.../your/app/main.go:42

Depends on #687
Ref T4487249

---

**Each commit should be reviewed separately.**