### PR TITLE
fx.In: Support unexported fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/stretchr/testify v1.4.0
-	go.uber.org/dig v1.10.0
+	go.uber.org/dig v1.11.0
 	go.uber.org/goleak v0.10.0
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/dig v1.10.0 h1:yLmDDj9/zuDjv3gz8GQGviXMs9TfysIUMUilCpgzUJY=
-go.uber.org/dig v1.10.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
+go.uber.org/dig v1.11.0 h1:tGTnPJE8TIozwn2VdsAsK7yr7sxtI5IHFYHujIeLf1w=
+go.uber.org/dig v1.11.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/goleak v0.10.0 h1:G3eWbSNIskeRqtsN/1uI5B+eP73y3JUuBsv9AZjehb4=
 go.uber.org/goleak v0.10.0/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=

--- a/inout.go
+++ b/inout.go
@@ -162,6 +162,29 @@ import "go.uber.org/dig"
 //
 // Note that values in a value group are unordered. Fx makes no guarantees
 // about the order in which these values will be produced.
+//
+// Unexported fields
+//
+// By default, a type that embeds fx.In may not have any unexported fields. The
+// following will return an error if used with Fx.
+//
+//   type Params struct {
+//     fx.In
+//
+//     Logger *zap.Logger
+//     mu     sync.Mutex
+//   }
+//
+// If you have need of unexported fields on such a type, you may opt-into
+// ignoring unexported fields by adding the ignore-unexported struct tag to the
+// fx.In. For example,
+//
+//   type Params struct {
+//     fx.In `ignore-unexported:"true"`
+//
+//     Logger *zap.Logger
+//     mu     sync.Mutex
+//   }
 type In = dig.In
 
 // Out is the inverse of In: it can be embedded in result structs to take


### PR DESCRIPTION
This adds support for `ignore-unexported` (uber-go/dig#273,
uber-go/dig#274) to Fx.

To add support, we merely need to bump the minimum version constraint to
a version of dig that has this feature.

Refs GO-374
