### PR TITLE
Add invoke sorting

### DIFF
--- a/testdata/one/one.go
+++ b/testdata/one/one.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package one
+
+// A ...
+type A struct{}
+
+// CreateFunction ...
+func CreateFunction() (*A, error) {
+	return &A{}, nil
+}

--- a/testdata/two/two.go
+++ b/testdata/two/two.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package two
+
+// Run ...
+func Run() error {
+	// running
+	return nil
+}


### PR DESCRIPTION
Invoke ordering has been a huge problem in the last years
that Fx has been live. Executing invokes in the order they
are provided to the fx.New() call is simply not good enough
as it often requires developers to think through the import
order of their modules, and how they interact with one
another.

Luckily help is at hand with a new fx.Option -- fx.Sort! Now
developers can finally take control of their own destiny
when it comes to the order of execution of invokes with the
two very deterministic launch orders: alphabetical, and by
length of the fully qualified function name (comes out of
the box with package name support!!!).

I think this is going to take the possibilities through the
roof.

The framework is there for adding more sorting options in
the future. Some ideas that have been thrown out:
- Random
- Reverse
- Probability
- Time of day
- Leap year

The possibilities are literally endless.