### PR TITLE
CI: Fix Windows FIND warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOLINT = $(GOBIN)/golint
 STATICCHECK = $(GOBIN)/staticcheck
 FXLINT = $(GOBIN)/fxlint
 
-GO_FILES := $(shell \
+GO_FILES = $(shell \
 	find . '(' -path '*/.*' -o -path './vendor' -o -path '*/testdata/*' ')' -prune \
 	-o -name '*.go' -print | cut -b3-)
 
@@ -33,7 +33,7 @@ $(GOLINT): tools/go.mod
 $(STATICCHECK): tools/go.mod
 	cd tools && go install honnef.co/go/tools/cmd/staticcheck
 
-$(FXLINT): $(shell find tools -name '*.go')
+$(FXLINT): tools/cmd/fxlint/main.go
 	cd tools && go install go.uber.org/fx/tools/cmd/fxlint
 
 .PHONY: lint


### PR DESCRIPTION
Currently, CI on Windows reports the following error:

```
FIND: Parameter format not correct
```

This is because of our eager evaluation of the `find` commands above
that are not quite valid on Windows.

Replace one unnecessary `find` command,
and turn the other to lazy evaluation.
With `=` instead of `:=`, that `find` will be evaluated in the
`make lint` task only, which doesn't run on Windows.
