### PR TITLE
Allow multiple As Annotations to be provided

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -449,8 +449,8 @@ func (ann *annotated) results() (
 	}
 
 	var resTypes []reflect.Type
-	for i := 0; i < numStructs; i++ {
-		resTypes = append(resTypes, reflect.StructOf(outFields[i]))
+	for _, fields := range outFields {
+		resTypes = append(resTypes, reflect.StructOf(fields))
 	}
 
 	if hasError {
@@ -461,8 +461,8 @@ func (ann *annotated) results() (
 		var outErr error
 		var remappedResults []reflect.Value
 
-		for structNum := 0; structNum < numStructs; structNum++ {
-			out := reflect.New(resTypes[structNum]).Elem()
+		for structNum, structType := range resTypes {
+			out := reflect.New(structType).Elem()
 			for i, r := range results {
 				if i == len(results)-1 && hasError {
 					// If hasError and this is the last item,

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -275,6 +276,18 @@ func TestAnnotatedAs(t *testing.T) {
 				assert.NoError(t, err)
 				_, err = buf.Write([]byte("."))
 				assert.NoError(t, err)
+			},
+		},
+		{
+			desc: "annotate fewer items than provided constructor",
+			provide: fx.Provide(
+				fx.Annotate(func() (*bytes.Buffer, *strings.Builder) {
+					s := "Hello"
+					return bytes.NewBuffer([]byte(s)), &strings.Builder{}
+				},
+					fx.As(new(io.Reader))),
+			),
+			invoke: func(r io.Reader) {
 			},
 		},
 	}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -203,6 +203,18 @@ func TestAnnotatedAs(t *testing.T) {
 				assert.Equal(t, "foo", s.String())
 			},
 		},
+		{
+			desc: "annotate as many interfaces",
+			provide: fx.Provide(
+				fx.Annotate(&asStringer{"foo"},
+					fx.As(new(fmt.Stringer)),
+					fx.As(new(myStringer))),
+			),
+			invoke: func(s fmt.Stringer, ms myStringer) {
+				assert.Equal(t, "foo", s.String())
+				assert.Equal(t, "foo", ms.String())
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -206,13 +206,75 @@ func TestAnnotatedAs(t *testing.T) {
 		{
 			desc: "annotate as many interfaces",
 			provide: fx.Provide(
-				fx.Annotate(&asStringer{"foo"},
+				fx.Annotate(func() *asStringer {
+					return &asStringer{name: "stringer"}
+				},
 					fx.As(new(fmt.Stringer)),
 					fx.As(new(myStringer))),
 			),
 			invoke: func(s fmt.Stringer, ms myStringer) {
-				assert.Equal(t, "foo", s.String())
-				assert.Equal(t, "foo", ms.String())
+				assert.Equal(t, "stringer", s.String())
+				assert.Equal(t, "stringer", ms.String())
+			},
+		},
+		{
+			desc: "annotate as many interfaces with both-annotated return values",
+			provide: fx.Provide(
+				fx.Annotate(func() (*asStringer, *bytes.Buffer) {
+					return &asStringer{name: "stringer"},
+						bytes.NewBuffer(make([]byte, 1))
+				},
+					fx.As(new(fmt.Stringer), new(io.Reader)),
+					fx.As(new(myStringer), new(io.Writer))),
+			),
+			invoke: func(s fmt.Stringer, ms myStringer, r io.Reader, w io.Writer) {
+				assert.Equal(t, "stringer", s.String())
+				assert.Equal(t, "stringer", ms.String())
+				_, err := w.Write([]byte("."))
+				assert.NoError(t, err)
+				buf := make([]byte, 1)
+				_, err = r.Read(buf)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			desc: "annotate as many interfaces with different numbers of annotations",
+			provide: fx.Provide(
+				fx.Annotate(func() (*asStringer, *bytes.Buffer) {
+					return &asStringer{name: "stringer"},
+						bytes.NewBuffer(make([]byte, 1))
+				},
+					// annotate both in here
+					fx.As(new(fmt.Stringer), new(io.Writer)),
+					// annotate just myStringer here
+					fx.As(new(myStringer))),
+			),
+			invoke: func(s fmt.Stringer, ms myStringer, w io.Writer) {
+				assert.Equal(t, "stringer", s.String())
+				assert.Equal(t, "stringer", ms.String())
+				_, err := w.Write([]byte("."))
+				assert.NoError(t, err)
+			},
+		},
+		{
+			desc: "annotate many interfaces with varying annotation count and check original type",
+			provide: fx.Provide(
+				fx.Annotate(func() (*asStringer, *bytes.Buffer) {
+					return &asStringer{name: "stringer"},
+						bytes.NewBuffer(make([]byte, 1))
+				},
+					// annotate just myStringer here
+					fx.As(new(myStringer)),
+					// annotate both in here
+					fx.As(new(fmt.Stringer), new(io.Writer))),
+			),
+			invoke: func(s fmt.Stringer, ms myStringer, buf *bytes.Buffer, w io.Writer) {
+				assert.Equal(t, "stringer", s.String())
+				assert.Equal(t, "stringer", ms.String())
+				_, err := w.Write([]byte("."))
+				assert.NoError(t, err)
+				_, err = buf.Write([]byte("."))
+				assert.NoError(t, err)
 			},
 		},
 	}
@@ -252,12 +314,6 @@ func TestAnnotatedAsFailures(t *testing.T) {
 			provide:       fx.Provide(fx.Annotate(newAsStringer, fx.As(new(io.Writer)))),
 			invoke:        func() {},
 			errorContains: "does not implement",
-		},
-		{
-			desc:          "provide two lines of As",
-			provide:       fx.Provide(fx.Annotate(newAsStringer, fx.As(new(io.Writer)), fx.As(new(io.Reader)))),
-			invoke:        func() {},
-			errorContains: "cannot apply more than one line of As",
 		},
 		{
 			desc:    "don't provide original type using As",


### PR DESCRIPTION
Currently, Fx errors out when two `As` annotations are provided to a constructor. This is inconvenient as there may be times where a user wants to annotate a single type as many interfaces that it implements.

This change allows such annotations to be provided. 

In particular, the following annotation is now possible:
```go
fx.Annotate(func() *bytes.Buffer {...},
  fx.As(new(io.Writer)),
  fx.As(new(io.Reader)),
}
```

`bytes.Buffer`  implements both `io.Writer` and `io.Reader`, hence this provides the same instance of `bytes.Buffer` as both `io.Writer` and `io.Reader` interface. Note that this provides the same *instances* as arguments that takes in these, and should NOT be used as if the constructor got invoked twice to provide two different instances of type `bytes.Buffer`, one as `io.Writer` and the other as `io.Writer`.

To allow this change, few modifications were made to internal representation of As tags. Most of the changes are changing the dimensions of the slices from 1D to 2D. The following changes were made:
- `annotated.As` is now an array of array of `reflect.Type`, where As[i][j] is the i-th type that j-th result needs to be annotated as. 
- offsets and results are now 2D slices as well, similar to `annotated.As`.
- The out type of annotated function generated by reflection is now multiple `fx.Out` structs, each of which correspond to one line of `fx.As` annotation, followed by an error type if one exists in the output type of the annotated constructor.

Refs: #811
GO-1023