### PR TITLE
Introduce Invoking and rename other event types

### DIFF
--- a/app.go
+++ b/app.go
@@ -574,7 +574,10 @@ func New(opts ...Option) *App {
 			app.err = multierr.Append(app.err, err)
 			app.log = fallbackLogger
 			bufferLogger.Connect(fallbackLogger)
-			app.log.LogEvent(&fxevent.LoggerInitialized{Err: err})
+			app.log.LogEvent(&fxevent.LoggerInitialized{
+				Err:         err,
+				Constructor: app.logConstructor,
+			})
 			return app
 		}
 		app.log.LogEvent(&fxevent.LoggerInitialized{Constructor: app.logConstructor})

--- a/app.go
+++ b/app.go
@@ -561,12 +561,9 @@ func New(opts ...Option) *App {
 	app.provide(provide{Target: app.shutdowner, Stack: frames})
 	app.provide(provide{Target: app.dotGraph, Stack: frames})
 
-	if app.err != nil {
-		app.log.LogEvent(&fxevent.Provide{Err: app.err})
-		// Don't return yet. If a custom logger was being used,
-		// we're still buffering messages. We'll want to flush them to
-		// the logger.
-	}
+	// If you are thinking about returning here after provides: do not (just yet)!
+	// If a custom logger was being used, we're still buffering messages.
+	// We'll want to flush them to the logger.
 
 	// If WithLogger and Printer are both provided, WithLogger takes
 	// precedence.
@@ -577,13 +574,13 @@ func New(opts ...Option) *App {
 			app.err = multierr.Append(app.err, err)
 			app.log = fallbackLogger
 			bufferLogger.Connect(fallbackLogger)
-			app.log.LogEvent(&fxevent.CustomLogger{Err: err})
+			app.log.LogEvent(&fxevent.LoggerInitialized{Err: err})
 			return app
 		}
-		app.log.LogEvent(&fxevent.CustomLogger{Function: app.logConstructor})
+		app.log.LogEvent(&fxevent.LoggerInitialized{Constructor: app.logConstructor})
 	}
 
