### PR TITLE
Fix documentation on WithLogger

### DIFF
--- a/app.go
+++ b/app.go
@@ -272,7 +272,7 @@ func (t stopTimeoutOption) String() string {
 // For example,
 //
 //   WithLogger(func(logger *zap.Logger) fxevent.Logger {
-//     return &fxevent.ZapLogger{Log: logger}
+//     return &fxevent.ZapLogger{Logger: logger}
 //   })
 //
 func WithLogger(constructor interface{}) Option {


### PR DESCRIPTION
The code sample in the documentation on `fx.WithLogger` was incorrect because it was referring to a non-existent field `Log` - this was renamed to `Logger` but the corresponding change wasn't made in the doc. Fixing this typo to make the code sample align with the actual API. 

