### PR TITLE
Support app shutdown with exit codes

### DIFF
--- a/app.go
+++ b/app.go
@@ -666,7 +666,11 @@ func (app *App) Run() {
 	// Historically, we do not os.Exit(0) even though most applications
 	// cede control to Fx with they call app.Run. To avoid a breaking
 	// change, never os.Exit for success.
-	if code := app.run(app.Done()); code != 0 {
+	code := app.run(app.Done())
+	if app.exitCode != 0 {
+		code = app.exitCode
+	}
+	if code != 0 {
 		app.exit(code)
 	}
 }

--- a/app.go
+++ b/app.go
@@ -817,7 +817,7 @@ type Shutdown struct {
 
 // DoneWithCode returns a channel of the Shutdown struct to block on after starting
 // the application. This behaves exactly as Done() does with the addition of
-// capturing an application exit code, if one exists.
+// capturing the application's exit code, if one is set.
 func (app *App) DoneWithCode() <-chan Shutdown {
 	c := make(chan Shutdown, 1)
 	// farm out a goroutine to wait for

--- a/app.go
+++ b/app.go
@@ -809,6 +809,25 @@ func (app *App) Done() <-chan os.Signal {
 	return c
 }
 
+// Shutdown captures a signal and exit code.
+type Shutdown struct {
+	Signal   os.Signal
+	ExitCode int
+}
+
+// DoneWithCode returns a channel of the Shutdown struct to block on after starting
+// the application. This behaves exactly as Done() does with the addition of
+// capturing an application exit code, if one exists.
+func (app *App) DoneWithCode() <-chan Shutdown {
+	c := make(chan Shutdown, 1)
+	// farm out a goroutine to wait for
+	// app.Done() channel to be populated
+	go func() {
+		c <- Shutdown{Signal: <-app.Done(), ExitCode: app.exitCode}
+	}()
+	return c
+}
+
 // StartTimeout returns the configured startup timeout. Apps default to using
 // DefaultTimeout, but users can configure this behavior using the
 // StartTimeout option.

--- a/app.go
+++ b/app.go
@@ -382,6 +382,7 @@ type App struct {
 	donesMu     sync.Mutex // guards dones and shutdownSig
 	dones       []chan os.Signal
 	shutdownSig os.Signal
+	exitCode    int
 
 	osExit func(code int) // os.Exit override; used for testing only
 }

--- a/shutdown.go
+++ b/shutdown.go
@@ -45,6 +45,10 @@ func (e exitCodeOption) apply(s *shutdowner) {
 	s.app.exitCode = int(e)
 }
 
+func (e exitCodeOption) String() string {
+	return fmt.Sprintf("s.Shutdown(%v)", int(e))
+}
+
 // WithExitCode allows the user to configure the exitCode upon application
 // shutdown.
 func WithExitCode(exitCode int) ShutdownOption {

--- a/shutdown.go
+++ b/shutdown.go
@@ -34,7 +34,7 @@ type Shutdowner interface {
 }
 
 // ShutdownOption provides a way to configure properties of the shutdown
-// process. Currently, no options have been implemented.
+// process.
 type ShutdownOption interface {
 	apply(*shutdowner)
 }

--- a/shutdown.go
+++ b/shutdown.go
@@ -65,7 +65,6 @@ type shutdowner struct {
 // In practice this means Shutdowner.Shutdown should not be called from an
 // fx.Invoke, but from a fx.Lifecycle.OnStart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
-	// Apply the options to shutdowner
 	for _, opt := range opts {
 		opt.apply(s)
 	}

--- a/shutdown.go
+++ b/shutdown.go
@@ -39,6 +39,18 @@ type ShutdownOption interface {
 	apply(*shutdowner)
 }
 
+type exitCodeOption int
+
+func (e exitCodeOption) apply(s *shutdowner) {
+	s.app.exitCode = int(e)
+}
+
+// WithExitCode allows the user to configure the exitCode upon application
+// shutdown.
+func WithExitCode(exitCode int) ShutdownOption {
+	return exitCodeOption(exitCode)
+}
+
 type shutdowner struct {
 	app *App
 }
@@ -49,6 +61,10 @@ type shutdowner struct {
 // In practice this means Shutdowner.Shutdown should not be called from an
 // fx.Invoke, but from a fx.Lifecycle.OnStart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
+	// Apply the options to shutdowner
+	for _, opt := range opts {
+		opt.apply(s)
+	}
 	return s.app.broadcastSignal(_sigTERM)
 }
 


### PR DESCRIPTION
We provide a way to shutdown an app via the Shutdowner interface but, we do not provide a way to specify/change the exit code. This commit adds support for shutting down apps with an exit code. Exit code can be controlled by providing a new Option to configure the Shutdowner. This can be done via `shutdowner.Shutdown(WithExitCode(...))`

* For apps that use `app.Run()`, the exit code is read directly and returned.
* For apps that are orchestrated with `app.Start()` and `app.Stop()`, a new function `app.DoneWithCode()` is presented that works similar to `app.Done()`. The following code illustrats its usage -
```
app := ...
app.Start(...)
done := app.DoneWithCode()
res := <-done
app.Stop(...)
res.ExitCode // captures the exit code
```

Refs: GO-981, #763 