### PR TITLE
Add events for lifecycle hook execution

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1094,9 +1094,11 @@ func TestCustomLoggerWithLifecycle(t *testing.T) {
 		"Provide",
 		"Provide",
 		"CustomLogger",
-		"LifecycleHookStart",
+		"LifecycleHookExecuting",
+		"LifecycleHookExecuted",
 		"Running",
-		"LifecycleHookStop",
+		"LifecycleHookExecuting",
+		"LifecycleHookExecuted",
 	}, spy.EventTypes())
 }
 

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -49,9 +49,9 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		l.logf("HOOK %s\t\t%s executing (caller: %s)", e.Method, e.FunctionName, e.CallerName)
 	case *LifecycleHookExecuted:
 		if e.Err != nil {
-			l.logf("HOOK %s\t\t%s called by %s failed: %v", e.Method, e.FunctionName, e.CallerName, e.Err)
+			l.logf("HOOK %s\t\t%s called by %s failed in %s: %v", e.Method, e.FunctionName, e.CallerName, e.Runtime, e.Err)
 		} else {
-			l.logf("HOOK %s\t\t%s called by %s ran successfully. Runtime: %s", e.Method, e.FunctionName, e.CallerName, e.Runtime)
+			l.logf("HOOK %s\t\t%s called by %s ran successfully in %s", e.Method, e.FunctionName, e.CallerName, e.Runtime)
 		}
 	case *ProvideError:
 		l.logf("Error after options were applied: %v", e.Err)

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -45,10 +45,14 @@ func (l *ConsoleLogger) logf(msg string, args ...interface{}) {
 // LogEvent logs the given event to the provided Zap logger.
 func (l *ConsoleLogger) LogEvent(event Event) {
 	switch e := event.(type) {
-	case *LifecycleHookStart:
-		l.logf("START\t\t%s", e.CallerName)
-	case *LifecycleHookStop:
-		l.logf("STOP\t\t%s", e.CallerName)
+	case *LifecycleHookExecuting:
+		l.logf("HOOK %s\t\t%s executing (caller: %s)", e.Method, e.FunctionName, e.CallerName)
+	case *LifecycleHookExecuted:
+		if e.Err != nil {
+			l.logf("HOOK %s\t\t%s called by %s failed: %v", e.Method, e.FunctionName, e.CallerName, e.Err)
+		} else {
+			l.logf("HOOK %s\t\t%s called by %s ran successfully. Runtime: %s", e.Method, e.FunctionName, e.CallerName, e.Runtime)
+		}
 	case *ProvideError:
 		l.logf("Error after options were applied: %v", e.Err)
 	case *Supply:

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -23,9 +23,11 @@ package fxevent
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -39,14 +41,33 @@ func TestConsoleLogger(t *testing.T) {
 		want string
 	}{
 		{
-			name: "LifecycleHookStart",
-			give: &LifecycleHookStart{CallerName: "bytes.NewBuffer"},
-			want: "[Fx] START		bytes.NewBuffer\n",
+			name: "LifecycleHookExecuting",
+			give: &LifecycleHookExecuting{
+				Method:       "OnStop",
+				FunctionName: "hook.onStop1",
+				CallerName:   "bytes.NewBuffer",
+			},
+			want: "[Fx] HOOK OnStop		hook.onStop1 executing (caller: bytes.NewBuffer)\n",
 		},
 		{
-			name: "LifecycleHookStop",
-			give: &LifecycleHookStop{CallerName: "bytes.NewBuffer"},
-			want: "[Fx] STOP		bytes.NewBuffer\n",
+			name: "LifecycleHookExecutedError",
+			give: &LifecycleHookExecuted{
+				Method:       "OnStart",
+				FunctionName: "hook.onStart1",
+				CallerName:   "bytes.NewBuffer",
+				Err:          fmt.Errorf("some error"),
+			},
+			want: "[Fx] HOOK OnStart		hook.onStart1 called by bytes.NewBuffer failed: some error\n",
+		},
+		{
+			name: "LifecycleHookExecuted",
+			give: &LifecycleHookExecuted{
+				Method:       "OnStart",
+				FunctionName: "hook.onStart1",
+				CallerName:   "bytes.NewBuffer",
+				Runtime:      time.Millisecond * 3,
+			},
+			want: "[Fx] HOOK OnStart		hook.onStart1 called by bytes.NewBuffer ran successfully. Runtime: 3ms\n",
 		},
 		{
 			name: "ProvideError",

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -57,7 +57,7 @@ func TestConsoleLogger(t *testing.T) {
 				CallerName:   "bytes.NewBuffer",
 				Err:          fmt.Errorf("some error"),
 			},
-			want: "[Fx] HOOK OnStart		hook.onStart1 called by bytes.NewBuffer failed: some error\n",
+			want: "[Fx] HOOK OnStart		hook.onStart1 called by bytes.NewBuffer failed in 0s: some error\n",
 		},
 		{
 			name: "LifecycleHookExecuted",
@@ -67,7 +67,7 @@ func TestConsoleLogger(t *testing.T) {
 				CallerName:   "bytes.NewBuffer",
 				Runtime:      time.Millisecond * 3,
 			},
-			want: "[Fx] HOOK OnStart		hook.onStart1 called by bytes.NewBuffer ran successfully. Runtime: 3ms\n",
+			want: "[Fx] HOOK OnStart		hook.onStart1 called by bytes.NewBuffer ran successfully in 3ms\n",
 		},
 		{
 			name: "ProvideError",

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -22,6 +22,7 @@ package fxevent
 
 import (
 	"os"
+	"time"
 )
 
 // Event defines an event emitted by fx.
@@ -30,30 +31,39 @@ type Event interface {
 }
 
 // Passing events by type to make Event hashable in the future.
-func (*LifecycleHookStart) event() {}
-func (*LifecycleHookStop) event()  {}
-func (*ProvideError) event()       {}
-func (*Supply) event()             {}
-func (*Provide) event()            {}
-func (*Invoke) event()             {}
-func (*InvokeError) event()        {}
-func (*StartError) event()         {}
-func (*StopSignal) event()         {}
-func (*StopError) event()          {}
-func (*Rollback) event()           {}
-func (*RollbackError) event()      {}
-func (*Running) event()            {}
-func (*CustomLoggerError) event()  {}
-func (*CustomLogger) event()       {}
+func (*LifecycleHookExecuting) event() {}
+func (*LifecycleHookExecuted) event()  {}
+func (*ProvideError) event()           {}
+func (*Supply) event()                 {}
+func (*Provide) event()                {}
+func (*Invoke) event()                 {}
+func (*InvokeError) event()            {}
+func (*StartError) event()             {}
+func (*StopSignal) event()             {}
+func (*StopError) event()              {}
+func (*Rollback) event()               {}
+func (*RollbackError) event()          {}
+func (*Running) event()                {}
+func (*CustomLoggerError) event()      {}
+func (*CustomLogger) event()           {}
 
-// LifecycleHookStart is emitted whenever an OnStart hook is executed
-type LifecycleHookStart struct {
+// LifecycleHookExecuting is emitted before an OnStart hook is about to be executed.
+type LifecycleHookExecuting struct {
+	// FunctionName is the name of the hook being executed.
+	FunctionName string
+	// CallerName is the name of the caller that appended the hook.
 	CallerName string
+	// Method is the lifecycle hook method getting called.
+	Method string
 }
 
-// LifecycleHookStop is emitted whenever an OnStart hook is executed
-type LifecycleHookStop struct {
-	CallerName string
+// LifecycleHookExecuted is emitted after an OnStart hook has been executed.
+type LifecycleHookExecuted struct {
+	FunctionName string
+	CallerName   string
+	Method       string
+	Runtime      time.Duration
+	Err          error
 }
 
 // ProvideError is emitted whenever there is an error applying options.

--- a/fxevent/event_test.go
+++ b/fxevent/event_test.go
@@ -29,8 +29,8 @@ import (
 // TestForCoverage adds coverage for own sake.
 func TestForCoverage(t *testing.T) {
 	events := []Event{
-		&LifecycleHookStart{},
-		&LifecycleHookStop{},
+		&LifecycleHookExecuting{},
+		&LifecycleHookExecuted{},
 		&ProvideError{},
 		&Supply{},
 		&Provide{},

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -37,10 +37,28 @@ var _ Logger = (*ZapLogger)(nil)
 // LogEvent logs the given event to the provided Zap logger.
 func (l *ZapLogger) LogEvent(event Event) {
 	switch e := event.(type) {
-	case *LifecycleHookStart:
-		l.Logger.Info("starting", zap.String("caller", e.CallerName))
-	case *LifecycleHookStop:
-		l.Logger.Info("stopping", zap.String("caller", e.CallerName))
+	case *LifecycleHookExecuting:
+		l.Logger.Info("hook executing",
+			zap.String("method", e.Method),
+			zap.String("callee", e.FunctionName),
+			zap.String("caller", e.CallerName),
+		)
+	case *LifecycleHookExecuted:
+		if e.Err != nil {
+			l.Logger.Info("hook execute failed",
+				zap.String("method", e.Method),
+				zap.String("callee", e.FunctionName),
+				zap.String("caller", e.CallerName),
+				zap.Error(e.Err),
+			)
+		} else {
+			l.Logger.Info("hook executed",
+				zap.String("method", e.Method),
+				zap.String("callee", e.FunctionName),
+				zap.String("caller", e.CallerName),
+				zap.String("runtime", e.Runtime.String()),
+			)
+		}
 	case *ProvideError:
 		l.Logger.Error("error encountered while applying options",
 			zap.Error(e.Err))

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -23,8 +23,10 @@ package fxevent
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,19 +46,49 @@ func TestZapLogger(t *testing.T) {
 		wantFields  map[string]interface{}
 	}{
 		{
-			name:        "LifecycleHookStart",
-			give:        &LifecycleHookStart{CallerName: "bytes.NewBuffer"},
-			wantMessage: "starting",
+			name: "LifecycleHookExecuting",
+			give: &LifecycleHookExecuting{
+				Method:       "OnStop",
+				FunctionName: "hook.onStop1",
+				CallerName:   "bytes.NewBuffer",
+			},
+			wantMessage: "hook executing",
 			wantFields: map[string]interface{}{
 				"caller": "bytes.NewBuffer",
+				"callee": "hook.onStop1",
+				"method": "OnStop",
 			},
 		},
 		{
-			name:        "LifecycleHookStop",
-			give:        &LifecycleHookStop{CallerName: "bytes.NewBuffer"},
-			wantMessage: "stopping",
+			name: "LifecycleHookExecutedError",
+			give: &LifecycleHookExecuted{
+				Method:       "OnStart",
+				FunctionName: "hook.onStart1",
+				CallerName:   "bytes.NewBuffer",
+				Err:          fmt.Errorf("some error"),
+			},
+			wantMessage: "hook execute failed",
 			wantFields: map[string]interface{}{
 				"caller": "bytes.NewBuffer",
+				"callee": "hook.onStart1",
+				"method": "OnStart",
+				"error":  "some error",
+			},
+		},
+		{
+			name: "LifecycleHookExecuted",
+			give: &LifecycleHookExecuted{
+				Method:       "OnStart",
+				FunctionName: "hook.onStart1",
+				CallerName:   "bytes.NewBuffer",
+				Runtime:      time.Millisecond * 3,
+			},
+			wantMessage: "hook executed",
+			wantFields: map[string]interface{}{
+				"caller":  "bytes.NewBuffer",
+				"callee":  "hook.onStart1",
+				"method":  "OnStart",
+				"runtime": "3ms",
 			},
 		},
 		{

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -95,6 +95,7 @@ func (l *Lifecycle) Start(ctx context.Context) error {
 					CallerName:   hook.callerFrame.Function,
 					FunctionName: funcName,
 					Method:       _hookStart,
+					Runtime:      time.Since(begin),
 					Err:          err,
 				})
 				return err


### PR DESCRIPTION
This adds events for lifecycle hook execution. `LifecycleHookStart` and `LifecycleHookStop` was being used to fire events separately for `OnStart` and `OnStop` events previously. Since the recorded fields for both events aren't different, this change merges the two events into a single set of events, and adds another event so that an event is fired before and another is fired after a hook is executed.

Specifically, `LifecycleHookExecuting` is fired right before either an `OnStart` or `OnStop` hook is executed. After the hook has finished executing, `LifecycleHookExecuted` is fired with either an error or the runtime. Both `LifecycleHookExecuting` and `LifecycleHookExecuted` events contain the name of the hook being executed, the name of the caller that appended the lifecycle, and the method that's being executed (either `OnStart` or `OnStop`).

Refs: GO-707.