### PR TITLE
fx.Annotate: Support variadic functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- No changes yet.
+### Changed
+- `fx.Annotate`: support variadic functions, and feeding value groups into
+  them.
 
 ## [1.15.0] - 2021-11-08
 ### Added

--- a/annotated.go
+++ b/annotated.go
@@ -552,7 +552,7 @@ func (ann *annotated) results() (
 //  }, fx.ParamTags(``, `group:"server"`))
 //
 // If we provide the above to the application,
-// any constructor in the Fx application can feed it HTTP handlers
+// any constructor in the Fx application can inject its HTTP handlers
 // by using fx.Annotate, fx.Annotated, or fx.Out.
 //
 //  fx.Annotate(

--- a/annotated.go
+++ b/annotated.go
@@ -528,6 +528,42 @@ func (ann *annotated) results() (
 //
 // If more tags are given than the number of parameters/results, only
 // the ones up to the number of parameters/results will be applied.
+//
+// Variadic functions
+//
+// If the provided function is variadic, Annotate treats its parameter as a
+// slice. For example,
+//
+//  fx.Annotate(func(w io.Writer, rs ...io.Reader) {
+//    // ...
+//  }, ...)
+//
+// Is equivalent to,
+//
+//  fx.Annotate(func(w io.Writer, rs []io.Reader) {
+//    // ...
+//  }, ...)
+//
+// You can use variadic parameters with Fx's value groups.
+// For example,
+//
+//  fx.Annotate(func(mux *http.ServeMux, handlers ...http.Handler) {
+//    // ...
+//  }, fx.ParamTags(``, `group:"server"`))
+//
+// If we provide the above to the application,
+// any constructor in the Fx application can feed it HTTP handlers
+// by using fx.Annotate, fx.Annotated, or fx.Out.
+//
+//  fx.Annotate(
+//    func(..) http.Handler { ... },
+//    fx.ResultTags(`group:"server"`),
+//  )
+//
+//  fx.Annotated{
+//    Target: func(..) http.Handler { ... },
+//    Group:  "server",
+//  }
 func Annotate(t interface{}, anns ...Annotation) interface{} {
 	result := annotated{Target: t}
 	for _, ann := range anns {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -529,7 +529,7 @@ func TestAnnotate(t *testing.T) {
 				fx.Annotate(T1{"bar"}, fx.ResultTags(`group:"t"`)),
 				fx.Annotate(T1{"baz"}, fx.ResultTags(`group:"t"`)),
 			),
-			fx.Invoke(fx.Annotate(func(got []T1) {
+			fx.Invoke(fx.Annotate(func(got ...T1) {
 				assert.ElementsMatch(t, []T1{{"foo"}, {"bar"}, {"baz"}}, got)
 			}, fx.ParamTags(`group:"t"`))),
 		)


### PR DESCRIPTION
Add support to fx.Annotate for variadic functions.
The last parameter of variadic functions is now treated as a slice.
With this users can feed value groups into variadic functions.

Ref https://github.com/uber-go/dig/issues/120