### PR TITLE
Clarify shutdowner can only be used on started fx applications

### DIFF
--- a/shutdown.go
+++ b/shutdown.go
@@ -44,9 +44,10 @@ type shutdowner struct {
 }
 
 // Shutdown broadcasts a signal to all of the application's Done channels
-// and begins the Stop process. Only started fx applications can be shutdown.
+// and begins the Stop process. Applications can be shut down only after they
+// have finished starting up.
 // In practice this means Shutdowner.Shutdown should not be called from an
-// fx.Invoke, but from a fx.Lifecycle.Onstart hook.
+// fx.Invoke, but from a fx.Lifecycle.OnStart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
 	return s.app.broadcastSignal(_sigTERM)
 }

--- a/shutdown.go
+++ b/shutdown.go
@@ -44,7 +44,9 @@ type shutdowner struct {
 }
 
 // Shutdown broadcasts a signal to all of the application's Done channels
-// and begins the Stop process.
+// and begins the Stop process. Only started fx applications can be shutdown.
+// In practice this means Shutdowner.Shutdown should not be called from an
+// fx.Invoke, but from a fx.Lifecycle.Onstart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
 	return s.app.broadcastSignal(_sigTERM)
 }


### PR DESCRIPTION
Although https://pkg.go.dev/go.uber.org/fx#Shutdowner states that
> ... Shutdowner works on applications using Run as well as Start, Done, and Stop. ...

We've had some reports of confusing behavior in which users attempt to call `Shutdown()` from an `fx.Invoke` and fx subsequently doesn't shutdown. Although this is expected (as invokes get executed on `fx.New` and fx.New should always return an app or error, not terminate) it is not explicitly documented. This PR attempts to improve the documentation.

Internal ref: GO-479