### PR TITLE
fxtest.Lifecycle: Write to testing.T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Fx now emits structured, JSON logs. These may be parsed and processed by
   log ingestion systems.
+- `fxtest.Lifecycle` now logs to the provided `testing.TB` instead of stderr.
 
 ## [1.13.1] - 2020-08-19
 ### Fixed

--- a/example_test.go
+++ b/example_test.go
@@ -208,7 +208,9 @@ func Example() {
 
 	// Normally, we'd block here with <-app.Done(). Instead, we'll make an HTTP
 	// request to demonstrate that our server is running.
-	http.Get("http://localhost:8080/")
+	if _, err := http.Get("http://localhost:8080/"); err != nil {
+		log.Fatal(err)
+	}
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/fxtest/lifecycle.go
+++ b/fxtest/lifecycle.go
@@ -22,11 +22,11 @@ package fxtest
 
 import (
 	"context"
-	"os"
 
 	"go.uber.org/fx"
 	"go.uber.org/fx/internal/fxlog"
 	"go.uber.org/fx/internal/lifecycle"
+	"go.uber.org/fx/internal/testutil"
 )
 
 // Lifecycle is a testing spy for fx.Lifecycle. It exposes Start and Stop
@@ -41,8 +41,9 @@ var _ fx.Lifecycle = (*Lifecycle)(nil)
 
 // NewLifecycle creates a new test lifecycle.
 func NewLifecycle(t TB) *Lifecycle {
+	w := testutil.WriteSyncer{T: t}
 	return &Lifecycle{
-		lc: lifecycle.New(fxlog.DefaultLogger(os.Stderr)),
+		lc: lifecycle.New(fxlog.DefaultLogger(w)),
 		t:  t,
 	}
 }

--- a/fxtest/lifecycle.go
+++ b/fxtest/lifecycle.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxtest
+
+import (
+	"context"
+	"os"
+
+	"go.uber.org/fx"
+	"go.uber.org/fx/internal/fxlog"
+	"go.uber.org/fx/internal/lifecycle"
+)
+
+// Lifecycle is a testing spy for fx.Lifecycle. It exposes Start and Stop
+// methods (and some test-specific helpers) so that unit tests can exercise
+// hooks.
+type Lifecycle struct {
+	t  TB
+	lc *lifecycle.Lifecycle
+}
+
+var _ fx.Lifecycle = (*Lifecycle)(nil)
+
+// NewLifecycle creates a new test lifecycle.
+func NewLifecycle(t TB) *Lifecycle {
+	return &Lifecycle{
+		lc: lifecycle.New(fxlog.DefaultLogger(os.Stderr)),
+		t:  t,
+	}
+}
+
+// Start executes all registered OnStart hooks in order, halting at the first
+// hook that doesn't succeed.
+func (l *Lifecycle) Start(ctx context.Context) error { return l.lc.Start(ctx) }
+
+// RequireStart calls Start with context.Background(), failing the test if an
+// error is encountered.
+func (l *Lifecycle) RequireStart() *Lifecycle {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := l.Start(ctx); err != nil {
+		l.t.Errorf("lifecycle didn't start cleanly: %v", err)
+		l.t.FailNow()
+	}
+	return l
+}
+
+// Stop calls all OnStop hooks whose OnStart counterpart was called, running
+// in reverse order.
+//
+// If any hook returns an error, execution continues for a best-effort
+// cleanup. Any errors encountered are collected into a single error and
+// returned.
+func (l *Lifecycle) Stop(ctx context.Context) error { return l.lc.Stop(ctx) }
+
+// RequireStop calls Stop with context.Background(), failing the test if an error
+// is encountered.
+func (l *Lifecycle) RequireStop() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := l.Stop(ctx); err != nil {
+		l.t.Errorf("lifecycle didn't stop cleanly: %v", err)
+		l.t.FailNow()
+	}
+}
+
+// Append registers a new Hook.
+func (l *Lifecycle) Append(h fx.Hook) {
+	l.lc.Append(lifecycle.Hook{
+		OnStart: h.OnStart,
+		OnStop:  h.OnStop,
+	})
+}

