### PR TITLE
Add fx.Supply()

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/annotated.go
+++ b/annotated.go
@@ -52,6 +52,8 @@ import (
 //   })
 //
 // Annotated cannot be used with constructors which produce fx.Out objects.
+//
+// When used with fx.Supply, the target is a value rather than a constructor function.
 type Annotated struct {
 	// If specified, this will be used as the name for all non-error values returned
 	// by the constructor. For more information on named values, see the documentation
@@ -66,7 +68,7 @@ type Annotated struct {
 	// A group option may not be provided if a name option is provided.
 	Group string
 
-	// Target is the constructor being annotated with fx.Annotated.
+	// Target is the constructor or value being annotated with fx.Annotated.
 	Target interface{}
 }
 

--- a/app.go
+++ b/app.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/app.go
+++ b/app.go
@@ -113,40 +113,6 @@ func (o provideOption) String() string {
 	return fmt.Sprintf("fx.Provide(%s)", strings.Join(items, ", "))
 }
 
-// Supply makes the given values available for dependency resolution as if
-// they had been provided by a constructor. Specifically, given:
-//
-//  type MyStruct struct{}
-//  var myStruct = &MyStruct{}
-//
-// The following two forms are equivalent:
-//
-//  fx.Provide(func() *MyStruct { return myStruct })
-//  fx.Supply(myStruct)
-//
-// Supply operates by constructing a constructor of the first form based on
-// the types of the supplied values. Supply accepts any number of arguments.
-func Supply(values ...interface{}) Option {
-	if len(values) == 0 {
-		return Options()
-	}
-
-	returnTypes := make([]reflect.Type, len(values))
-	returnValues := make([]reflect.Value, len(values))
-
-	for i, value := range values {
-		returnTypes[i] = reflect.TypeOf(value)
-		returnValues[i] = reflect.ValueOf(value)
-	}
-
-	ft := reflect.FuncOf([]reflect.Type{}, returnTypes, false)
-	fv := reflect.MakeFunc(ft, func([]reflect.Value) []reflect.Value {
-		return returnValues
-	})
-
-	return Provide(fv.Interface())
-}
-
 // Invoke registers functions that are executed eagerly on application start.
 // Arguments for these invocations are built using the constructors registered
 // by Provide. Passing multiple Invoke options appends the new invocations to

--- a/app.go
+++ b/app.go
@@ -351,6 +351,9 @@ type provide struct {
 
 	// Stack trace of where this provide was made.
 	Stack fxreflect.Stack
+
+	// IsSupply is true when the Target constructor was emitted by fx.Supply.
+	IsSupply bool
 }
 
 // invoke is a single invocation request to Fx.
@@ -574,11 +577,18 @@ func (app *App) dotGraph() (DotGraph, error) {
 }
 
 func (app *App) provide(p provide) {
-	constructor := p.Target
 	if app.err != nil {
 		return
 	}
-	app.logger.PrintProvide(constructor)
+
+	constructor := p.Target
+
+	switch {
+	case p.IsSupply:
+		app.logger.PrintSupply(constructor)
+	default:
+		app.logger.PrintProvide(constructor)
+	}
 
 	if _, ok := constructor.(Option); ok {
 		app.err = fmt.Errorf("fx.Option should be passed to fx.New directly, "+

--- a/app.go
+++ b/app.go
@@ -113,6 +113,40 @@ func (o provideOption) String() string {
 	return fmt.Sprintf("fx.Provide(%s)", strings.Join(items, ", "))
 }
 
+// Supply makes the given values available for dependency resolution as if
+// they had been provided by a constructor. Specifically, given:
+//
+//  type MyStruct struct{}
+//  var myStruct = &MyStruct{}
+//
+// The following two forms are equivalent:
+//
+//  fx.Provide(func() *MyStruct { return myStruct })
+//  fx.Supply(myStruct)
+//
+// Supply operates by constructing a constructor of the first form based on
+// the types of the supplied values. Supply accepts any number of arguments.
+func Supply(values ...interface{}) Option {
+	if len(values) == 0 {
+		return Options()
+	}
+
+	returnTypes := make([]reflect.Type, len(values))
+	returnValues := make([]reflect.Value, len(values))
+
+	for i, value := range values {
+		returnTypes[i] = reflect.TypeOf(value)
+		returnValues[i] = reflect.ValueOf(value)
+	}
+
+	ft := reflect.FuncOf([]reflect.Type{}, returnTypes, false)
+	fv := reflect.MakeFunc(ft, func([]reflect.Value) []reflect.Value {
+		return returnValues
+	})
+
+	return Provide(fv.Interface())
+}
+
 // Invoke registers functions that are executed eagerly on application start.
 // Arguments for these invocations are built using the constructors registered
 // by Provide. Passing multiple Invoke options appends the new invocations to

--- a/app_test.go
+++ b/app_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/app_test.go
+++ b/app_test.go
@@ -276,6 +276,20 @@ func TestInvokes(t *testing.T) {
 	})
 }
 
+func TestSupply(t *testing.T) {
+	type A struct{}
+	type B struct{}
+
+	aIn, bIn := A{}, B{}
+	aOut, bOut := (*A)(nil), (*B)(nil)
+	app := fxtest.New(t, Supply(&aIn, &bIn), Populate(&aOut, &bOut))
+	defer app.RequireStart().RequireStop()
+
+	require.NoError(t, app.Err())
+	require.Equal(t, &aIn, aOut)
+	require.Equal(t, &bIn, bOut)
+}
+
 func TestError(t *testing.T) {
 	t.Run("NilErrorOption", func(t *testing.T) {
 		var invoked bool

--- a/app_test.go
+++ b/app_test.go
@@ -277,17 +277,25 @@ func TestInvokes(t *testing.T) {
 }
 
 func TestSupply(t *testing.T) {
-	type A struct{}
-	type B struct{}
+	t.Run("NothingIsSupplied", func(t *testing.T) {
+		app := fxtest.New(t, Supply())
+		defer app.RequireStart().RequireStop()
+		require.NoError(t, app.Err())
+	})
 
-	aIn, bIn := A{}, B{}
-	aOut, bOut := (*A)(nil), (*B)(nil)
-	app := fxtest.New(t, Supply(&aIn, &bIn), Populate(&aOut, &bOut))
-	defer app.RequireStart().RequireStop()
+	t.Run("SomethingIsSupplied", func(t *testing.T) {
+		type A struct{}
+		type B struct{}
 
-	require.NoError(t, app.Err())
-	require.Equal(t, &aIn, aOut)
-	require.Equal(t, &bIn, bOut)
+		aIn, bIn := A{}, B{}
+		aOut, bOut := (*A)(nil), (*B)(nil)
+		app := fxtest.New(t, Supply(&aIn, &bIn), Populate(&aOut, &bOut))
+		defer app.RequireStart().RequireStop()
+
+		require.NoError(t, app.Err())
+		require.Equal(t, &aIn, aOut)
+		require.Equal(t, &bIn, bOut)
+	})
 }
 
 func TestError(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -276,28 +276,6 @@ func TestInvokes(t *testing.T) {
 	})
 }
 
-func TestSupply(t *testing.T) {
-	t.Run("NothingIsSupplied", func(t *testing.T) {
-		app := fxtest.New(t, Supply())
-		defer app.RequireStart().RequireStop()
-		require.NoError(t, app.Err())
-	})
-
-	t.Run("SomethingIsSupplied", func(t *testing.T) {
-		type A struct{}
-		type B struct{}
-
-		aIn, bIn := A{}, B{}
-		aOut, bOut := (*A)(nil), (*B)(nil)
-		app := fxtest.New(t, Supply(&aIn, &bIn), Populate(&aOut, &bOut))
-		defer app.RequireStart().RequireStop()
-
-		require.NoError(t, app.Err())
-		require.Equal(t, &aIn, aOut)
-		require.Equal(t, &bIn, bOut)
-	})
-}
-
 func TestError(t *testing.T) {
 	t.Run("NilErrorOption", func(t *testing.T) {
 		var invoked bool

--- a/app_test.go
+++ b/app_test.go
@@ -826,6 +826,16 @@ func TestOptionString(t *testing.T) {
 			give: ErrorHook(testErrorHandler{t}),
 			want: "fx.ErrorHook(TestOptionString)",
 		},
+		{
+			desc: "Supply/simple",
+			give: Supply(bytes.NewReader(nil), bytes.NewBuffer(nil)),
+			want: "fx.Supply(*bytes.Reader, *bytes.Buffer)",
+		},
+		{
+			desc: "Supply/Annotated",
+			give: Supply(Annotated{Target: bytes.NewReader(nil)}),
+			want: "fx.Supply(*bytes.Reader)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/fxlog/fxlog.go
+++ b/internal/fxlog/fxlog.go
@@ -58,6 +58,14 @@ func (l *Logger) PrintProvide(t interface{}) {
 	}
 }
 
+// PrintSupply logs a type supplied directly into the dig.Container
+// by the given constructor function.
+func (l *Logger) PrintSupply(constructor interface{}) {
+	for _, rtype := range fxreflect.ReturnTypes(constructor) {
+		l.Printf("SUPPLY\t%s", rtype)
+	}
+}
+
 // PrintSignal logs an os.Signal.
 func (l *Logger) PrintSignal(signal os.Signal) {
 	l.Printf(strings.ToUpper(signal.String()))

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -64,6 +64,12 @@ func TestPrint(t *testing.T) {
 		assert.Equal(t, "[Fx] PROVIDE\t*bytes.Buffer <= bytes.NewBuffer()\n", sink.String())
 	})
 
+	t.Run("PrintSupply", func(t *testing.T) {
+		sink.Reset()
+		logger.PrintSupply(func() *bytes.Buffer { return bytes.NewBuffer(nil) })
+		assert.Equal(t, "[Fx] SUPPLY\t*bytes.Buffer\n", sink.String())
+	})
+
 	t.Run("printExpandsTypesInOut", func(t *testing.T) {
 		sink.Reset()
 

--- a/supply.go
+++ b/supply.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/supply.go
+++ b/supply.go
@@ -1,0 +1,39 @@
+package fx
+
+import (
+	"reflect"
+)
+
+// Supply makes the given values available for dependency resolution as if
+// they had been provided by a constructor. Specifically, given:
+//
+//  type MyStruct struct{}
+//  var myStruct = &MyStruct{}
+//
+// The following two forms are equivalent:
+//
+//  fx.Provide(func() *MyStruct { return myStruct })
+//  fx.Supply(myStruct)
+//
+// Supply operates by constructing a constructor of the first form based on
+// the types of the supplied values. Supply accepts any number of arguments.
+func Supply(values ...interface{}) Option {
+	if len(values) == 0 {
+		return Options()
+	}
+
+	returnTypes := make([]reflect.Type, len(values))
+	returnValues := make([]reflect.Value, len(values))
+
+	for i, value := range values {
+		returnTypes[i] = reflect.TypeOf(value)
+		returnValues[i] = reflect.ValueOf(value)
+	}
+
+	ft := reflect.FuncOf([]reflect.Type{}, returnTypes, false)
+	fv := reflect.MakeFunc(ft, func([]reflect.Value) []reflect.Value {
+		return returnValues
+	})
+
+	return Provide(fv.Interface())
+}

--- a/supply.go
+++ b/supply.go
@@ -1,22 +1,56 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fx
 
 import (
 	"reflect"
 )
 
-// Supply makes the given values available for dependency resolution as if
-// they had been provided by a constructor. Specifically, given:
+// Supply provides instantiated values for dependency injection as if
+// they had been provided by a nullary constructor returning most specific type
+// (as determined by reflection) of any given value. For example, given:
 //
-//  type MyStruct struct{}
-//  var myStruct = &MyStruct{}
+//  type (
+// 		TypeA struct{}
+//		TypeB struct{}
+//	)
+//  var a, b = &TypeA{}, TypeB{}
 //
 // The following two forms are equivalent:
 //
-//  fx.Provide(func() *MyStruct { return myStruct })
-//  fx.Supply(myStruct)
+//	fx.Provide(
+//		func() *TypeA { return a },
+//		func() TypeB { return b },
+//	)
 //
-// Supply operates by constructing a constructor of the first form based on
-// the types of the supplied values. Supply accepts any number of arguments.
+//  fx.Supply(a, b)
+//
+// Supply operates by devising a constructor of the first form based on
+// the types of the supplied values. Supply accepts any number of arguments,
+// but with the following caveats:
+//
+// (1) Supply panics when given a naked nil, or an error value.
+// (2) When given a fx.Annotated, the target is expected to be a value.
+//     Supply replaces the target with a constructor function.
+//
 func Supply(values ...interface{}) Option {
 	if len(values) == 0 {
 		return Options()

--- a/supply.go
+++ b/supply.go
@@ -47,7 +47,7 @@ import (
 // the types of the supplied values. Supply accepts any number of arguments,
 // but with the following caveats:
 //
-// (1) Supply panics when given a naked nil, or an error value.
+// (1) Supply panics when given a naked nil or an error value.
 // (2) When given a fx.Annotated, the target is expected to be a value.
 //     Supply replaces the target with a constructor function.
 //
@@ -60,6 +60,13 @@ func Supply(values ...interface{}) Option {
 	returnValues := make([]reflect.Value, len(values))
 
 	for i, value := range values {
+		switch value.(type) {
+		case nil:
+			panic("untyped nil passed to fx.Supply")
+		case error:
+			panic("error value passed to fx.Supply")
+		}
+
 		returnTypes[i] = reflect.TypeOf(value)
 		returnValues[i] = reflect.ValueOf(value)
 	}

--- a/supply.go
+++ b/supply.go
@@ -49,7 +49,6 @@ import (
 //  )
 //
 // Supply panics if a value (or annotation target) is an untyped nil or an error.
-//
 func Supply(values ...interface{}) Option {
 	constructors := make([]interface{}, len(values)) // one function per value
 

--- a/supply_test.go
+++ b/supply_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/supply_test.go
+++ b/supply_test.go
@@ -1,0 +1,32 @@
+package fx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestSupply(t *testing.T) {
+	t.Run("NothingIsSupplied", func(t *testing.T) {
+		app := fxtest.New(t, fx.Supply())
+		defer app.RequireStart().RequireStop()
+		require.NoError(t, app.Err())
+	})
+
+	t.Run("SomethingIsSupplied", func(t *testing.T) {
+		type A struct{}
+		type B struct{}
+
+		aIn, bIn := A{}, B{}
+		aOut, bOut := (*A)(nil), (*B)(nil)
+		app := fxtest.New(t, fx.Supply(&aIn, &bIn), fx.Populate(&aOut, &bOut))
+		defer app.RequireStart().RequireStop()
+
+		require.NoError(t, app.Err())
+		require.Equal(t, &aIn, aOut)
+		require.Equal(t, &bIn, bOut)
+	})
+}

--- a/supply_test.go
+++ b/supply_test.go
@@ -41,9 +41,14 @@ func TestSupply(t *testing.T) {
 
 	t.Run("SomethingIsSupplied", func(t *testing.T) {
 		aIn, bIn := &A{}, &B{}
-		aOut, bOut := (*A)(nil), (*B)(nil)
+		var aOut *A
+		var bOut *B
 
-		app := fxtest.New(t, fx.Supply(aIn, bIn), fx.Populate(&aOut, &bOut))
+		app := fxtest.New(
+			t,
+			fx.Supply(aIn, bIn),
+			fx.Populate(&aOut, &bOut),
+		)
 		defer app.RequireStart().RequireStop()
 
 		require.Same(t, aIn, aOut)
@@ -54,6 +59,7 @@ func TestSupply(t *testing.T) {
 		firstIn, secondIn, thirdIn := &A{}, &A{}, &B{}
 		var out struct {
 			fx.In
+
 			First  *A `name:"first"`
 			Second *A `name:"second"`
 			Third  *B
@@ -65,7 +71,8 @@ func TestSupply(t *testing.T) {
 				fx.Annotated{Name: "first", Target: firstIn},
 				fx.Annotated{Name: "second", Target: secondIn},
 				thirdIn),
-			fx.Populate(&out))
+			fx.Populate(&out),
+		)
 		defer app.RequireStart().RequireStop()
 
 		require.Same(t, firstIn, out.First)
@@ -78,19 +85,20 @@ func TestSupply(t *testing.T) {
 			t,
 			"untyped nil passed to fx.Supply",
 			func() { fx.Supply(A{}, nil) },
-			"a naked nil should panic")
+			"a naked nil should panic",
+		)
 
 		require.NotPanicsf(
 			t,
-			func() {
-				fx.Supply(A{}, (*B)(nil))
-			},
-			"a wrapped nil should not panic")
+			func() { fx.Supply(A{}, (*B)(nil)) },
+			"a wrapped nil should not panic",
+		)
 
 		require.PanicsWithValuef(
 			t,
 			"error value passed to fx.Supply",
 			func() { fx.Supply(A{}, errors.New("fail")) },
-			"an error value should panic")
+			"an error value should panic",
+		)
 	})
 }

--- a/supply_test.go
+++ b/supply_test.go
@@ -37,7 +37,6 @@ func TestSupply(t *testing.T) {
 	t.Run("NothingIsSupplied", func(t *testing.T) {
 		app := fxtest.New(t, fx.Supply())
 		defer app.RequireStart().RequireStop()
-		require.NoError(t, app.Err())
 	})
 
 	t.Run("SomethingIsSupplied", func(t *testing.T) {
@@ -47,9 +46,8 @@ func TestSupply(t *testing.T) {
 		app := fxtest.New(t, fx.Supply(aIn, bIn), fx.Populate(&aOut, &bOut))
 		defer app.RequireStart().RequireStop()
 
-		require.NoError(t, app.Err())
-		require.Equal(t, aIn, aOut)
-		require.Equal(t, bIn, bOut)
+		require.Same(t, aIn, aOut)
+		require.Same(t, bIn, bOut)
 	})
 
 	t.Run("AnnotateIsSupplied", func(t *testing.T) {
@@ -70,10 +68,9 @@ func TestSupply(t *testing.T) {
 			fx.Populate(&out))
 		defer app.RequireStart().RequireStop()
 
-		require.NoError(t, app.Err())
-		require.Equal(t, firstIn, out.First)
-		require.Equal(t, secondIn, out.Second)
-		require.Equal(t, thirdIn, out.Third)
+		require.Same(t, firstIn, out.First)
+		require.Same(t, secondIn, out.Second)
+		require.Same(t, thirdIn, out.Third)
 	})
 
 	t.Run("InvalidArgumentIsSupplied", func(t *testing.T) {

--- a/supply_test.go
+++ b/supply_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fx_test
 
 import (


### PR DESCRIPTION
Adds `fx.Supply(values ...interface{})` to provide values for dependency injection that have been created externally (such as application configuration). `Supply` uses reflection to craft the appropriate function for `Provide`. As stated by the documentation:

Supply makes the given values available for dependency resolution as if they had been provided by a constructor. Specifically, given:

```go
type MyStruct struct{}
var myStruct = &MyStruct{}
```

The following two forms are equivalent:

```go
fx.Provide(func() *MyStruct { return myStruct })
fx.Supply(myStruct)
```

Supply operates by constructing a constructor of the first form based on the types of the supplied values. Supply accepts any number of arguments.