### PR TITLE
TestWindowsCtrlCHandler: Post-land fixups

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1683,27 +1683,7 @@ func TestOptionString(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if os.Getenv("VerifySignalHandler") != "" {
-		app := New(
-			NopLogger,
-			Invoke(func(lifecycle Lifecycle) {
-				lifecycle.Append(
-					Hook{
-						OnStart: func(ctx context.Context) error {
-							fmt.Fprintf(os.Stderr, "ready\n")
-							return nil
-						},
-						OnStop: func(ctx context.Context) error {
-							fmt.Fprintf(os.Stdout, "ONSTOP\n")
-							return nil
-						},
-					})
-			}),
-		)
-		app.Run()
-	} else {
-		goleak.VerifyTestMain(m)
-	}
+	goleak.VerifyTestMain(m)
 }
 
 type testLogger struct{ t *testing.T }


### PR DESCRIPTION
This makes some minor readability changes to the test added in #812.
Specifically,

- Instead of hijacking TestMain, invoke a specific test.
  This isolates the blast radius of this test to a single file.
- Check some previously unchecked errors.
- Reorder operations for readability.
- Use `close(channel)` instead of `<- struct{}{}`
  for a channel that fires only once.
- Don't consider stderr when verifiying output.
- Use a SCREAMING_SNAKE_CASE environment variable.
- Use `Fprintln` instead of `Printf` with a `\n`.
