### PR TITLE
Change when we log `fxevent.Invoking` and `fxevent.Invoked` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
--  No changes yet.
+### Changed
+-  For `fxevent` console implementation: no longer log non-error case for `fxevent.Invoke`
+   event, while for zap implementation, start logging `fx.Invoking` case without stack.
 
 ## [1.14.1] - 2021-08-16
 ### Changed

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -77,8 +77,6 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 	case *Invoked:
 		if e.Err != nil {
 			l.logf("ERROR\t\tfx.Invoke(%v) called from:\n%+vFailed: %v", e.FunctionName, e.Trace, e.Err)
-		} else {
-			l.logf("fx.Invoke(%v) called from:\n%v", e.FunctionName, e.Trace)
 		}
 	case *Stopping:
 		l.logf("%v", strings.ToUpper(e.Signal.String()))

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -121,18 +121,6 @@ func TestConsoleLogger(t *testing.T) {
 			want: "[Fx] INVOKE		bytes.NewBuffer()\n",
 		},
 		{
-			name: "Invoked/Success",
-			give: &Invoked{
-				FunctionName: "bytes.NewBuffer()",
-				Trace:        "foo()\n\tbar/baz.go:42\n",
-			},
-			want: joinLines(
-				"[Fx] fx.Invoke(bytes.NewBuffer()) called from:",
-				"foo()",
-				"	bar/baz.go:42\n",
-			),
-		},
-		{
 			name: "Invoked/Error",
 			give: &Invoked{
 				FunctionName: "bytes.NewBuffer()",

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -88,16 +88,13 @@ func (l *ZapLogger) LogEvent(event Event) {
 				zap.Error(e.Err))
 		}
 	case *Invoking:
-		// Do nothing. Will log on Invoked.
-
+		// Do not log stack as it will make logs hard to read.
+		l.Logger.Info("invoked",
+			zap.String("function", e.FunctionName))
 	case *Invoked:
 		if e.Err != nil {
 			l.Logger.Error("invoke failed",
 				zap.Error(e.Err),
-				zap.String("stack", e.Trace),
-				zap.String("function", e.FunctionName))
-		} else {
-			l.Logger.Info("invoked",
 				zap.String("stack", e.Trace),
 				zap.String("function", e.FunctionName))
 		}

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -89,7 +89,7 @@ func (l *ZapLogger) LogEvent(event Event) {
 		}
 	case *Invoking:
 		// Do not log stack as it will make logs hard to read.
-		l.Logger.Info("invoked",
+		l.Logger.Info("invoking",
 			zap.String("function", e.FunctionName))
 	case *Invoked:
 		if e.Err != nil {

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -166,7 +166,7 @@ func TestZapLogger(t *testing.T) {
 		{
 			name:        "Invoking/Success",
 			give:        &Invoking{FunctionName: "bytes.NewBuffer()"},
-			wantMessage: "invoked",
+			wantMessage: "invoking",
 			wantFields: map[string]interface{}{
 				"function": "bytes.NewBuffer()",
 			},

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -164,12 +164,11 @@ func TestZapLogger(t *testing.T) {
 			},
 		},
 		{
-			name:        "Invoked/Success",
-			give:        &Invoked{FunctionName: "bytes.NewBuffer()"},
+			name:        "Invoking/Success",
+			give:        &Invoking{FunctionName: "bytes.NewBuffer()"},
 			wantMessage: "invoked",
 			wantFields: map[string]interface{}{
 				"function": "bytes.NewBuffer()",
-				"stack":    "",
 			},
 		},
 		{


### PR DESCRIPTION
For `fxevent` console implementation: no longer log non-error case for `fxevent.Invoke` event, while for zap implementation, start logging `fx.Invoking` case without stack.