### PR TITLE
Fix interrupt handler on Windows

### DIFF
--- a/app.go
+++ b/app.go
@@ -787,7 +787,7 @@ func (app *App) Stop(ctx context.Context) (err error) {
 // using the Shutdown functionality (see the Shutdowner documentation for details).
 func (app *App) Done() <-chan os.Signal {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, _sigINT, _sigTERM)
+	signal.Notify(c, os.Interrupt, _sigINT, _sigTERM)
 
 	app.donesMu.Lock()
 	app.dones = append(app.dones, c)

--- a/app_test.go
+++ b/app_test.go
@@ -1685,14 +1685,16 @@ func TestOptionString(t *testing.T) {
 func TestMain(m *testing.M) {
 	if os.Getenv("VerifySignalHandler") != "" {
 		app := New(
+			NopLogger,
 			Invoke(func(lifecycle Lifecycle) {
 				lifecycle.Append(
 					Hook{
 						OnStart: func(ctx context.Context) error {
-							fmt.Printf("ok")
+							fmt.Fprintf(os.Stderr, "ready\n")
 							return nil
 						},
 						OnStop: func(ctx context.Context) error {
+							fmt.Fprintf(os.Stdout, "ONSTOP\n")
 							return nil
 						},
 					})

--- a/app_test.go
+++ b/app_test.go
@@ -1684,10 +1684,10 @@ func TestOptionString(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	if os.Getenv("VerifySignalHandler") != "" {
-		app := fx.New(
-			fx.Invoke(func(lifecycle fx.Lifecycle) {
+		app := New(
+			Invoke(func(lifecycle Lifecycle) {
 				lifecycle.Append(
-					fx.Hook{
+					Hook{
 						OnStart: func(ctx context.Context) error {
 							fmt.Printf("ok")
 							return nil

--- a/app_test.go
+++ b/app_test.go
@@ -1683,7 +1683,25 @@ func TestOptionString(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	if os.Getenv("VerifySignalHandler") != "" {
+		app := fx.New(
+			fx.Invoke(func(lifecycle fx.Lifecycle) {
+				lifecycle.Append(
+					fx.Hook{
+						OnStart: func(ctx context.Context) error {
+							fmt.Printf("ok")
+							return nil
+						},
+						OnStop: func(ctx context.Context) error {
+							return nil
+						},
+					})
+			}),
+		)
+		app.Run()
+	} else {
+		goleak.VerifyTestMain(m)
+	}
 }
 
 type testLogger struct{ t *testing.T }

--- a/app_windows_test.go
+++ b/app_windows_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020-2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build windows
+// +build windows
+
+package fx_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestCtrlCHandler(t *testing.T) {
+	// Launch a separate process we will send SIGINT to.
+	bin, err := os.Executable()
+	require.NoError(t, err)
+	cmd := exec.Command(bin)
+
+	// buffers used to capture the output of the child process.
+	var so bytes.Buffer
+	var se bytes.Buffer
+	cmd.Stdout = &so
+	cmd.Stderr = &se
+
+	cmd.Env = []string{"VerifySignalHandler=1"}
+	// CREATE_NEW_PROCESS_GROUP is required to send SIGINT to
+	// the child process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+	}
+	err = cmd.Start()
+	require.NoError(t, err)
+	childPid := cmd.Process.Pid
+
+	c := make(chan struct{}, 1)
+
+	go func() {
+		// poll stdout of child proc to see if it's ready to be killed.
+		for {
+			if so.String() != "" {
+				c <- struct{}{}
+				break
+			}
+			time.Sleep(time.Millisecond * 50)
+		}
+	}()
+
+	// block until child proc is ready.
+	<-c
+
+	// Send signal to child proc.
+	err = windows.GenerateConsoleCtrlEvent(1, uint32(childPid))
+	require.NoError(t, err)
+	err = cmd.Wait()
+
+	// Check that onstop hook ran.
+	assert.Contains(t, se.String(), "HOOK OnStop")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Per documentation on `os/signal` from https://pkg.go.dev/os/signal#hdr-Windows, on Windows, SIGINT gets translated to `os.Interrupt`, not `windows.SIGINT`. This fixes the signal handler to listen to `os.Interrupt` as well so that SIGINTs on Windows gets handled properly.

Fix #781. 
Internal Ref: GO-889.