### PR TITLE
log: Add shared Spy implementation

### DIFF
--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -23,7 +23,6 @@ package fxlog
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 
@@ -32,18 +31,6 @@ import (
 	"go.uber.org/fx/internal/fxlog/foovendor"
 	sample "go.uber.org/fx/internal/fxlog/sample.git"
 )
-
-type spy struct {
-	*bytes.Buffer
-}
-
-func newSpy() *spy {
-	return &spy{bytes.NewBuffer(nil)}
-}
-
-func (s *spy) Printf(format string, is ...interface{}) {
-	fmt.Fprintln(s, fmt.Sprintf(format, is...))
-}
 
 // stubs the exit call, returns a function that restores a real exit function
 // and asserts that the stub was called.
@@ -62,7 +49,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestPrint(t *testing.T) {
-	sink := newSpy()
+	sink := new(Spy)
 	logger := &Logger{sink}
 
 	t.Run("printf", func(t *testing.T) {
@@ -158,14 +145,14 @@ func TestPrint(t *testing.T) {
 }
 
 func TestPanic(t *testing.T) {
-	sink := newSpy()
+	sink := new(Spy)
 	logger := &Logger{sink}
 	assert.Panics(t, func() { logger.Panic(errors.New("foo")) })
 	assert.Equal(t, "[Fx] foo\n", sink.String())
 }
 
 func TestFatal(t *testing.T) {
-	sink := newSpy()
+	sink := new(Spy)
 	logger := &Logger{sink}
 
 	undo := stubExit()

--- a/internal/fxlog/spy.go
+++ b/internal/fxlog/spy.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxlog
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Spy is an Fx Printer that captures logged statements. It may be used in
+// tests of Fx logs.
+type Spy struct {
+	msgs []string
+}
+
+var _ Printer = &Spy{}
+
+// Printf logs the given message, formatting it in printf-style.
+func (s *Spy) Printf(msg string, args ...interface{}) {
+	s.msgs = append(s.msgs, fmt.Sprintf(msg, args...))
+}
+
+// Messages returns a copy of all captured messages.
+func (s *Spy) Messages() []string {
+	msgs := make([]string, len(s.msgs))
+	copy(msgs, s.msgs)
+	return msgs
+}
+
+// String returns all logged messages as a single newline-delimited string.
+func (s *Spy) String() string {
+	if len(s.msgs) == 0 {
+		return ""
+	}
+
+	// trailing newline because all log entries should have a newline
+	// after them.
+	return strings.Join(s.msgs, "\n") + "\n"
+}
+
+// Reset clears all messages from the Spy.
+func (s *Spy) Reset() {
+	s.msgs = s.msgs[:0]
+}

--- a/internal/fxlog/spy_test.go
+++ b/internal/fxlog/spy_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxlog
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpy(t *testing.T) {
+	var s Spy
+
+	t.Run("empty spy", func(t *testing.T) {
+		assert.Empty(t, s.Messages(), "messages must be empty")
+		assert.Empty(t, s.String(), "string must be empty")
+	})
+
+	s.Printf("foo bar")
+	t.Run("unformatted message", func(t *testing.T) {
+		assert.Equal(t, []string{"foo bar"}, s.Messages(), "messages must match")
+		assert.Equal(t, "foo bar\n", s.String(), "string must match")
+	})
+
+	s.Printf("something went wrong: %v", errors.New("great sadness"))
+	t.Run("formatted message", func(t *testing.T) {
+		assert.Equal(t, []string{
+			"foo bar",
+			"something went wrong: great sadness",
+		}, s.Messages())
+		assert.Equal(t, "foo bar\nsomething went wrong: great sadness\n", s.String())
+	})
+
+	s.Reset()
+	t.Run("reset", func(t *testing.T) {
+		assert.Empty(t, s.Messages(), "messages must be empty")
+		assert.Empty(t, s.String(), "string must be empty")
+	})
+
+	s.Printf("baz qux")
+	t.Run("use after reset", func(t *testing.T) {
+		assert.Equal(t, []string{"baz qux"}, s.Messages(), "messages must match")
+		assert.Equal(t, "baz qux\n", s.String(), "string must match")
+	})
+}


### PR DESCRIPTION
This consolidates the multiple Spy fx.Printer implementations into one.
The previous implementations operated by wrapping a Buffer and accessing
the result with `String()`. The methods used by us were,

    Reset()
    String() string

The new Spy implementation exposes both these methods, as well as a
`Messages() []string` method which exposes all logged messages
separately, which allows for a more accurate way to verify the logged
entries.