--- a/fxtest/lifecycle_test.go
+++ b/fxtest/lifecycle_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxtest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/goleak"
+)
+
+func TestLifecycle(t *testing.T) {
+	defer goleak.VerifyNoLeaks(t)
+
+	t.Run("Success", func(t *testing.T) {
+		spy := newTB()
+
+		n := 0
+		lc := NewLifecycle(spy)
+		lc.Append(fx.Hook{
+			OnStart: func(context.Context) error { n++; return nil },
+			OnStop:  func(context.Context) error { n++; return nil },
+		})
+		lc.RequireStart().RequireStop()
+
+		assert.Zero(t, spy.failures, "Lifecycle start/stop failed.")
+		assert.Equal(t, 2, n, "Didn't run start and stop hooks.")
+	})
+
+	t.Run("StartFailure", func(t *testing.T) {
+		spy := newTB()
+		lc := NewLifecycle(spy)
+		lc.Append(fx.Hook{OnStart: func(context.Context) error { return errors.New("fail") }})
+
+		lc.RequireStart()
+		assert.Equal(t, 1, spy.failures, "Expected lifecycle start to fail.")
+
+		lc.RequireStop()
+		assert.Equal(t, 1, spy.failures, "Expected lifecycle stop to succeed.")
+	})
+
+	t.Run("StopFailure", func(t *testing.T) {
+		spy := newTB()
+		lc := NewLifecycle(spy)
+		lc.Append(fx.Hook{OnStop: func(context.Context) error { return errors.New("fail") }})
+
+		lc.RequireStart()
+		assert.Equal(t, 0, spy.failures, "Expected lifecycle start to succeed.")
+
+		lc.RequireStop()
+		assert.Equal(t, 1, spy.failures, "Expected lifecycle stop to fail.")
+	})
+
+	t.Run("RequireLeakDetection", func(t *testing.T) {
+		spy := newTB()
+		lc := NewLifecycle(spy)
+
+		stop := make(chan struct{})
+		stopped := make(chan struct{})
+
+		onStart := func(ctx context.Context) error {
+			go func() {
+				<-stop
+				close(stopped)
+			}()
+			return ctx.Err()
+		}
+
+		onStop := func(ctx context.Context) error {
+			close(stop)
+			<-stopped
+			return ctx.Err()
+		}
+
+		lc.Append(fx.Hook{
+			OnStart: onStart,
+			OnStop:  onStop,
+		})
+
+		lc.RequireStart()
+		assert.Equal(t, 0, spy.failures, "Expected lifecycle start to succeed.")
+
+		lc.RequireStop()
+		assert.Equal(t, 0, spy.failures, "Expected lifecycle to stop.")
+	})
+}

--- a/fxtest/tb.go
+++ b/fxtest/tb.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxtest
+
+// TB is a subset of the standard library's testing.TB interface. It's
+// satisfied by both *testing.T and *testing.B.
+type TB interface {
+	Logf(string, ...interface{})
+	Errorf(string, ...interface{})
+	FailNow()
+}

--- a/fxtest/tb_test.go
+++ b/fxtest/tb_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fxtest
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// Verify that TB always matches testing.T.
+var _ TB = (*testing.T)(nil)
+
+type tb struct {
+	failures int
+	errors   *bytes.Buffer
+	logs     *bytes.Buffer
+}
+
+func newTB() *tb {
+	return &tb{0, &bytes.Buffer{}, &bytes.Buffer{}}
+}
+
+func (t *tb) FailNow() {
+	t.failures++
+}
+
+func (t *tb) Errorf(format string, args ...interface{}) {
+	fmt.Fprintf(t.errors, format, args...)
+	t.errors.WriteRune('\n')
+}
+
+func (t *tb) Logf(format string, args ...interface{}) {
+	fmt.Fprintf(t.logs, format, args...)
+	t.logs.WriteRune('\n')
+}

--- a/internal/fxlog/fxlog_test.go
+++ b/internal/fxlog/fxlog_test.go
@@ -30,12 +30,15 @@ import (
 	"go.uber.org/fx/internal/fxlog/foovendor"
 	"go.uber.org/fx/internal/fxlog/sample.git"
 	"go.uber.org/fx/internal/fxreflect"
+	"go.uber.org/fx/internal/testutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestNew(t *testing.T) {
-	assert.NotPanics(t, func() { DefaultLogger(os.Stderr) })
+	assert.NotPanics(t, func() {
+		DefaultLogger(testutil.WriteSyncer{T: t})
+	})
 }
 
 func TestPrint(t *testing.T) {

--- a/internal/testutil/writer.go
+++ b/internal/testutil/writer.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutil
+
+import "go.uber.org/zap/zapcore"
+
+// TestingT is a subset of the testing.T interface.
+type TestingT interface {
+	Logf(string, ...interface{})
+}
+
+// WriteSyncer is a zapcore.WriteSyncer that writes to the provided test
+// logger.
+type WriteSyncer struct{ T TestingT }
+
+var _ zapcore.WriteSyncer = WriteSyncer{}
+
+// Write writes the provided bytes to the underlying TestingT.
+func (w WriteSyncer) Write(bs []byte) (int, error) {
+	w.T.Logf("%s", bs)
+	return len(bs), nil
+}
+
+// Sync is a no-op.
+func (WriteSyncer) Sync() error { return nil }

--- a/internal/testutil/writer_test.go
+++ b/internal/testutil/writer_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// spy is a TestingT that captures Log requests.
+type spy struct{ Logs []string }
+
+func (s *spy) Clear() { s.Logs = nil }
+
+func (s *spy) Logf(msg string, args ...interface{}) {
+	s.Logs = append(s.Logs, fmt.Sprintf(msg, args...))
+}
+
+func TestWriteSyncer(t *testing.T) {
+	var spy spy
+	ws := WriteSyncer{T: &spy}
+
+	t.Run("log", func(t *testing.T) {
+		spy.Clear()
+
+		io.WriteString(ws, "hello")
+		assert.Equal(t, []string{"hello"}, spy.Logs)
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		assert.NoError(t, ws.Sync())
+	})
+}


### PR DESCRIPTION
fxtest.Lifecycle writes to stderr right now. This makes for noisy test
output.

Seeing as a testing.TB is already available, we should log to it
instead.

Refs GO-281