### PR TITLE
travis: Use stable, oldstable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 
 matrix:
   include:
-  - go: 1.12.x
-  - go: 1.13.x
+  - go: stable
+  - go: oldstable
     env: LINT=1
 
 install:


### PR DESCRIPTION
Since [`gimme 1.5.4`][1], Travis CI supports using `stable` and
`oldstable` as versions in the `travis.yml`. This will always map to the
most recent two minor releases of the language (1.15.x and 1.14.x
today), which is the support policy we have for our projects.

[1]: https://github.com/travis-ci/gimme/releases/tag/v1.5.4