### PR TITLE
Fix issues in Invoked event

### DIFF
--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -76,7 +76,9 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		l.logf("INVOKE\t\t%s", e.FunctionName)
 	case *Invoked:
 		if e.Err != nil {
-			l.logf("fx.Invoke(%v) called from:\n%+vFailed: %v", e.FunctionName, e.Trace, e.Err)
+			l.logf("ERROR\t\tfx.Invoke(%v) called from:\n%+vFailed: %v", e.FunctionName, e.Trace, e.Err)
+		} else {
+			l.logf("fx.Invoke(%v) called from:\n%v", e.FunctionName, e.Trace)
 		}
 	case *Stopping:
 		l.logf("%v", strings.ToUpper(e.Signal.String()))

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -126,6 +126,11 @@ func TestConsoleLogger(t *testing.T) {
 				FunctionName: "bytes.NewBuffer()",
 				Trace:        "foo()\n\tbar/baz.go:42\n",
 			},
+			want: joinLines(
+				"[Fx] fx.Invoke(bytes.NewBuffer()) called from:",
+				"foo()",
+				"	bar/baz.go:42\n",
+			),
 		},
 		{
 			name: "Invoked/Error",
@@ -135,7 +140,7 @@ func TestConsoleLogger(t *testing.T) {
 				Trace:        "foo()\n\tbar/baz.go:42\n",
 			},
 			want: joinLines(
-				"[Fx] fx.Invoke(bytes.NewBuffer()) called from:",
+				"[Fx] ERROR		fx.Invoke(bytes.NewBuffer()) called from:",
 				"foo()",
 				"	bar/baz.go:42",
 				"Failed: some error",

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -91,14 +91,16 @@ func (l *ZapLogger) LogEvent(event Event) {
 		// Do nothing. Will log on Invoked.
 
 	case *Invoked:
-		msg := "invoked"
 		if e.Err != nil {
-			msg = "invoke failed"
+			l.Logger.Error("invoke failed",
+				zap.Error(e.Err),
+				zap.String("stack", e.Trace),
+				zap.String("function", e.FunctionName))
+		} else {
+			l.Logger.Info("invoked",
+				zap.String("stack", e.Trace),
+				zap.String("function", e.FunctionName))
 		}
-		l.Logger.Error(msg,
-			zap.Error(e.Err),
-			zap.String("stack", e.Trace),
-			zap.String("function", e.FunctionName))
 	case *Stopping:
 		l.Logger.Info("received signal",
 			zap.String("signal", strings.ToUpper(e.Signal.String())))


### PR DESCRIPTION
Fix #770. 

`Invoked` event is being logged at error level at all times, even when it has succeeded. This is now being changed to be logged at `Info` level when `Invoke` succeeded.

There was also a discrepancy between the zap logger and the console logger in behavior because the console logger never logged `Invoked` event upon successfully invoking the provided function, so this fixes that behavior to be aligned with zap logger as well.