-	// This error might have come from the provide looop above. We've
+	// This error might have come from the provide loop above. We've
 	// already flushed to the custom logger, so we can return.
 	if app.err != nil {
 		return app
@@ -765,6 +762,10 @@ func (app *App) provide(p provide) {
 	}
 	defer func() {
 		if app.err != nil {
+			app.log.LogEvent(&fxevent.Provide{
+				Err:         app.err,
+				Constructor: constructor,
+			})
 			return
 		}
 
@@ -832,7 +833,7 @@ func (app *App) executeInvokes() error {
 
 	for _, i := range app.invokes {
 		fn := i.Target
-		app.log.LogEvent(&fxevent.Invoke{Function: fn})
+		app.log.LogEvent(&fxevent.Invoking{Function: fn})
 
 		var err error
 		if _, ok := fn.(Option); ok {
@@ -844,7 +845,7 @@ func (app *App) executeInvokes() error {
 		}
 
 		if err != nil {
-			app.log.LogEvent(&fxevent.Invoke{
+			app.log.LogEvent(&fxevent.Invoked{
 				Function:   fn,
 				Err:        err,
 				Stacktrace: fmt.Sprintf("%+v", i.Stack), // format stack trace as multi-line

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -62,13 +62,11 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		if e.Err != nil {
 			l.logf("Error after options were applied: %v", e.Err)
 		}
-	case *Invoke:
-		if e.Err != nil {
-			l.logf("fx.Invoke(%v) called from:\n%+vFailed: %v",
-				fxreflect.FuncName(e.Function), e.Stacktrace, e.Err)
-		} else {
-			l.logf("INVOKE\t\t%s", fxreflect.FuncName(e.Function))
-		}
+	case *Invoking:
+		l.logf("INVOKE\t\t%s", fxreflect.FuncName(e.Function))
+	case *Invoked:
+		l.logf("fx.Invoke(%v) called from:\n%+vFailed: %v",
+			fxreflect.FuncName(e.Function), e.Stacktrace, e.Err)
 	case *Stop:
 		if e.Err != nil {
 			l.logf("ERROR\t\tFailed to stop cleanly: %v", e.Err)
@@ -87,11 +85,11 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		} else {
 			l.logf("RUNNING")
 		}
-	case *CustomLogger:
+	case *LoggerInitialized:
 		if e.Err != nil {
-			l.logf("ERROR\t\tFailed to construct custom logger: %v", e.Err)
+			l.logf("ERROR\t\tFailed to initialize custom logger: %v", e.Err)
 		} else {
-			l.logf("LOGGER\tSetting up custom logger from %v", fxreflect.FuncName(e.Function))
+			l.logf("LOGGER\tInitializing custom logger from %v", fxreflect.FuncName(e.Constructor))
 		}
 	}
 }

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -89,7 +89,7 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		if e.Err != nil {
 			l.logf("ERROR\t\tFailed to initialize custom logger: %v", e.Err)
 		} else {
-			l.logf("LOGGER\tInitializing custom logger from %v", fxreflect.FuncName(e.Constructor))
+			l.logf("LOGGER\tInitialized custom logger from %v", fxreflect.FuncName(e.Constructor))
 		}
 	}
 }

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -143,7 +143,7 @@ func TestConsoleLogger(t *testing.T) {
 			give: &LoggerInitialized{
 				Constructor: func() Logger { panic("should not run") },
 			},
-			want: "[Fx] LOGGER	Initializing custom logger from go.uber.org/fx/fxevent.TestConsoleLogger.func1()\n",
+			want: "[Fx] LOGGER	Initialized custom logger from go.uber.org/fx/fxevent.TestConsoleLogger.func1()\n",
 		},
 	}
 

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -85,13 +85,13 @@ func TestConsoleLogger(t *testing.T) {
 			want: "[Fx] PROVIDE	*bytes.Buffer <= bytes.NewBuffer()\n",
 		},
 		{
-			name: "Invoke",
-			give: &Invoke{Function: bytes.NewBuffer, Err: nil},
+			name: "Invoked",
+			give: &Invoking{Function: bytes.NewBuffer},
 			want: "[Fx] INVOKE		bytes.NewBuffer()\n",
 		},
 		{
 			name: "InvokeError",
-			give: &Invoke{
+			give: &Invoked{
 				Function:   bytes.NewBuffer,
 				Err:        errors.New("some error"),
 				Stacktrace: "foo()\n\tbar/baz.go:42\n",
@@ -135,15 +135,15 @@ func TestConsoleLogger(t *testing.T) {
 		},
 		{
 			name: "CustomLoggerError",
-			give: &CustomLogger{Err: errors.New("great sadness")},
-			want: "[Fx] ERROR		Failed to construct custom logger: great sadness\n",
+			give: &LoggerInitialized{Err: errors.New("great sadness")},
+			want: "[Fx] ERROR		Failed to initialize custom logger: great sadness\n",
 		},
 		{
-			name: "CustomLogger",
-			give: &CustomLogger{
-				Function: func() Logger { panic("should not run") },
+			name: "LoggerInitialized",
+			give: &LoggerInitialized{
+				Constructor: func() Logger { panic("should not run") },
 			},
-			want: "[Fx] LOGGER	Setting up custom logger from go.uber.org/fx/fxevent.TestConsoleLogger.func1()\n",
+			want: "[Fx] LOGGER	Initializing custom logger from go.uber.org/fx/fxevent.TestConsoleLogger.func1()\n",
 		},
 	}
 

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -35,11 +35,12 @@ func (*LifecycleHookExecuting) event() {}
 func (*LifecycleHookExecuted) event()  {}
 func (*Supplied) event()               {}
 func (*Provide) event()                {}
-func (*Invoke) event()                 {}
+func (*Invoking) event()               {}
+func (*Invoked) event()                {}
 func (*Stop) event()                   {}
 func (*Rollback) event()               {}
 func (*Started) event()                {}
-func (*CustomLogger) event()           {}
+func (*LoggerInitialized) event()      {}
 
 // LifecycleHookExecuting is emitted before an OnStart hook is about to be executed.
 type LifecycleHookExecuting struct {
@@ -78,8 +79,13 @@ type Provide struct {
 	Err error
 }
 
-// Invoke is emitted whenever a function is being invoked and/or it errored.
-type Invoke struct {
+// Invoking is emitted whenever a function is being invoked.
+type Invoking struct {
+	Function interface{}
+}
+
+// Invoked is emitted whenever a function errored.
+type Invoked struct {
 	Function   interface{}
 	Err        error
 	Stacktrace string
@@ -103,8 +109,8 @@ type Rollback struct {
 	Err      error
 }
 
-// CustomLogger is emitted whenever a custom logger is set or produces an error.
-type CustomLogger struct {
-	Function interface{}
-	Err      error
+// LoggerInitialized is emitted whenever a custom logger is set or produces an error.
+type LoggerInitialized struct {
+	Constructor interface{}
+	Err         error
 }

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -84,7 +84,7 @@ type Invoking struct {
 	Function interface{}
 }
 
-// Invoked is emitted whenever a function errored.
+// Invoked is emitted whenever a function being invoked errored.
 type Invoked struct {
 	Function   interface{}
 	Err        error

--- a/fxevent/event_test.go
+++ b/fxevent/event_test.go
@@ -33,11 +33,12 @@ func TestForCoverage(t *testing.T) {
 		&LifecycleHookExecuted{},
 		&Supplied{},
 		&Provide{},
-		&Invoke{},
+		&Invoking{},
+		&Invoked{},
 		&Stop{},
 		&Rollback{},
 		&Started{},
-		&CustomLogger{},
+		&LoggerInitialized{},
 	}
 
 	for _, e := range events {

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -72,16 +72,14 @@ func (l *ZapLogger) LogEvent(event Event) {
 			l.Logger.Error("error encountered while applying options",
 				zap.Error(e.Err))
 		}
-	case *Invoke:
-		if e.Err != nil {
-			l.Logger.Error("invoke failed",
-				zap.Error(e.Err),
-				zap.String("stack", e.Stacktrace),
-				zap.String("function", fxreflect.FuncName(e.Function)))
-		} else {
-			l.Logger.Info("invoked",
-				zap.String("function", fxreflect.FuncName(e.Function)))
-		}
+	case *Invoking:
+		l.Logger.Info("invoked",
+			zap.String("function", fxreflect.FuncName(e.Function)))
+	case *Invoked:
+		l.Logger.Error("invoke failed",
+			zap.Error(e.Err),
+			zap.String("stack", e.Stacktrace),
+			zap.String("function", fxreflect.FuncName(e.Function)))
 	case *Stop:
 		if e.Err != nil {
 			l.Logger.Error("stop failed", zap.Error(e.Err))
@@ -101,12 +99,12 @@ func (l *ZapLogger) LogEvent(event Event) {
 		} else {
 			l.Logger.Info("started")
 		}
-	case *CustomLogger:
+	case *LoggerInitialized:
 		if e.Err != nil {
-			l.Logger.Error("custom logger installation failed", zap.Error(e.Err))
+			l.Logger.Error("custom logger initialization failed", zap.Error(e.Err))
 		} else {
-			l.Logger.Info("installed custom fxevent.Logger",
-				zap.String("function", fxreflect.FuncName(e.Function)))
+			l.Logger.Info("initialized custom fxevent.Logger",
+				zap.String("function", fxreflect.FuncName(e.Constructor)))
 		}
 	}
 }

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -118,8 +118,8 @@ func TestZapLogger(t *testing.T) {
 			},
 		},
 		{
-			name:        "Invoke",
-			give:        &Invoke{Function: bytes.NewBuffer, Err: nil},
+			name:        "Invoking",
+			give:        &Invoking{Function: bytes.NewBuffer},
 			wantMessage: "invoked",
 			wantFields: map[string]interface{}{
 				"function": "bytes.NewBuffer()",
@@ -127,7 +127,7 @@ func TestZapLogger(t *testing.T) {
 		},
 		{
 			name:        "InvokeError",
-			give:        &Invoke{Function: bytes.NewBuffer, Err: someError},
+			give:        &Invoked{Function: bytes.NewBuffer, Err: someError},
 			wantMessage: "invoke failed",
 			wantFields: map[string]interface{}{
 				"error":    "some error",
@@ -182,17 +182,17 @@ func TestZapLogger(t *testing.T) {
 			wantFields:  map[string]interface{}{},
 		},
 		{
-			name:        "CustomLogger Error",
-			give:        &CustomLogger{Err: someError},
-			wantMessage: "custom logger installation failed",
+			name:        "LoggerInitialized Error",
+			give:        &LoggerInitialized{Err: someError},
+			wantMessage: "custom logger initialization failed",
 			wantFields: map[string]interface{}{
 				"error": "some error",
 			},
 		},
 		{
-			name:        "CustomLogger",
-			give:        &CustomLogger{Function: bytes.NewBuffer, Err: nil},
-			wantMessage: "installed custom fxevent.Logger",
+			name:        "LoggerInitialized",
+			give:        &LoggerInitialized{Constructor: bytes.NewBuffer, Err: nil},
+			wantMessage: "initialized custom fxevent.Logger",
 			wantFields: map[string]interface{}{
 				"function": "bytes.NewBuffer()",
 			},


### PR DESCRIPTION
Follow up to #756 where we introduce a new `Invoking` event to be emitted before an `fx.Invoke`, rename `Invoke` to `Invoked`.

Additionally, `Provide` event will have access to constructor field in case it's emitted as a result of an error.

Ref GO-743