### PR TITLE
Parallelize all tests

### DIFF
--- a/annotated_test.go
+++ b/annotated_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestAnnotated(t *testing.T) {
+	t.Parallel()
+
 	type a struct {
 		name string
 	}
@@ -43,6 +45,8 @@ func TestAnnotated(t *testing.T) {
 		return &a{name: "foo"}
 	}
 	t.Run("Provide", func(t *testing.T) {
+		t.Parallel()
+
 		var in in
 		app := fxtest.New(t,
 			fx.Provide(
@@ -60,6 +64,8 @@ func TestAnnotated(t *testing.T) {
 }
 
 func TestAnnotatedWrongUsage(t *testing.T) {
+	t.Parallel()
+
 	type a struct {
 		name string
 	}
@@ -73,6 +79,8 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 	}
 
 	t.Run("In Constructor", func(t *testing.T) {
+		t.Parallel()
+
 		var in in
 		app := fx.New(
 			fx.WithLogger(func() fxevent.Logger {
@@ -105,6 +113,8 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 	})
 
 	t.Run("Result Type", func(t *testing.T) {
+		t.Parallel()
+
 		app := fx.New(
 			fx.WithLogger(func() fxevent.Logger {
 				return fxtest.NewTestLogger(t)
@@ -123,6 +133,8 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 }
 
 func TestAnnotatedString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		give fx.Annotated
@@ -171,13 +183,18 @@ func TestAnnotatedString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.want, tt.give.String())
 		})
 	}
 }
 
 func TestAnnotate(t *testing.T) {
+	t.Parallel()
+
 	type a struct{}
 	type b struct{ a *a }
 	type c struct{ b *b }
@@ -190,6 +207,8 @@ func TestAnnotate(t *testing.T) {
 	}
 
 	t.Run("Provide with optional", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			fx.Provide(
 				fx.Annotate(newB, fx.ParamTags(`name:"a" optional:"true"`)),
@@ -201,6 +220,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("Provide with many annotated params", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			fx.Provide(
 				fx.Annotate(newB, fx.ParamTags(`optional:"true"`)),
@@ -216,6 +237,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("Invoke with optional", func(t *testing.T) {
+		t.Parallel()
+
 		app := fx.New(
 			fx.Invoke(
 				fx.Annotate(newB, fx.ParamTags(`optional:"true"`)),
@@ -226,6 +249,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("Invoke with a missing dependency", func(t *testing.T) {
+		t.Parallel()
+
 		app := fx.New(
 			fx.Invoke(
 				fx.Annotate(newB, fx.ParamTags(`name:"a"`)),
@@ -238,6 +263,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("provide with annotated results", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			fx.Provide(
 				fx.Annotate(func() *a {
@@ -265,6 +292,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("provide with missing annotated results", func(t *testing.T) {
+		t.Parallel()
+
 		app := fx.New(
 			fx.Provide(
 				fx.Annotate(func() *a {
@@ -292,6 +321,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("provide with annotated results with error", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			fx.Provide(
 				//lint:ignore ST1008 we want to test error in the middle.
@@ -311,6 +342,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("specify more ParamTags than Params", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			fx.Provide(
 				// This should just leave newA as it is.
@@ -325,6 +358,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("specify two ParamTags", func(t *testing.T) {
+		t.Parallel()
+
 		app := fx.New(
 			fx.Provide(
 				// This should just leave newA as it is.
@@ -342,6 +377,8 @@ func TestAnnotate(t *testing.T) {
 	})
 
 	t.Run("specify two ResultTags", func(t *testing.T) {
+		t.Parallel()
+
 		app := fx.New(
 			fx.Provide(
 				// This should just leave newA as it is.

--- a/app_internal_test.go
+++ b/app_internal_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestAppRun(t *testing.T) {
+	t.Parallel()
+
 	spy := new(fxlog.Spy)
 	app := New(
 		WithLogger(func() fxevent.Logger { return spy }),
@@ -62,6 +64,8 @@ func TestAppRun(t *testing.T) {
 
 // TestValidateString verifies private option. Public options are tested in app_test.go.
 func TestValidateString(t *testing.T) {
+	t.Parallel()
+
 	stringer, ok := validate(true).(fmt.Stringer)
 	require.True(t, ok, "option must implement stringer")
 	assert.Equal(t, "fx.validate(true)", stringer.String())

--- a/app_test.go
+++ b/app_test.go
@@ -78,7 +78,11 @@ func validateTestApp(tb testing.TB, opts ...Option) error {
 }
 
 func TestNewApp(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ProvidesLifecycleAndShutdowner", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			l Lifecycle
 			s Shutdowner
@@ -92,6 +96,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("OptionsHappensBeforeProvides", func(t *testing.T) {
+		t.Parallel()
+
 		// Should be grouping all provides and pushing them into the container
 		// after applying other options. This prevents the app configuration
 		// (e.g., logging) from changing halfway through our provides.
@@ -108,6 +114,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("CircularGraphReturnsError", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{}
 		app := NewForTest(t,
@@ -125,6 +133,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("ProvidesDotGraph", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{}
 		type C struct{}
@@ -141,6 +151,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("ProvidesWithAnnotate", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 
 		type B struct {
@@ -180,6 +192,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("ProvidesWithAnnotateFlattened", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			Provide(Annotated{
 				Target: func() []int { return []int{1} },
@@ -200,6 +214,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("ProvidesWithEmptyAnnotate", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 
 		type B struct {
@@ -226,6 +242,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("CannotNameAndGroup", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 
 		app := NewForTest(t,
@@ -253,6 +271,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("ErrorProvidingAnnotated", func(t *testing.T) {
+		t.Parallel()
+
 		app := NewForTest(t, Provide(Annotated{
 			Target: 42, // not a constructor
 			Name:   "foo",
@@ -275,6 +295,8 @@ func TestNewApp(t *testing.T) {
 	})
 
 	t.Run("ErrorProviding", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewForTest(t, Provide(42)).Err()
 		require.Error(t, err)
 
@@ -319,6 +341,8 @@ func TestWithLogger(t *testing.T) {
 	})
 
 	t.Run("error in WithLogger provider, use default", func(t *testing.T) {
+		t.Parallel()
+
 		// This test cannot be run in paralllel with the others because
 		// it hijacks stderr.
 
@@ -434,7 +458,11 @@ type errHandlerFunc func(error)
 func (f errHandlerFunc) HandleError(err error) { f(err) }
 
 func TestInvokes(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Success event", func(t *testing.T) {
+		t.Parallel()
+
 		app, spy := NewSpied(
 			Invoke(func() {}),
 		)
@@ -446,6 +474,8 @@ func TestInvokes(t *testing.T) {
 	})
 
 	t.Run("Failure event", func(t *testing.T) {
+		t.Parallel()
+
 		app, spy := NewSpied(
 			Invoke(func() error {
 				return errors.New("great sadness")
@@ -459,6 +489,8 @@ func TestInvokes(t *testing.T) {
 	})
 
 	t.Run("ErrorsAreNotOverriden", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{}
 
@@ -473,6 +505,8 @@ func TestInvokes(t *testing.T) {
 	})
 
 	t.Run("ErrorHooksAreCalled", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 
 		count := 0
@@ -488,7 +522,11 @@ func TestInvokes(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NilErrorOption", func(t *testing.T) {
+		t.Parallel()
+
 		var invoked bool
 
 		app := NewForTest(t,
@@ -501,6 +539,8 @@ func TestError(t *testing.T) {
 	})
 
 	t.Run("SingleErrorOption", func(t *testing.T) {
+		t.Parallel()
+
 		app := NewForTest(t,
 			Error(errors.New("module failure")),
 			Invoke(func() { t.Errorf("Invoke should not be called") }),
@@ -510,6 +550,8 @@ func TestError(t *testing.T) {
 	})
 
 	t.Run("MultipleErrorOption", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 
 		app := NewForTest(t,
@@ -532,6 +574,8 @@ func TestError(t *testing.T) {
 	})
 
 	t.Run("ProvideAndInvokeErrorsAreIgnored", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{}
 
@@ -550,7 +594,11 @@ func TestError(t *testing.T) {
 }
 
 func TestOptions(t *testing.T) {
+	t.Parallel()
+
 	t.Run("OptionsComposition", func(t *testing.T) {
+		t.Parallel()
+
 		var n int
 		construct := func() struct{} {
 			n++
@@ -565,6 +613,8 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("ProvidesCalledInGraphOrder", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
@@ -598,6 +648,8 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("ProvidesCalledLazily", func(t *testing.T) {
+		t.Parallel()
+
 		count := 0
 		newBuffer := func() *bytes.Buffer {
 			t.Error("this module should not init: no provided type relies on it")
@@ -616,6 +668,8 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("Error", func(t *testing.T) {
+		t.Parallel()
+
 		spy := new(fxlog.Spy)
 		New(
 			Provide(&bytes.Buffer{}), // error, not a constructor
@@ -627,6 +681,8 @@ func TestOptions(t *testing.T) {
 }
 
 func TestTimeoutOptions(t *testing.T) {
+	t.Parallel()
+
 	const timeout = time.Minute
 	// Further assertions can't succeed unless the test timeout is greater than the default.
 	require.True(t, timeout > DefaultTimeout, "test assertions require timeout greater than default")
@@ -666,7 +722,11 @@ func TestTimeoutOptions(t *testing.T) {
 }
 
 func TestAppStart(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Timeout", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		blocker := func(lc Lifecycle) *A {
 			lc.Append(
@@ -699,6 +759,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("TimeoutWithFinishedHooks", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{ A *A }
 		type C struct{ B *B }
@@ -763,6 +825,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("CtxCancelledDuringStart", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		running := make(chan struct{})
 		newA := func(lc Lifecycle) *A {
@@ -801,6 +865,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("Rollback", func(t *testing.T) {
+		t.Parallel()
+
 		failStart := func(lc Lifecycle) struct{} {
 			lc.Append(Hook{OnStart: func(context.Context) error {
 				return errors.New("OnStart fail")
@@ -828,6 +894,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("StartAndStopErrors", func(t *testing.T) {
+		t.Parallel()
+
 		errStop1 := errors.New("OnStop fail 1")
 		errStart2 := errors.New("OnStart fail 2")
 		fail := func(lc Lifecycle) struct{} {
@@ -864,6 +932,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("InvokeNonFunction", func(t *testing.T) {
+		t.Parallel()
+
 		spy := new(fxlog.Spy)
 
 		app := New(WithLogger(func() fxevent.Logger { return spy }), Invoke(struct{}{}))
@@ -888,6 +958,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("ProvidingAProvideShouldFail", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
@@ -918,6 +990,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("InvokingAnInvokeShouldFail", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 
 		app := NewForTest(t,
@@ -945,6 +1019,8 @@ func TestAppStart(t *testing.T) {
 	})
 
 	t.Run("ProvidingOptionsShouldFail", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 		type type2 struct{}
 		type type3 struct{}
@@ -982,7 +1058,11 @@ func TestAppStart(t *testing.T) {
 }
 
 func TestAppStop(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Timeout", func(t *testing.T) {
+		t.Parallel()
+
 		block := func(ctx context.Context) error {
 			<-ctx.Done()
 			return ctx.Err()
@@ -1008,6 +1088,8 @@ func TestAppStop(t *testing.T) {
 	})
 
 	t.Run("StopError", func(t *testing.T) {
+		t.Parallel()
+
 		failStop := func(lc Lifecycle) struct{} {
 			lc.Append(Hook{OnStop: func(context.Context) error {
 				return errors.New("OnStop fail")
@@ -1026,6 +1108,8 @@ func TestAppStop(t *testing.T) {
 }
 
 func TestValidateApp(t *testing.T) {
+	t.Parallel()
+
 	// helper to use the test logger
 	validateApp := func(t *testing.T, opts ...Option) error {
 		return ValidateApp(
@@ -1034,6 +1118,8 @@ func TestValidateApp(t *testing.T) {
 	}
 
 	t.Run("do not run provides on graph validation", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 		err := validateApp(t,
 			Provide(func() *type1 {
@@ -1045,6 +1131,8 @@ func TestValidateApp(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("do not run provides nor invokes on graph validation", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 		err := validateApp(t,
 			Provide(func() *type1 {
@@ -1058,6 +1146,8 @@ func TestValidateApp(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("provide depends on something not available", func(t *testing.T) {
+		t.Parallel()
+
 		type type1 struct{}
 		err := validateApp(t,
 			Provide(func(type1) int { return 0 }),
@@ -1070,6 +1160,8 @@ func TestValidateApp(t *testing.T) {
 		assert.Contains(t, errMsg, "missing type: fx_test.type1")
 	})
 	t.Run("provide introduces a cycle", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{}
 		err := validateApp(t,
@@ -1082,6 +1174,8 @@ func TestValidateApp(t *testing.T) {
 		assert.Contains(t, errMsg, "cycle detected in dependency graph")
 	})
 	t.Run("invoke a type that's not available", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		err := validateApp(t,
 			Invoke(func(A) {}),
@@ -1092,6 +1186,8 @@ func TestValidateApp(t *testing.T) {
 		assert.Contains(t, errMsg, "missing type: fx_test.A")
 	})
 	t.Run("no error", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		err := validateApp(t,
 			Provide(func() A {
@@ -1104,6 +1200,8 @@ func TestValidateApp(t *testing.T) {
 }
 
 func TestDone(t *testing.T) {
+	t.Parallel()
+
 	done := fxtest.New(t).Done()
 	require.NotNil(t, done, "Got a nil channel.")
 	select {
@@ -1114,6 +1212,8 @@ func TestDone(t *testing.T) {
 }
 
 func TestReplaceLogger(t *testing.T) {
+	t.Parallel()
+
 	spy := new(fxlog.Spy)
 	app := fxtest.New(t, WithLogger(func() fxevent.Logger { return spy }))
 	app.RequireStart().RequireStop()
@@ -1121,11 +1221,15 @@ func TestReplaceLogger(t *testing.T) {
 }
 
 func TestNopLogger(t *testing.T) {
+	t.Parallel()
+
 	app := fxtest.New(t, NopLogger)
 	app.RequireStart().RequireStop()
 }
 
 func TestCustomLoggerWithPrinter(t *testing.T) {
+	t.Parallel()
+
 	// If we provide both, an fx.Logger and fx.WithLogger, and the logger
 	// fails, we should fall back to the fx.Logger.
 
@@ -1146,6 +1250,8 @@ func TestCustomLoggerWithPrinter(t *testing.T) {
 }
 
 func TestCustomLoggerWithLifecycle(t *testing.T) {
+	t.Parallel()
+
 	var started, stopped bool
 	defer func() {
 		assert.True(t, started, "never started")
@@ -1194,6 +1300,8 @@ func TestCustomLoggerWithLifecycle(t *testing.T) {
 }
 
 func TestCustomLoggerFailure(t *testing.T) {
+	t.Parallel()
+
 	var buff bytes.Buffer
 	app := New(
 		// We expect WithLogger to fail, so this buffer should be
@@ -1225,18 +1333,26 @@ func (we testErrorWithGraph) Error() string {
 }
 
 func TestVisualizeError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NotWrappedError", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := VisualizeError(errors.New("great sadness"))
 		require.Error(t, err)
 	})
 
 	t.Run("WrappedErrorWithEmptyGraph", func(t *testing.T) {
+		t.Parallel()
+
 		graph, err := VisualizeError(testErrorWithGraph{graph: ""})
 		assert.Empty(t, graph)
 		require.Error(t, err)
 	})
 
 	t.Run("WrappedError", func(t *testing.T) {
+		t.Parallel()
+
 		graph, err := VisualizeError(testErrorWithGraph{graph: "graph"})
 		assert.Equal(t, "graph", graph)
 		require.NoError(t, err)
@@ -1244,7 +1360,11 @@ func TestVisualizeError(t *testing.T) {
 }
 
 func TestErrorHook(t *testing.T) {
+	t.Parallel()
+
 	t.Run("UnvisualizableError", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 
 		var graphErr error
@@ -1260,6 +1380,8 @@ func TestErrorHook(t *testing.T) {
 	})
 
 	t.Run("GraphWithError", func(t *testing.T) {
+		t.Parallel()
+
 		type A struct{}
 		type B struct{}
 
@@ -1281,6 +1403,8 @@ func TestErrorHook(t *testing.T) {
 }
 
 func TestOptionString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		give Option
@@ -1367,7 +1491,10 @@ func TestOptionString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			stringer, ok := tt.give.(fmt.Stringer)
 			require.True(t, ok, "option must implement stringer")
 			assert.Equal(t, tt.want, stringer.String())

--- a/extract_test.go
+++ b/extract_test.go
@@ -34,11 +34,15 @@ import (
 )
 
 func TestExtract(t *testing.T) {
+	t.Parallel()
+
 	type type1 struct{}
 	type type2 struct{}
 	type type3 struct{}
 
 	t.Run("Failures", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []interface{}{
 			3,
 			func() {},
@@ -47,7 +51,10 @@ func TestExtract(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
 			t.Run(fmt.Sprintf("%T", tt), func(t *testing.T) {
+				t.Parallel()
+
 				app := NewForTest(t,
 					Provide(func() *bytes.Buffer { return &bytes.Buffer{} }),
 					Extract(&tt),
@@ -60,6 +67,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("ValidateApp", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []interface{}{
 			3,
 			func() {},
@@ -68,7 +77,10 @@ func TestExtract(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
 			t.Run(fmt.Sprintf("%T", tt), func(t *testing.T) {
+				t.Parallel()
+
 				err := validateTestApp(t,
 					Provide(func() *bytes.Buffer { return &bytes.Buffer{} }),
 					Extract(&tt),
@@ -81,6 +93,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
 		new1 := func() *type1 { panic("new1 must not be called") }
 		new2 := func() *type2 { panic("new2 must not be called") }
 
@@ -93,6 +107,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("StructIsExtracted", func(t *testing.T) {
+		t.Parallel()
+
 		var gave1 *type1
 		new1 := func() *type1 {
 			gave1 = &type1{}
@@ -123,6 +139,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("EmbeddedExportedField", func(t *testing.T) {
+		t.Parallel()
+
 		type T1 struct{}
 
 		var gave1 *T1
@@ -144,6 +162,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("EmbeddedUnexportedField", func(t *testing.T) {
+		t.Parallel()
+
 		new1 := func() *type1 { return &type1{} }
 		var out struct{ *type1 }
 
@@ -155,6 +175,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("EmbeddedUnexportedFieldValue", func(t *testing.T) {
+		t.Parallel()
+
 		type type4 struct{ foo string }
 		new4 := func() type4 { return type4{"foo"} }
 		var out struct{ type4 }
@@ -167,6 +189,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("DuplicateFields", func(t *testing.T) {
+		t.Parallel()
+
 		var gave *type1
 		new1 := func() *type1 {
 			require.Nil(t, gave, "gave must be nil")
@@ -192,6 +216,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("SkipsUnexported", func(t *testing.T) {
+		t.Parallel()
+
 		var gave1 *type1
 		new1 := func() *type1 {
 			gave1 = &type1{}
@@ -226,6 +252,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("DoesNotZeroUnexported", func(t *testing.T) {
+		t.Parallel()
+
 		var gave1 *type1
 		new1 := func() *type1 {
 			gave1 = &type1{}
@@ -254,12 +282,16 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("TopLevelDigIn", func(t *testing.T) {
+		t.Parallel()
+
 		var out struct{ dig.In }
 		app := fxtest.New(t, Extract(&out))
 		defer app.RequireStart().RequireStop()
 	})
 
 	t.Run("TopLevelFxIn", func(t *testing.T) {
+		t.Parallel()
+
 		new1 := func() *type1 { panic("new1 must not be called") }
 		new2 := func() *type2 { panic("new2 must not be called") }
 
@@ -273,6 +305,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("NestedFxIn", func(t *testing.T) {
+		t.Parallel()
+
 		var gave1 *type1
 		new1 := func() *type1 {
 			gave1 = &type1{}
@@ -300,6 +334,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("FurtherNestedFxIn", func(t *testing.T) {
+		t.Parallel()
+
 		var out struct {
 			In
 
@@ -319,6 +355,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("FieldsCanBeOptional", func(t *testing.T) {
+		t.Parallel()
+
 		var gave1 *type1
 		new1 := func() *type1 {
 			gave1 = &type1{}

--- a/fxevent/event_test.go
+++ b/fxevent/event_test.go
@@ -28,6 +28,8 @@ import (
 
 // TestForCoverage adds coverage for own sake.
 func TestForCoverage(t *testing.T) {
+	t.Parallel()
+
 	events := []Event{
 		&OnStartExecuting{},
 		&OnStartExecuted{},

--- a/fxtest/app_test.go
+++ b/fxtest/app_test.go
@@ -30,7 +30,11 @@ import (
 )
 
 func TestApp(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 
 		New(spy).RequireStart().RequireStop()
@@ -40,6 +44,8 @@ func TestApp(t *testing.T) {
 	})
 
 	t.Run("NewFailure", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 
 		New(
@@ -54,6 +60,8 @@ func TestApp(t *testing.T) {
 	})
 
 	t.Run("StartError", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 
 		New(
@@ -71,6 +79,8 @@ func TestApp(t *testing.T) {
 	})
 
 	t.Run("StopFailure", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 
 		construct := func(lc fx.Lifecycle) struct{} {

--- a/fxtest/lifecycle_test.go
+++ b/fxtest/lifecycle_test.go
@@ -34,7 +34,11 @@ import (
 )
 
 func TestLifecycle(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 
 		n := 0
@@ -50,6 +54,8 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("StartError", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 		lc := NewLifecycle(spy)
 		lc.Append(fx.Hook{OnStart: func(context.Context) error { return errors.New("fail") }})
@@ -62,6 +68,8 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("StopFailure", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 		lc := NewLifecycle(spy)
 		lc.Append(fx.Hook{OnStop: func(context.Context) error { return errors.New("fail") }})
@@ -74,6 +82,8 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("RequireLeakDetection", func(t *testing.T) {
+		t.Parallel()
+
 		spy := newTB()
 		lc := NewLifecycle(spy)
 
@@ -108,7 +118,11 @@ func TestLifecycle(t *testing.T) {
 }
 
 func TestLifecycle_OptionalT(t *testing.T) {
+	t.Parallel()
+
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
 		lc := NewLifecycle(nil)
 
 		var started, stopped bool
@@ -134,6 +148,8 @@ func TestLifecycle_OptionalT(t *testing.T) {
 	})
 
 	t.Run("start error", func(t *testing.T) {
+		t.Parallel()
+
 		lc := NewLifecycle(nil)
 		lc.Append(fx.Hook{
 			OnStart: func(context.Context) error {
@@ -152,7 +168,11 @@ func TestLifecycle_OptionalT(t *testing.T) {
 }
 
 func TestPanicT(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Logf", func(t *testing.T) {
+		t.Parallel()
+
 		var buff bytes.Buffer
 		pt := panicT{W: &buff}
 		pt.Logf("hello: %v", "world")
@@ -161,6 +181,8 @@ func TestPanicT(t *testing.T) {
 	})
 
 	t.Run("Errorf", func(t *testing.T) {
+		t.Parallel()
+
 		var buff bytes.Buffer
 		pt := panicT{W: &buff}
 		pt.Errorf("hello: %v", "world")
@@ -170,6 +192,8 @@ func TestPanicT(t *testing.T) {
 		// Functionally there's no difference between Logf and Errorf
 		// unless FailNow is called.
 		t.Run("FailNow", func(t *testing.T) {
+			t.Parallel()
+
 			var pval interface{}
 			func() {
 				defer func() { pval = recover() }()
@@ -181,6 +205,8 @@ func TestPanicT(t *testing.T) {
 
 	// FailNow without calling Errorf will use the fixed message.
 	t.Run("FailNow", func(t *testing.T) {
+		t.Parallel()
+
 		var buff bytes.Buffer
 		pt := panicT{W: &buff}
 		pt.Logf("hello: %v", "world")

--- a/fxtest/printer_test.go
+++ b/fxtest/printer_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestNewTestPrinter(t *testing.T) {
+	t.Parallel()
+
 	spy := newTB()
 	p := NewTestPrinter(spy)
 	p.Printf("static")

--- a/inout_test.go
+++ b/inout_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestIn(t *testing.T) {
+	t.Parallel()
+
 	type in struct {
 		fx.In
 	}
@@ -37,6 +39,8 @@ func TestIn(t *testing.T) {
 }
 
 func TestOut(t *testing.T) {
+	t.Parallel()
+
 	type out struct {
 		fx.Out
 	}
@@ -44,6 +48,8 @@ func TestOut(t *testing.T) {
 }
 
 func TestOptionalTypes(t *testing.T) {
+	t.Parallel()
+
 	type foo struct{}
 	newFoo := func() *foo { return &foo{} }
 
@@ -58,6 +64,8 @@ func TestOptionalTypes(t *testing.T) {
 	}
 
 	t.Run("NotProvided", func(t *testing.T) {
+		t.Parallel()
+
 		ran := false
 		app := fxtest.New(t, fx.Provide(newFoo), fx.Invoke(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
@@ -69,6 +77,8 @@ func TestOptionalTypes(t *testing.T) {
 	})
 
 	t.Run("Provided", func(t *testing.T) {
+		t.Parallel()
+
 		ran := false
 		app := fxtest.New(t, fx.Provide(newFoo, newBar), fx.Invoke(func(in in) {
 			assert.NotNil(t, in.Foo, "foo was not optional and provided, expected not nil")
@@ -81,6 +91,8 @@ func TestOptionalTypes(t *testing.T) {
 }
 
 func TestNamedTypes(t *testing.T) {
+	t.Parallel()
+
 	type a struct {
 		name string
 	}
@@ -131,6 +143,8 @@ func TestNamedTypes(t *testing.T) {
 }
 
 func TestIgnoreUnexported(t *testing.T) {
+	t.Parallel()
+
 	type A struct{ ID int }
 	type B struct{ ID int }
 

--- a/internal/fxlog/default_test.go
+++ b/internal/fxlog/default_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	assert.NotPanics(t, func() {
 		DefaultLogger(testutil.WriteSyncer{T: t})
 	})

--- a/internal/fxlog/spy_test.go
+++ b/internal/fxlog/spy_test.go
@@ -29,9 +29,13 @@ import (
 )
 
 func TestSpy(t *testing.T) {
+	t.Parallel()
+
 	var s Spy
 
 	t.Run("empty spy", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Empty(t, s.Events(), "events must be empty")
 		assert.Zero(t, s.Events().Len(), "events length must be zero")
 		assert.Empty(t, s.EventTypes(), "event types must be empty")
@@ -39,23 +43,31 @@ func TestSpy(t *testing.T) {
 
 	s.LogEvent(&fxevent.Started{})
 	t.Run("use after reset", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, "Started", s.EventTypes()[0])
 	})
 
 	s.LogEvent(&fxevent.Provided{Err: fmt.Errorf("some error")})
 	t.Run("some error", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, 1, s.Events().SelectByTypeName("Provided").Len())
 		assert.Equal(t, "Provided", s.EventTypes()[1])
 	})
 
 	s.Reset()
 	t.Run("reset", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Empty(t, s.Events(), "events must be empty")
 		assert.Empty(t, s.EventTypes(), "event types must be empty")
 	})
 
 	s.LogEvent(&fxevent.Started{})
 	t.Run("use after reset", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, "Started", s.EventTypes()[0])
 	})
 }

--- a/internal/fxlog/spy_test.go
+++ b/internal/fxlog/spy_test.go
@@ -34,8 +34,6 @@ func TestSpy(t *testing.T) {
 	var s Spy
 
 	t.Run("empty spy", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Empty(t, s.Events(), "events must be empty")
 		assert.Zero(t, s.Events().Len(), "events length must be zero")
 		assert.Empty(t, s.EventTypes(), "event types must be empty")
@@ -43,31 +41,23 @@ func TestSpy(t *testing.T) {
 
 	s.LogEvent(&fxevent.Started{})
 	t.Run("use after reset", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Equal(t, "Started", s.EventTypes()[0])
 	})
 
 	s.LogEvent(&fxevent.Provided{Err: fmt.Errorf("some error")})
 	t.Run("some error", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Equal(t, 1, s.Events().SelectByTypeName("Provided").Len())
 		assert.Equal(t, "Provided", s.EventTypes()[1])
 	})
 
 	s.Reset()
 	t.Run("reset", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Empty(t, s.Events(), "events must be empty")
 		assert.Empty(t, s.EventTypes(), "event types must be empty")
 	})
 
 	s.LogEvent(&fxevent.Started{})
 	t.Run("use after reset", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Equal(t, "Started", s.EventTypes()[0])
 	})
 }

--- a/internal/fxreflect/fxreflect_test.go
+++ b/internal/fxreflect/fxreflect_test.go
@@ -28,12 +28,16 @@ import (
 )
 
 func TestCaller(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, "go.uber.org/fx/internal/fxreflect.TestCaller", Caller())
 }
 
 func someFunc() {}
 
 func TestFuncName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		give interface{}
@@ -52,13 +56,18 @@ func TestFuncName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.want, FuncName(tt.give))
 		})
 	}
 }
 
 func TestSanitizeFuncNames(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		input    string
@@ -81,7 +90,10 @@ func TestSanitizeFuncNames(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, c.expected, sanitize(c.input))
 		})
 	}

--- a/internal/fxreflect/stack_test.go
+++ b/internal/fxreflect/stack_test.go
@@ -29,12 +29,16 @@ import (
 )
 
 func TestStack(t *testing.T) {
+	t.Parallel()
+
 	// NOTE:
 	// We don't assert the length of the stack because we cannot make
 	// guarantees about how many frames the test runner is allowed to
 	// introduce.
 
 	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
 		frames := CallerStack(0, 0)
 		require.NotEmpty(t, frames)
 		f := frames[0]
@@ -44,6 +48,8 @@ func TestStack(t *testing.T) {
 	})
 
 	t.Run("default/deeper", func(t *testing.T) {
+		t.Parallel()
+
 		// Introduce a few frames.
 		frames := func() []Frame {
 			return func() []Frame {
@@ -61,6 +67,8 @@ func TestStack(t *testing.T) {
 	})
 
 	t.Run("skip", func(t *testing.T) {
+		t.Parallel()
+
 		// Introduce a few frames and skip 2.
 		frames := func() []Frame {
 			return func() []Frame {
@@ -77,6 +85,8 @@ func TestStack(t *testing.T) {
 }
 
 func TestStackCallerName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		give Stack
@@ -148,13 +158,18 @@ func TestStackCallerName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.want, tt.give.CallerName())
 		})
 	}
 }
 
 func TestFrameString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		give Frame
@@ -198,13 +213,18 @@ func TestFrameString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.want, tt.give.String())
 		})
 	}
 }
 
 func TestStackFormat(t *testing.T) {
+	t.Parallel()
+
 	stack := Stack{
 		{
 			Function: "path/to/module.SomeFunction()",
@@ -219,6 +239,8 @@ func TestStackFormat(t *testing.T) {
 	}
 
 	t.Run("single line", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t,
 			"path/to/module.SomeFunction() (path/to/file.go:42); "+
 				"path/to/another/module.AnotherFunction() (path/to/another/file.go:12)",
@@ -226,6 +248,8 @@ func TestStackFormat(t *testing.T) {
 	})
 
 	t.Run("multi line", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, `path/to/module.SomeFunction()
 	path/to/file.go:42
 path/to/another/module.AnotherFunction()

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -44,7 +44,11 @@ func testLogger(t *testing.T) fxevent.Logger {
 }
 
 func TestLifecycleStart(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ExecutesInOrder", func(t *testing.T) {
+		t.Parallel()
+
 		l := New(testLogger(t))
 		count := 0
 
@@ -67,6 +71,8 @@ func TestLifecycleStart(t *testing.T) {
 		assert.Equal(t, 2, count)
 	})
 	t.Run("ErrHaltsChainAndRollsBack", func(t *testing.T) {
+		t.Parallel()
+
 		l := New(testLogger(t))
 		err := errors.New("a starter error")
 		starterCount := 0
@@ -115,12 +121,18 @@ func TestLifecycleStart(t *testing.T) {
 }
 
 func TestLifecycleStop(t *testing.T) {
+	t.Parallel()
+
 	t.Run("DoesNothingWithoutHooks", func(t *testing.T) {
+		t.Parallel()
+
 		l := &Lifecycle{logger: testLogger(t)}
 		assert.Nil(t, l.Stop(context.Background()), "no lifecycle hooks should have resulted in stop returning nil")
 	})
 
 	t.Run("DoesNothingWhenNotStarted", func(t *testing.T) {
+		t.Parallel()
+
 		hook := Hook{
 			OnStop: func(context.Context) error {
 				assert.Fail(t, "OnStop should not be called if lifecycle was never started")
@@ -133,6 +145,8 @@ func TestLifecycleStop(t *testing.T) {
 	})
 
 	t.Run("ExecutesInReverseOrder", func(t *testing.T) {
+		t.Parallel()
+
 		l := &Lifecycle{logger: testLogger(t)}
 		count := 2
 
@@ -157,6 +171,8 @@ func TestLifecycleStop(t *testing.T) {
 	})
 
 	t.Run("ErrDoesntHaltChain", func(t *testing.T) {
+		t.Parallel()
+
 		l := New(testLogger(t))
 		count := 0
 
@@ -179,6 +195,8 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Equal(t, 2, count)
 	})
 	t.Run("GathersAllErrs", func(t *testing.T) {
+		t.Parallel()
+
 		l := New(testLogger(t))
 
 		err := errors.New("some stop error")
@@ -199,6 +217,8 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Equal(t, multierr.Combine(err, err2), l.Stop(context.Background()))
 	})
 	t.Run("AllowEmptyHooks", func(t *testing.T) {
+		t.Parallel()
+
 		l := New(testLogger(t))
 		l.Append(Hook{})
 		l.Append(Hook{})
@@ -208,6 +228,8 @@ func TestLifecycleStop(t *testing.T) {
 	})
 
 	t.Run("DoesNothingIfStartFailed", func(t *testing.T) {
+		t.Parallel()
+
 		l := New(testLogger(t))
 		err := errors.New("some start error")
 
@@ -227,7 +249,11 @@ func TestLifecycleStop(t *testing.T) {
 }
 
 func TestHookRecordsFormat(t *testing.T) {
+	t.Parallel()
+
 	t.Run("SortRecords", func(t *testing.T) {
+		t.Parallel()
+
 		t1, err := time.ParseDuration("10ms")
 		require.NoError(t, err)
 		t2, err := time.ParseDuration("20ms")

--- a/internal/testutil/writer_test.go
+++ b/internal/testutil/writer_test.go
@@ -38,10 +38,14 @@ func (s *spy) Logf(msg string, args ...interface{}) {
 }
 
 func TestWriteSyncer(t *testing.T) {
+	t.Parallel()
+
 	var spy spy
 	ws := WriteSyncer{T: &spy}
 
 	t.Run("log", func(t *testing.T) {
+		t.Parallel()
+
 		spy.Clear()
 
 		io.WriteString(ws, "hello")
@@ -49,6 +53,8 @@ func TestWriteSyncer(t *testing.T) {
 	})
 
 	t.Run("sync", func(t *testing.T) {
+		t.Parallel()
+
 		assert.NoError(t, ws.Sync())
 	})
 }

--- a/log_test.go
+++ b/log_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestLogBufferConnect(t *testing.T) {
+	t.Parallel()
+
 	spy := new(fxlog.Spy)
 	event := &fxevent.Started{}
 	lb := &logBuffer{
@@ -41,6 +43,8 @@ func TestLogBufferConnect(t *testing.T) {
 }
 
 func TestLogBufferLog(t *testing.T) {
+	t.Parallel()
+
 	spy := new(fxlog.Spy)
 	event := &fxevent.Started{}
 	lb := &logBuffer{

--- a/populate_test.go
+++ b/populate_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestPopulate(t *testing.T) {
+	t.Parallel()
+
 	// We make sure t1 has a size so when we compare pointers, 2 different
 	// objects are not equal.
 	type t1 struct {
@@ -44,6 +46,8 @@ func TestPopulate(t *testing.T) {
 	_ = new(t1).buf // buf is unused
 
 	t.Run("populate nothing", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t,
 			Provide(func() *t1 { panic("should not be called ") }),
 			Populate(),
@@ -52,6 +56,8 @@ func TestPopulate(t *testing.T) {
 	})
 
 	t.Run("populate single", func(t *testing.T) {
+		t.Parallel()
+
 		var v1 *t1
 		app := fxtest.New(t,
 			Provide(func() *t1 { return &t1{} }),
@@ -62,6 +68,8 @@ func TestPopulate(t *testing.T) {
 	})
 
 	t.Run("populate interface", func(t *testing.T) {
+		t.Parallel()
+
 		var reader io.Reader
 		app := fxtest.New(t,
 			Provide(func() io.Reader { return strings.NewReader("hello world") }),
@@ -75,6 +83,8 @@ func TestPopulate(t *testing.T) {
 	})
 
 	t.Run("populate multiple inline values", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			v1 *t1
 			v2 *t2
@@ -93,6 +103,8 @@ func TestPopulate(t *testing.T) {
 	})
 
 	t.Run("populate fx.In struct", func(t *testing.T) {
+		t.Parallel()
+
 		targets := struct {
 			In
 
@@ -113,6 +125,8 @@ func TestPopulate(t *testing.T) {
 	})
 
 	t.Run("populate named field", func(t *testing.T) {
+		t.Parallel()
+
 		type result struct {
 			Out
 
@@ -146,6 +160,8 @@ func TestPopulate(t *testing.T) {
 	})
 
 	t.Run("populate group", func(t *testing.T) {
+		t.Parallel()
+
 		type result struct {
 			Out
 
@@ -180,6 +196,8 @@ func TestPopulate(t *testing.T) {
 }
 
 func TestPopulateErrors(t *testing.T) {
+	t.Parallel()
+
 	type t1 struct{}
 	type container struct {
 		In
@@ -247,6 +265,8 @@ func TestPopulateErrors(t *testing.T) {
 }
 
 func TestPopulateValidateApp(t *testing.T) {
+	t.Parallel()
+
 	type t1 struct{}
 	type container struct {
 		In
@@ -302,7 +322,10 @@ func TestPopulateValidateApp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
+			t.Parallel()
+
 			testOpts := []Option{
 				NopLogger,
 				Provide(func() *t1 { return &t1{} }),

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -29,7 +29,11 @@ import (
 )
 
 func TestShutdown(t *testing.T) {
+	t.Parallel()
+
 	t.Run("BroadcastsToMultipleChannels", func(t *testing.T) {
+		t.Parallel()
+
 		var s fx.Shutdowner
 		app := fxtest.New(
 			t,
@@ -45,6 +49,8 @@ func TestShutdown(t *testing.T) {
 	})
 
 	t.Run("ErrorOnUnsentSignal", func(t *testing.T) {
+		t.Parallel()
+
 		var s fx.Shutdowner
 		app := fxtest.New(
 			t,

--- a/supply_test.go
+++ b/supply_test.go
@@ -34,15 +34,21 @@ import (
 )
 
 func TestSupply(t *testing.T) {
+	t.Parallel()
+
 	type A struct{}
 	type B struct{}
 
 	t.Run("NothingIsSupplied", func(t *testing.T) {
+		t.Parallel()
+
 		app := fxtest.New(t, fx.Supply())
 		defer app.RequireStart().RequireStop()
 	})
 
 	t.Run("SomethingIsSupplied", func(t *testing.T) {
+		t.Parallel()
+
 		aIn, bIn := &A{}, &B{}
 		var aOut *A
 		var bOut *B
@@ -59,6 +65,8 @@ func TestSupply(t *testing.T) {
 	})
 
 	t.Run("AnnotateIsSupplied", func(t *testing.T) {
+		t.Parallel()
+
 		firstIn, secondIn, thirdIn := &A{}, &A{}, &B{}
 		var out struct {
 			fx.In
@@ -84,6 +92,8 @@ func TestSupply(t *testing.T) {
 	})
 
 	t.Run("InvalidArgumentIsSupplied", func(t *testing.T) {
+		t.Parallel()
+
 		require.PanicsWithValuef(
 			t,
 			"untyped nil passed to fx.Supply",
@@ -106,6 +116,8 @@ func TestSupply(t *testing.T) {
 	})
 
 	t.Run("SupplyCollision", func(t *testing.T) {
+		t.Parallel()
+
 		type foo struct{}
 
 		var spy fxlog.Spy

--- a/tools/analysis/passes/allfxevents/analysis_test.go
+++ b/tools/analysis/passes/allfxevents/analysis_test.go
@@ -27,5 +27,7 @@ import (
 )
 
 func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
 	analysistest.Run(t, analysistest.TestData(), Analyzer, "./...")
 }


### PR DESCRIPTION
This adds `t.Parallel()` for all tests and subtests.

This change was made automatically with the following gopatch patch.

```diff
@@
var Test identifier
@@
 func Test(t *testing.T) {
+  t.Parallel()
   ...
 }

@@
var tt identifier
var tests expression
@@
 for _, tt := range tests {
+  tt := tt
   t.Run(..., func(t *testing.T) {
+     t.Parallel()
      ...
   })
 }

@@
@@
   t.Run(..., func(t *testing.T) {
+     t.Parallel()
      ...
   })

@@
@@
 t.Parallel()
-t.Parallel()
```

To keep style consistent, I added a newline after each `t.Parallel()` where
absent with the following commands.

```
$ git diff --name-only | xargs perl -p -i -e 's/(t.Parallel\(\))/$1\n/'
$ gofmt -s -w $(git diff --name-only)
```

Finally, I reverted or adjusted the two cases where we cannot run tests in
parallel:

- app_test/WithLogger: One of the subtests alters `os.Stderr` temporarily, so
  it cannot run in parallel with any other test. However, because the outer
  test is marked as parallel, it ends up running in parallel with other tests
  after all.
- fxlog/spy_test: The test's subtests specifically rely on sharing the object
  and cannot run in parallel with each other.
