### PR TITLE
Support app shutdown before app.Done() is called

### DIFF
--- a/app.go
+++ b/app.go
@@ -379,7 +379,7 @@ type App struct {
 	errorHooks []ErrorHandler
 	validate   bool
 	// Used to signal shutdowns.
-	donesMu     sync.Mutex
+	donesMu     sync.Mutex  // guards dones and shutdownSig
 	dones       []chan os.Signal
 	shutdownSig os.Signal
 
@@ -798,8 +798,8 @@ func (app *App) Done() <-chan os.Signal {
 		c <- app.shutdownSig
 		return c
 	}
-	signal.Notify(c, _sigINT, _sigTERM)
 
+	signal.Notify(c, _sigINT, _sigTERM)
 	app.dones = append(app.dones, c)
 	return c
 }

--- a/app.go
+++ b/app.go
@@ -379,7 +379,7 @@ type App struct {
 	errorHooks []ErrorHandler
 	validate   bool
 	// Used to signal shutdowns.
-	donesMu     sync.Mutex  // guards dones and shutdownSig
+	donesMu     sync.Mutex // guards dones and shutdownSig
 	dones       []chan os.Signal
 	shutdownSig os.Signal
 

--- a/shutdown.go
+++ b/shutdown.go
@@ -57,8 +57,8 @@ func (app *App) shutdowner() Shutdowner {
 }
 
 func (app *App) broadcastSignal(signal os.Signal) error {
-	app.donesMu.RLock()
-	defer app.donesMu.RUnlock()
+	app.donesMu.Lock()
+	defer app.donesMu.Unlock()
 
 	// Record a shutdown signal
 	app.shutdownSig = signal

--- a/shutdown.go
+++ b/shutdown.go
@@ -60,6 +60,9 @@ func (app *App) broadcastSignal(signal os.Signal) error {
 	app.donesMu.RLock()
 	defer app.donesMu.RUnlock()
 
+	// Record a shutdown signal
+	app.shutdownSig = signal
+
 	var unsent int
 	for _, done := range app.dones {
 		select {

--- a/shutdown.go
+++ b/shutdown.go
@@ -60,7 +60,6 @@ func (app *App) broadcastSignal(signal os.Signal) error {
 	app.donesMu.Lock()
 	defer app.donesMu.Unlock()
 
-	// Record a shutdown signal
 	app.shutdownSig = signal
 
 	var unsent int

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -83,6 +83,8 @@ func TestShutdown(t *testing.T) {
 		assert.NoError(t, s.Shutdown(), "error in app shutdown")
 		done1, done2 := app.Done(), app.Done()
 		defer app.Stop(context.Background())
+		// Receiving on done1 and done2 will deadlock in the event that app.Done()
+		// doesn't work as expected.
 		assert.NotNil(t, <-done1, "done channel 1 did not receive signal")
 		assert.NotNil(t, <-done2, "done channel 2 did not receive signal")
 	})

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -121,7 +121,7 @@ func TestDataRace(t *testing.T) {
 	go func() {
 		<-ready
 		defer wg.Done()
-		s.Shutdown()
+		assert.NoError(t, s.Shutdown(), "error in app shutdown")
 	}()
 
 	close(ready)

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -102,7 +102,7 @@ func TestDataRace(t *testing.T) {
 
 	const N = 50
 	ready := make(chan struct{}) // used to orchestrate goroutines for Done() and ShutdownOption()
-	var wg sync.WaitGroup // tracks and waits for all goroutines
+	var wg sync.WaitGroup        // tracks and waits for all goroutines
 
 	// call app.Done()
 	wg.Add(N)

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -103,7 +103,8 @@ func TestDataRace(t *testing.T) {
 	ready := make(chan struct{}) // used to orchestrate goroutines for Done() and ShutdownOption()
 	var wg sync.WaitGroup        // tracks and waits for all goroutines
 
-	// call app.Done()
+	// Spawn N goroutines, each of which call app.Done() and assert
+	// the signal received.
 	wg.Add(N)
 	for i := 0; i < N; i++ {
 		i := i

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -88,40 +88,42 @@ func TestShutdown(t *testing.T) {
 		assert.NotNil(t, <-done1, "done channel 1 did not receive signal")
 		assert.NotNil(t, <-done2, "done channel 2 did not receive signal")
 	})
+}
 
-	t.Run("test data race: shutdown app before calling Done()", func(t *testing.T) {
-		t.Parallel()
+func TestDataRace(t *testing.T) {
+	t.Parallel()
 
-		var s fx.Shutdowner
-		app := fxtest.New(
-			t,
-			fx.Populate(&s),
-		)
-		require.NoError(t, app.Start(context.Background()), "error starting app")
+	var s fx.Shutdowner
+	app := fxtest.New(
+		t,
+		fx.Populate(&s),
+	)
+	require.NoError(t, app.Start(context.Background()), "error starting app")
 
-		const N = 50
-		ready := make(chan struct{})
-		var wg sync.WaitGroup // tracks and waits for all goroutines
+	const N = 50
+	ready := make(chan struct{}) // used to orchestrate goroutines for Done() and ShutdownOption()
+	var wg sync.WaitGroup // tracks and waits for all goroutines
 
-		// call app.Done()
-		wg.Add(N)
-		for i := 0; i < N; i++ {
-			i := i
-			go func() {
-				defer wg.Done()
-				done := app.Done()
-				assert.NotNil(t, <-done, fmt.Sprintf("done channel %v did not receive signal", i))
-			}()
-		}
-
-		// call Shutdown()
-		wg.Add(1)
+	// call app.Done()
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
 		go func() {
 			defer wg.Done()
-			s.Shutdown()
+			<-ready
+			done := app.Done()
+			assert.NotNil(t, <-done, fmt.Sprintf("done channel %v did not receive signal", i))
 		}()
+	}
 
-		close(ready)
-		wg.Wait()
-	})
+	// call Shutdown()
+	wg.Add(1)
+	go func() {
+		<-ready
+		defer wg.Done()
+		s.Shutdown()
+	}()
+
+	close(ready)
+	wg.Wait()
 }

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -22,7 +22,6 @@ package fx_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 
@@ -112,7 +111,7 @@ func TestDataRace(t *testing.T) {
 			defer wg.Done()
 			<-ready
 			done := app.Done()
-			assert.NotNil(t, <-done, fmt.Sprintf("done channel %v did not receive signal", i))
+			assert.NotNil(t, <-done, "done channel %v did not receive signal", i)
 		}()
 	}
 


### PR DESCRIPTION
In the event of shutdown of an app before app.Done() is called, we currently run into a data race. This leads to a situation where an app.Done() is blocked forever. 

In order to fix this race condition, we record the shutdown signal and modify app.Done() to offer it on a channel, independent of the done channels in the app.

Refs: GO-982, #679