### PR TITLE
Add Priority field to Hook

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -33,13 +33,13 @@ import (
 type Priority int
 
 const (
-	// PriorityLowest hooks are executed last.
+	// PriorityLowest hooks are started last and stoppped first.
 	// For example, hooks that start serving network traffic might wish to execute
 	// only after all other application components are initialized.
 	PriorityLowest Priority = -1000
 	// PriorityNormal is the default priority level
 	PriorityNormal = 0
-	// PriorityHighest hooks are executed first.
+	// PriorityHighest hooks are started first and stopped last.
 	PriorityHighest = 1000
 )
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -70,15 +70,17 @@ func New(logger *fxlog.Logger) *Lifecycle {
 // Append adds a Hook to the lifecycle.
 func (l *Lifecycle) Append(hook Hook) {
 	hook.caller = fxreflect.Caller()
+	// Can be replaced with priority double ended queue,
+	// but is it really necessary?
 	l.hooks = append(l.hooks, hook)
+	sort.SliceStable(l.hooks, func(i, j int) bool {
+		return l.hooks[i].Priority > l.hooks[j].Priority
+	})
 }
 
 // Start runs all OnStart hooks, returning immediately if it encounters an
 // error.
 func (l *Lifecycle) Start(ctx context.Context) error {
-	sort.SliceStable(l.hooks, func(i, j int) bool {
-		return l.hooks[i].Priority > l.hooks[j].Priority
-	})
 	for _, hook := range l.hooks {
 		if hook.OnStart != nil {
 			l.logger.Printf("START\t\t%s()", hook.caller)

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -70,17 +70,16 @@ func New(logger *fxlog.Logger) *Lifecycle {
 // Append adds a Hook to the lifecycle.
 func (l *Lifecycle) Append(hook Hook) {
 	hook.caller = fxreflect.Caller()
-	// Can be replaced with priority double ended queue,
-	// but is it really necessary?
 	l.hooks = append(l.hooks, hook)
-	sort.SliceStable(l.hooks, func(i, j int) bool {
-		return l.hooks[i].Priority > l.hooks[j].Priority
-	})
 }
 
 // Start runs all OnStart hooks, returning immediately if it encounters an
 // error.
 func (l *Lifecycle) Start(ctx context.Context) error {
+	// Highest priority to lowest priority
+	sort.SliceStable(l.hooks, func(i, j int) bool {
+		return l.hooks[i].Priority > l.hooks[j].Priority
+	})
 	for _, hook := range l.hooks {
 		if hook.OnStart != nil {
 			l.logger.Printf("START\t\t%s()", hook.caller)


### PR DESCRIPTION
Proof of concept for priority idea. `PriorityLowest` would allow Hooks that start serving user IO (e.g. gRPC/HTTP servers) to run last as they require the whole application to be initialized and operational.

Few downsides of this approach:
1. No way to order the lowest priority hooks. Should not be a big problem since hooks are still expected to be independent of other hooks.
2. Requires fair use by Hooks author - if a hook is assigned a priority that does reflect it's use-case, we're going to have the same issues. For example, if a hook that initializes a database session is assigned the lowest priority same as RPC server, the same race condition will occur.