### PR TITLE
Fix race in timeout error report

### DIFF
--- a/app.go
+++ b/app.go
@@ -931,13 +931,18 @@ func withTimeout(ctx context.Context, param *withTimeoutParams) error {
 func formatTimeoutError(err error, param *withTimeoutParams) error {
 	// On timeout, report running hook's caller and recorded
 	// runtimes of hooks successfully run till end.
-	r := param.lifecycle.hookRecords()
-	sort.Sort(r)
+	var r lifecycle.HookRecords
+	if param.hook == _onStartHook {
+		r = param.lifecycle.startHookRecords()
+	} else {
+		r = param.lifecycle.stopHookRecords()
+	}
 	caller := param.lifecycle.runningHookCaller()
 	// TODO: Once this is integrated into fxevent, we can
 	// leave error unchanged and send this to fxevent.Logger, whose
 	// implementation can then determine how the error is presented.
 	if len(r) > 0 {
+		sort.Sort(r)
 		return fmt.Errorf("%v hook added by %v failed: %w\n%+v",
 			param.hook,
 			caller,

--- a/app_test.go
+++ b/app_test.go
@@ -628,7 +628,7 @@ func TestAppStart(t *testing.T) {
 				Hook{
 					OnStart: func(ctx context.Context) error {
 						<-ctx.Done()
-						return nil
+						return ctx.Err()
 					},
 				},
 			)
@@ -678,7 +678,7 @@ func TestAppStart(t *testing.T) {
 				Hook{
 					OnStart: func(ctx context.Context) error {
 						<-ctx.Done()
-						return nil
+						return ctx.Err()
 					},
 				},
 			)
@@ -715,7 +715,7 @@ func TestAppStart(t *testing.T) {
 					OnStart: func(ctx context.Context) error {
 						close(running)
 						<-ctx.Done()
-						return nil
+						return ctx.Err()
 					},
 				},
 			)
@@ -899,7 +899,7 @@ func TestAppStop(t *testing.T) {
 	t.Run("Timeout", func(t *testing.T) {
 		block := func(ctx context.Context) error {
 			<-ctx.Done()
-			return nil
+			return ctx.Err()
 		}
 		app := fxtest.New(t, Invoke(func(l Lifecycle) {
 			l.Append(Hook{OnStop: block})

--- a/app_test.go
+++ b/app_test.go
@@ -628,7 +628,7 @@ func TestAppStart(t *testing.T) {
 				Hook{
 					OnStart: func(ctx context.Context) error {
 						<-ctx.Done()
-						return ctx.Err()
+						return nil
 					},
 				},
 			)
@@ -678,7 +678,7 @@ func TestAppStart(t *testing.T) {
 				Hook{
 					OnStart: func(ctx context.Context) error {
 						<-ctx.Done()
-						return ctx.Err()
+						return nil
 					},
 				},
 			)
@@ -715,7 +715,7 @@ func TestAppStart(t *testing.T) {
 					OnStart: func(ctx context.Context) error {
 						close(running)
 						<-ctx.Done()
-						return ctx.Err()
+						return nil
 					},
 				},
 			)
@@ -899,7 +899,7 @@ func TestAppStop(t *testing.T) {
 	t.Run("Timeout", func(t *testing.T) {
 		block := func(ctx context.Context) error {
 			<-ctx.Done()
-			return ctx.Err()
+			return nil
 		}
 		app := fxtest.New(t, Invoke(func(l Lifecycle) {
 			l.Append(Hook{OnStop: block})

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -51,8 +51,12 @@ func (l *lifecycleWrapper) Append(h Hook) {
 	})
 }
 
-func (l *lifecycleWrapper) hookRecords() lifecycle.HookRecords {
-	return l.HookRecords()
+func (l *lifecycleWrapper) startHookRecords() lifecycle.HookRecords {
+	return l.StartHookRecords()
+}
+
+func (l *lifecycleWrapper) stopHookRecords() lifecycle.HookRecords {
+	return l.StopHookRecords()
 }
 
 func (l *lifecycleWrapper) runningHookCaller() string {


### PR DESCRIPTION
In the timeout tests where we intentionally make hooks timeout and check the error messages, I noticed that it sometimes fails with errors like this:

```
        writer.go:40: [Fx] ERROR		Start failed, rolling back: context deadline exceeded
        app_test.go:698: 
            	Error Trace:	app_test.go:698
            	Error:      	"context deadline exceeded" does not contain "OnStart hook added by go.uber.org/fx_test.TestAppStart.func2.3 failed: context deadline exceeded"
            	Test:       	TestAppStart/TimeoutWithFinishedHooks
        app_test.go:701: 
            	Error Trace:	app_test.go:701
            	Error:      	Expect "context deadline exceeded" to match "app_test.go:\d+"
            	Test:       	TestAppStart/TimeoutWithFinishedHooks
        app_test.go:706: 
            	Error Trace:	app_test.go:706
            	Error:      	"-1" is not greater than "-1"
            	Test:       	TestAppStart/TimeoutWithFinishedHooks
    writer.go:40: [Fx] ERROR		Start failed, rolling back: context canceled
```

There were two races:

1. It's possible for the goroutine executing the OnStart hook itself to see the timeout error first, then return it, which will hit the `err := <- c` case in `withTimeout`, which just returns the error as it is. 

Fixed this race by checking for the timeout error in the `err := <- c` case and format the error the same way as when the parent goroutine sees the timeout error first. 

2. When the timeout error is returned from the onStart to the main goroutine, the main goroutine pokes at the lifecycle's records field while the onStart-executing goroutine is trying to unroll using Stop(), which overwrites that records field. 

Fixed this race by splitting the records field into start records and stop records which are reported separately.