### PR TITLE
Add fx.Annotate

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -101,6 +101,17 @@ type paramTags struct {
 	tags []string
 }
 
+// Given func(T1, T2, T3, ..., TN), this generates a type roughly
+// equivalent to,
+//
+//   struct {
+//     fx.In
+//
+//     Field1 T1 `$tags[0]`
+//     Field2 T2 `$tags[1]`
+//     ...
+//     FieldN TN `$tags[N-1]`
+//   }
 func (p paramTags) getAnnotatedType(fType reflect.Type) []reflect.Type {
 	annotatedParams := []reflect.StructField{{
 		Name:      "In",
@@ -135,6 +146,17 @@ type resultTags struct {
 	tags []string
 }
 
+// Given func(T1, T2, T3, ..., TN), this generates a type roughly
+// equivalent to,
+//
+//   struct {
+//     fx.Out
+//
+//     Field1 T1 `$tags[0]`
+//     Field2 T2 `$tags[1]`
+//     ...
+//     FieldN TN `$tags[N-1]`
+//   }
 func (resultTags) getAnnotatedType(fType reflect.Type) []reflect.Type {
 	annotatedResult := []reflect.StructField{{
 		Name:      "Out",
@@ -199,14 +221,14 @@ func ResultTags(tags ...string) Annotation {
 //
 // For example,
 //
-// fx.Provide(
-//   fx.Annotate(
-//     NewGateWay,
-//     fx.ParamTags(`name:"ro" optional:"true"`),
-//     fx.ParamTags(`name:"rw"),
-//     fx.ResultTags(`name:"foo"`)
-//   )
-// )
+//  fx.Provide(
+//    fx.Annotate(
+//      NewGateWay,
+//      fx.ParamTags(`name:"ro" optional:"true"`),
+//      fx.ParamTags(`name:"rw"),
+//      fx.ResultTags(`name:"foo"`)
+//    )
+//  )
 //
 // is considered an invalid usage and will not apply any of the
 // Annotations to NewGateway.

--- a/annotated.go
+++ b/annotated.go
@@ -333,15 +333,13 @@ func Annotate(f interface{}, anns ...Annotation) interface{} {
 		fResults = fVal.Call(fParams)
 		if annotations.annotatedOut {
 			// wrap the result in an annotated struct
-			var numAnnotated int
 			results := reflect.New(outs[0]).Elem()
 			for i := 0; i < numOut; i++ {
 				if fResults[i].Type() == _typeOfError {
 					continue
 				}
 				results.FieldByName(fmt.Sprintf("Field%d",
-					numAnnotated)).Set(fResults[numAnnotated])
-				numAnnotated++
+					i)).Set(fResults[i])
 			}
 			return []reflect.Value{results}
 		}

--- a/annotated.go
+++ b/annotated.go
@@ -224,21 +224,18 @@ func (rt resultTagsAnnotation) apply(ann *annotations) error {
 		Anonymous: true,
 	}}
 
-	var numAnnotated int
-
 	for i := 0; i < fType.NumOut(); i++ {
 		// guard against error results
 		if fType.Out(i) == _typeOfError {
 			continue
 		}
 		structField := reflect.StructField{
-			Name: fmt.Sprintf("Field%d", numAnnotated),
+			Name: fmt.Sprintf("Field%d", i),
 			Type: fType.Out(i),
 		}
-		if numAnnotated < len(rt.tags) {
-			structField.Tag = reflect.StructTag(rt.tags[numAnnotated])
+		if i < len(rt.tags) {
+			structField.Tag = reflect.StructTag(rt.tags[i])
 		}
-		numAnnotated++
 		annotatedResult = append(annotatedResult, structField)
 	}
 

--- a/annotated.go
+++ b/annotated.go
@@ -346,24 +346,3 @@ func Annotate(f interface{}, anns ...Annotation) interface{} {
 	annotatedFunc := reflect.MakeFunc(annotatedFuncType, newF)
 	return annotatedFunc.Interface()
 }
-
-func verifyAnnotation(numIn int, numOut int, anns ...Annotation) bool {
-	sawParamAnn := false
-	sawResultAnn := false
-
-	for _, ann := range anns {
-		if _, ok := ann.(paramTags); ok {
-			if sawParamAnn {
-				return false
-			}
-			sawParamAnn = true
-		}
-		if _, ok := ann.(resultTags); ok {
-			if sawResultAnn {
-				return false
-			}
-			sawResultAnn = true
-		}
-	}
-	return true
-}

--- a/annotated.go
+++ b/annotated.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2020-2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -186,15 +186,33 @@ func ResultTags(tags ...string) Annotation {
 //
 //  type result struct {
 //    fx.Out
-
+//
 //    GW *Gateway `name:"foo"`
 //   }
 //
 //   fx.Provide(func(p params) result {
 //     return result{GW: NewGateway(p.RO, p.RW)}
 //   })
-
-// Annotate takes an array of names, and returns function to be called with user function. names are in order.
+//
+// If there are more Annotations are specified than than one per
+// Annotation type, none of the Annotations will be applied.
+//
+// For example,
+//
+// fx.Provide(
+//   fx.Annotate(
+//     NewGateWay,
+//     fx.ParamTags(`name:"ro" optional:"true"`),
+//     fx.ParamTags(`name:"rw"),
+//     fx.ResultTags(`name:"foo"`)
+//   )
+// )
+//
+// is considered an invalid usage and will not apply any of the
+// Annotations to NewGateway.
+//
+// If more tags are given than the number of parameters/results, only
+// the ones up to the number of parameters/results will be applied.
 func Annotate(f interface{}, anns ...Annotation) interface{} {
 	fVal := reflect.ValueOf(f)
 	fType := fVal.Type()

--- a/annotated.go
+++ b/annotated.go
@@ -100,7 +100,7 @@ type paramTags struct {
 	tags []string
 }
 
-func (p paramTags) getAnnotatedType(fType reflect.Type) []reflect.Type{
+func (p paramTags) getAnnotatedType(fType reflect.Type) []reflect.Type {
 	annotatedParams := []reflect.StructField{{
 		Name:      "In",
 		Type:      reflect.TypeOf(In{}),
@@ -123,7 +123,7 @@ func (p paramTags) getAnnotatedType(fType reflect.Type) []reflect.Type{
 	return paramTypes
 }
 
-func ParamTags(tags... string) Annotation {
+func ParamTags(tags ...string) Annotation {
 	p := paramTags{tags}
 	return p
 }
@@ -134,8 +134,8 @@ type resultTags struct {
 
 func (resultTags) getAnnotatedType(fType reflect.Type) []reflect.Type {
 	annotatedResult := []reflect.StructField{{
-		Name:	   "Out",
-		Type:	   reflect.TypeOf(Out{}),
+		Name:      "Out",
+		Type:      reflect.TypeOf(Out{}),
 		Anonymous: true,
 	}}
 
@@ -152,11 +152,10 @@ func (resultTags) getAnnotatedType(fType reflect.Type) []reflect.Type {
 	return resultTypes
 }
 
-func ResultTags(tags... string) Annotation {
+func ResultTags(tags ...string) Annotation {
 	r := resultTags{tags}
 	return r
 }
-
 
 // Annotate allows to inject annotated options without declare your own struct
 //
@@ -189,7 +188,7 @@ func ResultTags(tags... string) Annotation {
 //   })
 //
 // Annotate takes an array of names, and returns function to be called with user function. names are in order.
-func Annotate(f interface{}, anns... Annotation) interface{} {
+func Annotate(f interface{}, anns ...Annotation) interface{} {
 	fVal := reflect.ValueOf(f)
 	fType := fVal.Type()
 	numIn := fType.NumIn()
@@ -241,7 +240,7 @@ func Annotate(f interface{}, anns... Annotation) interface{} {
 	return annotatedFunc.Interface()
 }
 
-func verifyAnnotation(numIn int, numOut int, anns... Annotation) bool {
+func verifyAnnotation(numIn int, numOut int, anns ...Annotation) bool {
 	sawParamAnn := false
 	sawResultAnn := false
 

--- a/annotated.go
+++ b/annotated.go
@@ -242,7 +242,7 @@ func Annotate(f interface{}, anns ...Annotation) interface{} {
 			fParams := make([]reflect.Value, numIn)
 			params := args[0]
 			for i := 0; i < numIn; i++ {
-				fParams[i] = params.Field(i+1)
+				fParams[i] = params.Field(i + 1)
 			}
 			fResults := fVal.Call(fParams)
 			results := reflect.New(outs[0]).Elem()
@@ -256,7 +256,7 @@ func Annotate(f interface{}, anns ...Annotation) interface{} {
 			fParams := make([]reflect.Value, numIn)
 			params := args[0]
 			for i := 0; i < numIn; i++ {
-				fParams[i] = params.Field(i+1)
+				fParams[i] = params.Field(i + 1)
 			}
 			return fVal.Call(fParams)
 		}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -267,8 +267,8 @@ func TestAnnotate(t *testing.T) {
 	t.Run("provide with annotated results with error", func(t *testing.T) {
 		app := fxtest.New(t,
 			fx.Provide(
-				fx.Annotate(func() (*a, error) {
-					return &a{}, nil
+				fx.Annotate(func() (*a, error, *a) {
+					return &a{}, nil, &a{}
 				}, fx.ResultTags(`name:"firstA"`)),
 				fx.Annotate(func() (*a, error) {
 					return &a{}, nil

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -235,3 +235,35 @@ func TestAnnotateParamTags(t *testing.T) {
 		assert.Contains(t, err.Error(), `missing type: *fx_test.a[name="a"]`)
 	})
 }
+
+func TestAnnotateResultTags(t *testing.T) {
+	type a struct{}
+	type b struct{ a *a }
+
+	newB := func(aa *a) *b {
+		return &b{aa}
+	}
+
+	t.Run("invoke with annotated result", func(t *testing.T) {
+		app := fxtest.New(t,
+			fx.Provide(
+				fx.Annotate(newB, fx.ResultTags(`name:"B"`)),
+			),
+		)
+
+		err := app.Err()
+		require.NoError(t, err)
+		defer app.RequireStart().RequireStop()
+	})
+
+	t.Run("cannot annotate with name and group", func(t *testing.T) {
+		newA := func() *a { return &a{} }
+		app := fxtest.New(t,
+			fx.Provide(
+				newA,
+			),
+		)
+		err := app.Err()
+		require.NoError(t, err)
+	})
+}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -260,8 +260,25 @@ func TestAnnotate(t *testing.T) {
 			fx.Invoke(newC),
 		)
 
-		err := app.Err()
-		require.NoError(t, err)
+		require.NoError(t, app.Err())
+		defer app.RequireStart().RequireStop()
+	})
+
+	t.Run("provide with annotated results with error", func(t *testing.T) {
+		app := fxtest.New(t,
+			fx.Provide(
+				fx.Annotate(func() (*a, error) {
+					return &a{}, nil
+				}, fx.ResultTags(`name:"firstA"`)),
+				fx.Annotate(func() (*a, error) {
+					return &a{}, nil
+				}, fx.ResultTags(`name:"secondA"`)),
+			),
+			fx.Invoke(fx.Annotate(func(a1 *a, a2 *a) *b {
+				return &b{a2}
+			}, fx.ParamTags(`name:"firstA"`, `name:"secondA"`))))
+
+		require.NoError(t, app.Err())
 		defer app.RequireStart().RequireStop()
 	})
 

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -264,4 +264,21 @@ func TestAnnotate(t *testing.T) {
 		require.NoError(t, err)
 		defer app.RequireStart().RequireStop()
 	})
+	t.Run("specify two ParamTags", func(t *testing.T) {
+		app := fxtest.New(t,
+			fx.Provide(
+				// This should just leave newA as it is.
+				fx.Annotate(
+					newA,
+					fx.ParamTags(`name:"something"`),
+					fx.ParamTags(`name:"anotherThing"`),
+				),
+			),
+			fx.Invoke(newB),
+		)
+
+		err := app.Err()
+		require.NoError(t, err)
+		defer app.RequireStart().RequireStop()
+	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -237,11 +237,25 @@ func TestAnnotate(t *testing.T) {
 		assert.Contains(t, err.Error(), `missing type: *fx_test.a[name="a"]`)
 	})
 
-	t.Run("provide with annotated result", func(t *testing.T) {
+	t.Run("provide with annotated results", func(t *testing.T) {
 		app := fxtest.New(t,
 			fx.Provide(
-				newA,
-				fx.Annotate(newB, fx.ResultTags(`name:"B"`)),
+				fx.Annotate(func() *a {
+					return &a{}
+				}, fx.ResultTags(`name:"firstA"`)),
+				fx.Annotate(func() *a {
+					return &a{}
+				}, fx.ResultTags(`name:"secondA"`)),
+				fx.Annotate(func() *a {
+					return &a{}
+				}, fx.ResultTags(`name:"thirdA"`)),
+				fx.Annotate(func(a1 *a, a2 *a, a3 *a) *b {
+					return &b{a1}
+				}, fx.ParamTags(
+					`name:"firstA"`,
+					`name:"secondA"`,
+					`name:"thirdA"`,
+				)),
 			),
 			fx.Invoke(newC),
 		)

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -295,8 +295,9 @@ func TestAnnotate(t *testing.T) {
 		require.NoError(t, err)
 		defer app.RequireStart().RequireStop()
 	})
+
 	t.Run("specify two ParamTags", func(t *testing.T) {
-		app := fxtest.New(t,
+		app := fx.New(
 			fx.Provide(
 				// This should just leave newA as it is.
 				fx.Annotate(
@@ -307,13 +308,13 @@ func TestAnnotate(t *testing.T) {
 			),
 			fx.Invoke(newB),
 		)
-
 		err := app.Err()
-		require.NoError(t, err)
-		defer app.RequireStart().RequireStop()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "encountered error while applying annotation using fx.Annotate to go.uber.org/fx_test.TestAnnotate.func1(): cannot apply more than one line of ParamTags")
 	})
+
 	t.Run("specify two ResultTags", func(t *testing.T) {
-		app := fxtest.New(t,
+		app := fx.New(
 			fx.Provide(
 				// This should just leave newA as it is.
 				fx.Annotate(
@@ -326,7 +327,7 @@ func TestAnnotate(t *testing.T) {
 		)
 
 		err := app.Err()
-		require.NoError(t, err)
-		defer app.RequireStart().RequireStop()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "encountered error while applying annotation using fx.Annotate to go.uber.org/fx_test.TestAnnotate.func1(): cannot apply more than one line of ResultTags")
 	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -277,13 +277,13 @@ func TestAnnotate(t *testing.T) {
 					return &a{}
 				}, fx.ResultTags(`name:"fourthA"`)),
 			),
-			fx.Invoke(fx.Annotate(func(a1 *a, a2 *a, a3 *a) *b {
+			fx.Invoke(
+				fx.Annotate(func(a1 *a, a2 *a, a3 *a) *b {
 					return &b{a1}
 				}, fx.ParamTags(
 					`name:"firstA"`,
 					`name:"secondA"`,
-					`name:"thirdA"`,
-				)),
+					`name:"thirdA"`)),
 			),
 		)
 		err := app.Err()

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -281,4 +281,21 @@ func TestAnnotate(t *testing.T) {
 		require.NoError(t, err)
 		defer app.RequireStart().RequireStop()
 	})
+	t.Run("specify two ResultTags", func(t *testing.T) {
+		app := fxtest.New(t,
+			fx.Provide(
+				// This should just leave newA as it is.
+				fx.Annotate(
+					newA,
+					fx.ResultTags(`name:"A"`),
+					fx.ResultTags(`name:"AA"`),
+				),
+			),
+			fx.Invoke(newB),
+		)
+
+		err := app.Err()
+		require.NoError(t, err)
+		defer app.RequireStart().RequireStop()
+	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -178,9 +178,9 @@ func TestAnnotatedString(t *testing.T) {
 }
 
 func TestAnnotateParamTags(t *testing.T) {
-	type a struct {}
-	type b struct { a *a }
-	type c struct { b *b }
+	type a struct{}
+	type b struct{ a *a }
+	type c struct{ b *b }
 	newB := func(a *a) *b {
 		return &b{a}
 	}
@@ -235,4 +235,3 @@ func TestAnnotateParamTags(t *testing.T) {
 		assert.Contains(t, err.Error(), `missing type: *fx_test.a[name="a"]`)
 	})
 }
-

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -265,18 +265,19 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("provide with annotated results with error", func(t *testing.T) {
+		//lint:ignore ST1008 we want to check cases when user annotates a function that doesn't return an error as the last argument.
 		app := fxtest.New(t,
 			fx.Provide(
 				fx.Annotate(func() (*a, error, *a) {
 					return &a{}, nil, &a{}
-				}, fx.ResultTags(`name:"firstA"`)),
+				}, fx.ResultTags(`name:"firstA"`, ``, `name:"secondA"`)),
 				fx.Annotate(func() (*a, error) {
 					return &a{}, nil
-				}, fx.ResultTags(`name:"secondA"`)),
+				}, fx.ResultTags(`name:"thirdA"`)),
 			),
-			fx.Invoke(fx.Annotate(func(a1 *a, a2 *a) *b {
+			fx.Invoke(fx.Annotate(func(a1 *a, a2 *a, a3 *a) *b {
 				return &b{a2}
-			}, fx.ParamTags(`name:"firstA"`, `name:"secondA"`))))
+			}, fx.ParamTags(`name:"firstA"`, `name:"secondA"`, `name:"thirdA"`))))
 
 		require.NoError(t, app.Err())
 		defer app.RequireStart().RequireStop()

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -265,9 +265,9 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("provide with annotated results with error", func(t *testing.T) {
-		//lint:ignore ST1008 we want to check cases when user annotates a function that doesn't return an error as the last argument.
 		app := fxtest.New(t,
 			fx.Provide(
+				//lint:ignore ST1008 we want to test error in the middle.
 				fx.Annotate(func() (*a, error, *a) {
 					return &a{}, nil, &a{}
 				}, fx.ResultTags(`name:"firstA"`, ``, `name:"secondA"`)),

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -250,4 +250,18 @@ func TestAnnotate(t *testing.T) {
 		require.NoError(t, err)
 		defer app.RequireStart().RequireStop()
 	})
+
+	t.Run("specify more ParamTags than Params", func(t *testing.T) {
+		app := fxtest.New(t,
+			fx.Provide(
+				// This should just leave newA as it is.
+				fx.Annotate(newA, fx.ParamTags(`name:"something"`)),
+			),
+			fx.Invoke(newB),
+		)
+
+		err := app.Err()
+		require.NoError(t, err)
+		defer app.RequireStart().RequireStop()
+	})
 }

--- a/app.go
+++ b/app.go
@@ -784,6 +784,12 @@ func (app *App) provide(p provide) {
 		}
 	}()
 
+	if annError, ok := constructor.(annotationError); ok {
+		app.err = fmt.Errorf("encountered error while applying annotation using fx.Annotate to %s: %+v",
+			fxreflect.FuncName(annError.target), annError.err)
+		return
+	}
+
 	if ann, ok := constructor.(Annotated); ok {
 		switch {
 		case len(ann.Group) > 0 && len(ann.Name) > 0:


### PR DESCRIPTION
This adds fx.Annotate, along with fx.Annotation, fx.ParamTags, and fx.ResultTags.

fx.Annotate takes an arbitrary function and annotates it with supplied fx.Annotations.

fx.ParamTags takes in a list of strings in the form of struct tags that can be used as tags to each parameter to the supplied function, and returns an fx.Annotation that can be used with fx.Annotate. 

fx.ResultTags also takes in a list of strings in the form of struct tags that can be used as tags to each result of the supplied function, and returns an fx.Annotation that can be used with fx.Annotate.

Using this, one can annotate both parameter and result to `fx.Provide`d or `Invoke`d functions.

Current implementation makes heavy use of reflection to construct a struct type at runtime, both for the parameters and results depending on which tags are specified. fx.Annotate uses reflection to generate a function wrapper that invokes the provided function with an a struct that contains all the arguments with annotated parameters, and wraps the result inside a struct with the specified result tags.

We may decide in the future to replace the implementation similar to how fx.Annotated is implemented, but for now this should still work.

Refs GO-549.
