### PR TITLE
Release v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.13.0] - 2020-06-16
 ### Added
 - Added `fx.ValidateGraph` which allows graph cycle validation and dependency correctness
  without running anything. This is useful if `fx.Invoke` has side effects, does I/O, etc.
@@ -203,7 +203,7 @@ promising API compatibility between beta releases and the final 1.0.0 release.
 In fact, we expect our beta user feedback to require some changes to the way
 things work. Once we reach 1.0, we will provider proper version compatibility.
 
-[Unreleased]: https://github.com/uber-go/fx/compare/v1.12.0...HEAD
+[1.13.0]: https://github.com/uber-go/fx/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/uber-go/fx/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/uber-go/fx/compare/v1.10.0...1.11.0
 [1.10.0]: https://github.com/uber-go/fx/compare/v1.9.0...v1.10.0

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.13.0-dev"
+const Version = "1.13.0"


### PR DESCRIPTION
This sets up release v1.13.0. The only change in this release is addition of `ValidateGraph`.

List of changes: [v1.12.0...v1.13.0](https://github.com/uber-go/fx/compare/v1.12.0...v1.13.0)