### PR TITLE
In/Out: Use type aliases

### DIFF
--- a/inout.go
+++ b/inout.go
@@ -162,7 +162,7 @@ import "go.uber.org/dig"
 //
 // Note that values in a value group are unordered. Fx makes no guarantees
 // about the order in which these values will be produced.
-type In struct{ dig.In }
+type In = dig.In
 
 // Out is the inverse of In: it can be embedded in result structs to take
 // advantage of advanced features.
@@ -262,4 +262,4 @@ type In struct{ dig.In }
 //     Handler []int `group:"server"`         // Consume as [][]int
 //     Handler []int `group:"server,flatten"` // Consume as []int
 //   }
-type Out struct{ dig.Out }
+type Out = dig.Out


### PR DESCRIPTION
When `fx.In` and `fx.Out` were originally implemented on top of `dig.In`
and `dig.Out`, type aliases didn't exist so they were implemented by
embedding the structs.

Now that we're well past Go 1.9 (when type aliases were added), we
should be more than safe to switch over to type aliases.

Note that even though we're changing the definition of the type, this is
not a breaking change because the `dig.In` and `dig.Out` types were not
usable directly before either as they embedded an internal sentinel
type.

Resolves #730
Refs GO-374
