### PR TITLE
fxreflect: Delete ReturnTypes in favor of dig.Info

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2020-2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -632,14 +632,6 @@ func (app *App) provide(p provide) {
 	}
 
 	constructor := p.Target
-
-	switch {
-	case p.IsSupply:
-		app.log.LogEvent(&fxevent.Supply{TypeName: p.SupplyType.String()})
-	default:
-		app.log.LogEvent(&fxevent.Provide{Constructor: constructor})
-	}
-
 	if _, ok := constructor.(Option); ok {
 		app.err = fmt.Errorf("fx.Option should be passed to fx.New directly, "+
 			"not to fx.Provide: fx.Provide received %v from:\n%+v",
@@ -647,8 +639,32 @@ func (app *App) provide(p provide) {
 		return
 	}
 
+	var info dig.ProvideInfo
+	opts := []dig.ProvideOption{
+		dig.FillProvideInfo(&info),
+	}
+	defer func() {
+		if app.err != nil {
+			return
+		}
+
+		switch {
+		case p.IsSupply:
+			app.log.LogEvent(&fxevent.Supply{TypeName: p.SupplyType.String()})
+		default:
+			outputNames := make([]string, len(info.Outputs))
+			for i, o := range info.Outputs {
+				outputNames[i] = o.String()
+			}
+
+			app.log.LogEvent(&fxevent.Provide{
+				Constructor:     constructor,
+				OutputTypeNames: outputNames,
+			})
+		}
+	}()
+
 	if ann, ok := constructor.(Annotated); ok {
-		var opts []dig.ProvideOption
 		switch {
 		case len(ann.Group) > 0 && len(ann.Name) > 0:
 			app.err = fmt.Errorf(
@@ -685,7 +701,7 @@ func (app *App) provide(p provide) {
 		}
 	}
 
-	if err := app.container.Provide(constructor); err != nil {
+	if err := app.container.Provide(constructor, opts...); err != nil {
 		app.err = fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", fxreflect.FuncName(constructor), p.Stack, err)
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2020-2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,6 @@ import (
 	"go.uber.org/fx/fxevent"
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/fx/internal/fxlog"
-	"go.uber.org/fx/internal/fxreflect"
 	"go.uber.org/multierr"
 )
 
@@ -70,7 +69,8 @@ func TestNewApp(t *testing.T) {
 		require.Equal(t,
 			[]string{"Provide", "Provide", "Provide", "Provide", "Running"},
 			spy.EventTypes())
-		assert.Contains(t, fxreflect.ReturnTypes(spy.Events()[0].(*fxevent.Provide).Constructor), "struct {}")
+
+		assert.Contains(t, spy.Events()[0].(*fxevent.Provide).OutputTypeNames, "struct {}")
 	})
 
 	t.Run("CircularGraphReturnsError", func(t *testing.T) {
@@ -426,8 +426,8 @@ func TestOptions(t *testing.T) {
 			Provide(&bytes.Buffer{}), // error, not a constructor
 			WithLogger(spy),
 		)
-		require.Equal(t, []string{"Provide", "ProvideError"}, spy.EventTypes())
-		assert.Contains(t, spy.Events()[1].(*fxevent.ProvideError).Err.Error(), "must provide constructor function")
+		require.Equal(t, []string{"ProvideError"}, spy.EventTypes())
+		assert.Contains(t, spy.Events()[0].(*fxevent.ProvideError).Err.Error(), "must provide constructor function")
 	})
 }
 

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -20,7 +20,9 @@
 
 package fxevent
 
-import "os"
+import (
+	"os"
+)
 
 // Event defines an event emitted by fx.
 type Event interface {
@@ -63,9 +65,13 @@ type Supply struct {
 	TypeName string
 }
 
-// Provide is emitted whenever Provide was called and is not provided by fx.Supply.
+// Provide is emitted when we add a constructor to the container.
 type Provide struct {
 	Constructor interface{}
+
+	// OutputTypeNames is a list of names of types that are produced by
+	// this constructor.
+	OutputTypeNames []string
 }
 
 // Invoke is emitted whenever a function is invoked.

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -46,7 +46,7 @@ func (l *ZapLogger) LogEvent(event Event) {
 	case *Supply:
 		l.Logger.Info("supplying", zap.String("type", e.TypeName))
 	case *Provide:
-		for _, rtype := range fxreflect.ReturnTypes(e.Constructor) {
+		for _, rtype := range e.OutputTypeNames {
 			l.Logger.Info("providing",
 				zap.String("constructor", fxreflect.FuncName(e.Constructor)),
 				zap.String("type", rtype),

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -91,7 +91,7 @@ func TestZapLogger(t *testing.T) {
 	})
 	t.Run("Provide", func(t *testing.T) {
 		defer ts.Reset()
-		zapLogger.LogEvent(&Provide{bytes.NewBuffer})
+		zapLogger.LogEvent(&Provide{bytes.NewBuffer, []string{"*bytes.Buffer"}})
 		ts.AssertMessages("INFO\tproviding\t{\"constructor\": \"bytes.NewBuffer()\", \"type\": \"*bytes.Buffer\"}")
 	})
 	t.Run("Invoke", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d
 )
+
+replace go.uber.org/dig => go.uber.org/dig v1.11.1-0.20210622212612-931c2ba30782

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/dig v1.11.0 h1:tGTnPJE8TIozwn2VdsAsK7yr7sxtI5IHFYHujIeLf1w=
-go.uber.org/dig v1.11.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
+go.uber.org/dig v1.11.1-0.20210622212612-931c2ba30782 h1:wfMqAcA7VmYM63riKRCFC2yNFtoRf5Fmg2TsEao3t+w=
+go.uber.org/dig v1.11.1-0.20210622212612-931c2ba30782/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/goleak v0.10.0 h1:G3eWbSNIskeRqtsN/1uI5B+eP73y3JUuBsv9AZjehb4=
 go.uber.org/goleak v0.10.0/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=

--- a/internal/fxreflect/fxreflect_test.go
+++ b/internal/fxreflect/fxreflect_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2019-2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,68 +21,10 @@
 package fxreflect
 
 import (
-	"bytes"
-	"errors"
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/dig"
 )
-
-type hollerer interface {
-	Holler()
-}
-
-type impl struct{}
-
-func (impl) Holler() {}
-
-type result struct {
-	dig.Out // referencing fx introduces import cycles
-
-	buff   *bytes.Buffer
-	Logger *log.Logger
-}
-
-func TestReturnTypes(t *testing.T) {
-	t.Run("non-function", func(t *testing.T) {
-		assert.Empty(t, ReturnTypes(42))
-	})
-	t.Run("primitive", func(t *testing.T) {
-		fn := func() (int, string) {
-			return 0, ""
-		}
-		assert.Equal(t, []string{"int", "string"}, ReturnTypes(fn))
-	})
-	t.Run("pointer", func(t *testing.T) {
-		type s struct{}
-		fn := func() *s {
-			return &s{}
-		}
-		assert.Equal(t, []string{"*fxreflect.s"}, ReturnTypes(fn))
-	})
-	t.Run("interface", func(t *testing.T) {
-		fn := func() hollerer {
-			return impl{}
-		}
-		assert.Equal(t, []string{"fxreflect.hollerer"}, ReturnTypes(fn))
-	})
-	t.Run("result struct", func(t *testing.T) {
-		fn := func() result {
-			return result{
-				buff: bytes.NewBufferString("foo"),
-			}
-		}
-		assert.Equal(t, []string{"*log.Logger"}, ReturnTypes(fn))
-	})
-	t.Run("skips errors", func(t *testing.T) {
-		fn := func() (string, error) {
-			return "", errors.New("err")
-		}
-		assert.Equal(t, []string{"string"}, ReturnTypes(fn))
-	})
-}
 
 func TestCaller(t *testing.T) {
 	assert.Equal(t, "go.uber.org/fx/internal/fxreflect.TestCaller", Caller())

--- a/supply.go
+++ b/supply.go
@@ -94,15 +94,9 @@ func (o supplyOption) apply(app *App) {
 
 func (o supplyOption) String() string {
 	items := make([]string, 0, len(o.Targets))
-	for _, target := range o.Targets {
-		switch target := target.(type) {
-		case Annotated:
-			items = append(items, fxreflect.ReturnTypes(target.Target)...)
-		default:
-			items = append(items, fxreflect.ReturnTypes(target)...)
-		}
+	for _, typ := range o.Types {
+		items = append(items, typ.String())
 	}
-
 	return fmt.Sprintf("fx.Supply(%s)", strings.Join(items, ", "))
 }
 


### PR DESCRIPTION
With uber-go/dig#280 done, we can use the ProvideInfo produced by Dig to
determine what types will be produced by a constructor and log them, so we
no longer need to reimplement the `dig.Out` inspection logic in Fx.

To surface this information with the new event API introduced in #747, this
adds a new field to fxevent.Provide:

    OutputTypeNames []string

This, in lieu of exposing `dig.Info` wholesale ensures that we have some
wiggle room here.

Note that this introduces one behavioral difference on when the Provide
event is logged: previously, the Provide event would be logged whether
it succeeded or failed. I've created GO-677 internally to discuss
consistency here.

With this change, it will be logged only if it succeeds -- after it
succeeds. This makes sense because otherwise we can't extract information
about the function from Dig.

This temporarily pins Fx to the unreleased `master` branch of Dig. We'll
have to tag a releaes of Dig before we can release this feature.

Refs GO-676
