### PR TITLE
fxevent: Log Started/Stopped on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
--  No changes yet.
+### Fixed
+- Fix `fxevent.Stopped` not being logged when `App.Stop` is called.
+- Fix `fxevent.Started` or `fxevent.Stopped` not being logged when start or
+  stop times out.
 
 ## [1.14.2] - 2021-08-16
 ### Changed

--- a/app.go
+++ b/app.go
@@ -957,6 +957,12 @@ func withTimeout(ctx context.Context, param *withTimeoutParams) error {
 	case <-ctx.Done():
 		err = ctx.Err()
 	case err = <-c:
+		// If the context finished at the same time as the callback
+		// prefer the context error.
+		// This eliminates non-determinism in select-case selection.
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
 	}
 	if err != context.DeadlineExceeded {
 		return err

--- a/app.go
+++ b/app.go
@@ -724,16 +724,7 @@ var (
 //
 // Note that Start short-circuits immediately if the New constructor
 // encountered any errors in application initialization.
-func (app *App) Start(ctx context.Context) error {
-	return withTimeout(ctx, &withTimeoutParams{
-		hook:      _onStartHook,
-		callback:  app.start,
-		lifecycle: app.lifecycle,
-		log:       app.log,
-	})
-}
-
-func (app *App) start(ctx context.Context) (err error) {
+func (app *App) Start(ctx context.Context) (err error) {
 	defer func() {
 		app.log.LogEvent(&fxevent.Started{Err: err})
 	}()
@@ -743,7 +734,15 @@ func (app *App) start(ctx context.Context) (err error) {
 		return app.err
 	}
 
-	// Attempt to start cleanly.
+	return withTimeout(ctx, &withTimeoutParams{
+		hook:      _onStartHook,
+		callback:  app.start,
+		lifecycle: app.lifecycle,
+		log:       app.log,
+	})
+}
+
+func (app *App) start(ctx context.Context) error {
 	if err := app.lifecycle.Start(ctx); err != nil {
 		// Start failed, rolling back.
 		app.log.LogEvent(&fxevent.RollingBack{StartErr: err})
@@ -757,7 +756,6 @@ func (app *App) start(ctx context.Context) (err error) {
 
 		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
As reported in #782, `App.Run` had a bug so that
if an application using it failed to start up because of a timeout
no event would be logged to indicate this.
The system would silently exit with a non-zero status code.

This PR resolves this by ensuring that even for timeouts,
we log `Started` or `Stopped` events with non-nil `Err` values.
This matches the behavior for other startup or shutdown failures.

To test this, I wanted to use `App.Run` directly so
I added an internal test-only option `WithExit`
that lets us override the behavior of `os.Exit`
without a global variable. (#792)

The issue resolution was pretty straightforward:

- Start: `defer LogEvent(..)` in Start instead of
  the wrapped `start` method which runs inside a separate gorotuine.
- Stop: Apply `defer LogEvent(..)` in Stop instead of `App.Run`.
  This actually exposed a bug too: we did not previously log `Stopped`
  if `App.Stop` was called. This resulted in some test changes.

There was a small non-determinism in `withTimeout`:
What if the context times out at the same time as the callback finishing?
`select` will pick one of the `case`s randomly.
I resolved this non-determinism by checking `ctx.Err()` in the success case again.

I also moved `App.start` next to `App.Start`, and `App.run` next to `App.Run`
to aid in readability. The move is in #791.

Resolves #782
Resolves GO-866
