### PR TITLE
app: Add internal option to override os.Exit

### DIFF
--- a/app_internal_test.go
+++ b/app_internal_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxevent"
 	"go.uber.org/fx/internal/fxlog"
+	"go.uber.org/fx/internal/fxreflect"
 )
 
 func TestAppRun(t *testing.T) {
@@ -69,4 +70,20 @@ func TestValidateString(t *testing.T) {
 	stringer, ok := validate(true).(fmt.Stringer)
 	require.True(t, ok, "option must implement stringer")
 	assert.Equal(t, "fx.validate(true)", stringer.String())
+}
+
+// WithExit is an internal option available only to tests defined in this
+// package. It changes how os.Exit behaves for the application.
+func WithExit(f func(int)) Option {
+	return withExitOption(f)
+}
+
+type withExitOption func(int)
+
+func (o withExitOption) String() string {
+	return fmt.Sprintf("WithExit(%v)", fxreflect.FuncName(o))
+}
+
+func (o withExitOption) apply(app *App) {
+	app.osExit = o
 }


### PR DESCRIPTION
Add an option exposed only to tests in the go.uber.org/fx package that
allows overriding how `os.Exit` behaves.

The way the new option works is,

- `App` gets a new `osExit func(int)` field which defaults to `os.Exit`
- app_internal_test.go uses `package fx` and therefore, it can access
  internal fields of the `App`. We define a new exported option in this
  package that sets `osExit`. Because this option is defined in a test
  file, though, it is not made part of the public API of the package.
- app_test.go uses `package fx_test` so it's an external test--it cannot
  access unexported fields, but it can access the exported option
  defined in app_internal_test.go.

This will allow testing the `app.Run` function directly.
