### PR TITLE
Make Populate return errorOption allowing ValidateApp to recognise wireup problems

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -65,7 +65,7 @@ func NewSpied(opts ...Option) (*App, *fxlog.Spy) {
 	return New(opts...), spy
 }
 
-func NewValidateAppErr(tb testing.TB, opts ...Option) error {
+func validateTestApp(tb testing.TB, opts ...Option) error {
 	testOpts := []Option{
 		// Provide both: Logger and WithLogger so that if the test
 		// WithLogger fails, we don't pollute stderr.

--- a/app_test.go
+++ b/app_test.go
@@ -65,6 +65,18 @@ func NewSpied(opts ...Option) (*App, *fxlog.Spy) {
 	return New(opts...), spy
 }
 
+func NewValidateAppErr(tb testing.TB, opts ...Option) error {
+	testOpts := []Option{
+		// Provide both: Logger and WithLogger so that if the test
+		// WithLogger fails, we don't pollute stderr.
+		Logger(fxtest.NewTestPrinter(tb)),
+		WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(tb) }),
+	}
+	opts = append(testOpts, opts...)
+
+	return ValidateApp(opts...)
+}
+
 func TestNewApp(t *testing.T) {
 	t.Run("ProvidesLifecycleAndShutdowner", func(t *testing.T) {
 		var (

--- a/extract.go
+++ b/extract.go
@@ -39,7 +39,7 @@ func Extract(target interface{}) Option {
 	v := reflect.ValueOf(target)
 
 	if t := v.Type(); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
-		return invokeErr(fmt.Errorf("Extract expected a pointer to a struct, got a %v", t))
+		return Error(fmt.Errorf("Extract expected a pointer to a struct, got a %v", t))
 	}
 
 	v = v.Elem()

--- a/extract_test.go
+++ b/extract_test.go
@@ -59,6 +59,27 @@ func TestExtract(t *testing.T) {
 		}
 	})
 
+	t.Run("ValidateApp", func(t *testing.T) {
+		tests := []interface{}{
+			3,
+			func() {},
+			struct{}{},
+			struct{ Foo *bytes.Buffer }{},
+		}
+
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%T", tt), func(t *testing.T) {
+				err := NewValidateAppErr(t,
+					Provide(func() *bytes.Buffer { return &bytes.Buffer{} }),
+					Extract(&tt),
+				)
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "Extract expected a pointer to a struct")
+			})
+		}
+	})
+
 	t.Run("Empty", func(t *testing.T) {
 		new1 := func() *type1 { panic("new1 must not be called") }
 		new2 := func() *type2 { panic("new2 must not be called") }

--- a/extract_test.go
+++ b/extract_test.go
@@ -69,7 +69,7 @@ func TestExtract(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("%T", tt), func(t *testing.T) {
-				err := NewValidateAppErr(t,
+				err := validateTestApp(t,
 					Provide(func() *bytes.Buffer { return &bytes.Buffer{} }),
 					Extract(&tt),
 				)

--- a/populate.go
+++ b/populate.go
@@ -38,11 +38,11 @@ func Populate(targets ...interface{}) Option {
 	targetTypes := make([]reflect.Type, len(targets))
 	for i, t := range targets {
 		if t == nil {
-			return invokeErr(fmt.Errorf("failed to Populate: target %v is nil", i+1))
+			return Error(fmt.Errorf("failed to Populate: target %v is nil", i+1))
 		}
 		rt := reflect.TypeOf(t)
 		if rt.Kind() != reflect.Ptr {
-			return invokeErr(fmt.Errorf("failed to Populate: target %v is not a pointer type, got %T", i+1, t))
+			return Error(fmt.Errorf("failed to Populate: target %v is not a pointer type, got %T", i+1, t))
 		}
 
 		targetTypes[i] = reflect.TypeOf(t).Elem()
@@ -64,10 +64,4 @@ func Populate(targets ...interface{}) Option {
 		return nil
 	})
 	return Invoke(fn.Interface())
-}
-
-func invokeErr(err error) Option {
-	return Invoke(func() error {
-		return err
-	})
 }

--- a/populate_test.go
+++ b/populate_test.go
@@ -261,42 +261,42 @@ func TestPopulateValidateApp(t *testing.T) {
 
 	tests := []struct {
 		msg     string
-		opt     Option
+		opts    []interface{}
 		wantErr string
 	}{
 		{
 			msg:     "inline value",
-			opt:     Populate(t1{}),
+			opts:    []interface{}{t1{}},
 			wantErr: "not a pointer",
 		},
 		{
 			msg:     "container value",
-			opt:     Populate(container{}),
+			opts:    []interface{}{container{}},
 			wantErr: "not a pointer",
 		},
 		{
 			msg:     "container pointer without fx.In",
-			opt:     Populate(&containerNoIn{}),
+			opts:    []interface{}{&containerNoIn{}},
 			wantErr: "missing type: fx_test.containerNoIn",
 		},
 		{
 			msg:     "function",
-			opt:     Populate(fn),
+			opts:    []interface{}{fn},
 			wantErr: "not a pointer",
 		},
 		{
 			msg:     "function pointer",
-			opt:     Populate(&fn),
+			opts:    []interface{}{&fn},
 			wantErr: "missing type: func()",
 		},
 		{
 			msg:     "invalid last argument",
-			opt:     Populate(&v, t1{}),
+			opts:    []interface{}{&v, t1{}},
 			wantErr: "target 2 is not a pointer type",
 		},
 		{
 			msg:     "nil argument",
-			opt:     Populate(&v, nil, &v),
+			opts:    []interface{}{&v, nil, &v},
 			wantErr: "target 2 is nil",
 		},
 	}
@@ -306,11 +306,10 @@ func TestPopulateValidateApp(t *testing.T) {
 			testOpts := []Option{
 				NopLogger,
 				Provide(func() *t1 { return &t1{} }),
-
-				tt.opt,
+				Populate(tt.opts...),
 			}
 
-			err := NewValidateAppErr(t, testOpts...)
+			err := validateTestApp(t, testOpts...)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})


### PR DESCRIPTION
This PR solves issue #762 that I've reported earlier. 

This slightly changes the internal behaviour of `Populate`, instead of returning a dedicated custom `invokeErr` option it returns a standard `errorOption`. This allows the `ValidateApp()` helper to recognise wire-up issues that arise from incorrectly configured `Populate` options. This wasn't possible earlier because `ValidateApp` sets `DryRun=true` for the `dig` container, and that makes it ignore and not execute any invocations, so the `invokeErr` was never called and the related errors could not be discovered in the unit tests relying on `ValidateApp`.

Using `errorOption` sets the `App.err` explicitly on applying option (rather than on calling invocations), so it allows to surface errors produced by `Populate` in dry-run mode without calling the invocations.

This also makes the same change to the deprecated `Extract` function, since I'm not sure when/if it will be removed.