### PR TITLE
Add fx.Optional for marking optional params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Back to development.
+- Added `fx.Optional` embedded type to mark parameter structs as optional.
 
 ## [1.10.0] - 2019-11-20
 ### Added

--- a/example_test.go
+++ b/example_test.go
@@ -30,6 +30,13 @@ import (
 	"go.uber.org/fx"
 )
 
+// LoggerParams is an optional type for configuring the Logger.
+type LoggerParams struct {
+	fx.Optional
+
+	Prefix string
+}
+
 // NewLogger constructs a logger. It's just a regular Go function, without any
 // special relationship to Fx.
 //
@@ -45,8 +52,8 @@ import (
 //
 // By default, Fx applications only allow one constructor for each type. See
 // the documentation of the In and Out types for ways around this restriction.
-func NewLogger() *log.Logger {
-	logger := log.New(os.Stdout, "" /* prefix */, 0 /* flags */)
+func NewLogger(p LoggerParams) *log.Logger {
+	logger := log.New(os.Stdout, p.Prefix, 0 /* flags */)
 	logger.Print("Executing NewLogger.")
 	return logger
 }

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,6 @@ require (
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 	golang.org/x/tools v0.0.0-20191114200427-caa0b0f7d508 // indirect
 )
+
+// TODO: remove once dig.Optional is available in go.uber.org/dig
+replace go.uber.org/dig => github.com/orishu/dig v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/orishu/dig v0.0.1 h1:BA0mCH3q6DB2lXfKdZ7Is3AcM70yIrl/SWfSheXSY/w=
+github.com/orishu/dig v0.0.1/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/inout.go
+++ b/inout.go
@@ -252,3 +252,26 @@ type In struct{ dig.In }
 // different types: if a group of constructors each returns type T, parameter
 // structs consuming the group must use a field of type []T.
 type Out struct{ dig.Out }
+
+// Optional can be embedded in a constructor's parameter struct to take
+// advantage of advanced dependency injection features.
+//
+// Optional Parameters
+//
+// Fx constructors declare their dependencies as function parameters and fx.In
+// structs.  With optional parameter structs, users can either provide or not
+// provide a value without breaking the dependency chain.  In the example
+// below, the NewLogger provider may use a LoggerParams struct if provided.
+// Otherwise, it receives a zero value as parameter.
+//
+//   type LoggerParams struct {
+//     fx.Optional
+//
+//     Prefix string
+//   }
+//
+//   func NewLogger(p LoggerParams) *log.Logger {
+//     return log.New(os.Stdout, p.Prefix, 0 /* flags */)
+//   }
+//
+type Optional struct{ dig.Optional }

--- a/inout_test.go
+++ b/inout_test.go
@@ -50,29 +50,59 @@ func TestOptionalTypes(t *testing.T) {
 	type bar struct{}
 	newBar := func() *bar { return &bar{} }
 
+	type baz struct {
+		fx.Optional
+	}
+	newBaz := func() *baz { return &baz{} }
+
 	type in struct {
 		fx.In
 
 		Foo *foo
 		Bar *bar `optional:"true"`
+		Baz *baz
 	}
 
-	t.Run("NotProvided", func(t *testing.T) {
+	t.Run("NotProvidedField", func(t *testing.T) {
 		ran := false
 		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
 			assert.Nil(t, in.Bar, "bar was optional and not provided, expected nil")
+			assert.Nil(t, in.Baz, "baz was optional and not provided, expected nil")
 			ran = true
 		}))
 		app.RequireStart().RequireStop()
 		assert.True(t, ran, "expected invoke to run")
 	})
 
-	t.Run("Provided", func(t *testing.T) {
+	t.Run("ProvidedField", func(t *testing.T) {
 		ran := false
-		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
+		app := fxtest.New(t, fx.Provide(newFoo, newBar, newBaz), fx.Invoke(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
 			assert.NotNil(t, in.Bar, "bar was optional and provided, expected not nil")
+			assert.NotNil(t, in.Baz, "baz was optional and provided, expected not nil")
+			ran = true
+		}))
+		app.RequireStart().RequireStop()
+		assert.True(t, ran, "expected invoke to run")
+	})
+
+	t.Run("NotProvidedParam", func(t *testing.T) {
+		ran := false
+		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(f *foo, b *baz) {
+			assert.NotNil(t, f, "foo was not optional and provided, expected not nil")
+			assert.Nil(t, b, "baz was optional and not provided, expected nil")
+			ran = true
+		}))
+		app.RequireStart().RequireStop()
+		assert.True(t, ran, "expected invoke to run")
+	})
+
+	t.Run("ProvidedParam", func(t *testing.T) {
+		ran := false
+		app := fxtest.New(t, fx.Provide(newFoo, newBaz), fx.Invoke(func(f *foo, b *baz) {
+			assert.NotNil(t, f, "foo was not optional and provided, expected not nil")
+			assert.NotNil(t, b, "baz was optional and provided, expected not nil")
 			ran = true
 		}))
 		app.RequireStart().RequireStop()


### PR DESCRIPTION
Realized that fx can be improved so certain parameters provided, while in their absence, a default parameter value would be used.

Dependency: pull request in uber-go/dig: [255](https://github.com/uber-go/dig/pull/255)

Add a new `fx.Optional` type that can be embedded in structs to mark
that the dependency on them is optional.