### PR TITLE
Validate arguments to fx.Annotate for fx.In and fx.Out

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -326,8 +326,10 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if ot.Kind() != reflect.Struct {
 			continue
 		}
-		if ot.NumField() > 0 && ot.Field(0).Type == reflect.TypeOf(Out{}) {
-			return fmt.Errorf("fx.Out structs cannot be annotated")
+		for i := 0; i < ot.NumField(); i++ {
+			if ot.Field(i).Type == reflect.TypeOf(Out{}) {
+				return errors.New("fx.Out structs cannot be annotated")
+			}
 		}
 	}
 
@@ -336,8 +338,10 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if it.Kind() != reflect.Struct {
 			continue
 		}
-		if it.NumField() > 0 && it.Field(0).Type == reflect.TypeOf(In{}) {
-			return fmt.Errorf("fx.In structs cannot be annotated")
+		for i := 0; i < it.NumField(); i++ {
+			if it.Field(i).Type == reflect.TypeOf(In{}) {
+				return errors.New("fx.In structs cannot be annotated")
+			}
 		}
 	}
 	return nil

--- a/annotated.go
+++ b/annotated.go
@@ -289,6 +289,10 @@ func (ann *annotated) Build() (interface{}, error) {
 		return nil, fmt.Errorf("must provide constructor function, got %v (%T)", ann.Target, ann.Target)
 	}
 
+	if err := ann.typeCheckOrigFn(); err != nil {
+		return nil, fmt.Errorf("error while applying annotation to function %T: %w", ann.Target, err)
+	}
+
 	paramTypes, remapParams := ann.parameters()
 	resultTypes, remapResults, err := ann.results()
 	if err != nil {
@@ -310,6 +314,37 @@ func (ann *annotated) Build() (interface{}, error) {
 	})
 
 	return newFn.Interface(), nil
+}
+
+// checks whether the target function is either
+// returning an fx.Out struct or an taking in a
+// fx.In struct as a parameter.
+func (ann *annotated) typeCheckOrigFn() error {
+	ft := reflect.TypeOf(ann.Target)
+	for i := 0; i < ft.NumOut(); i++ {
+		ot := ft.Out(i)
+		if ot.Kind() != reflect.Struct {
+			continue
+		}
+		for _, sf := range reflect.VisibleFields(ot) {
+			if sf.Type == reflect.TypeOf(Out{}) {
+				return fmt.Errorf("fx.Out structs cannot be annotated")
+			}
+		}
+	}
+
+	for i := 0; i < ft.NumIn(); i++ {
+		it := ft.In(i)
+		if it.Kind() != reflect.Struct {
+			continue
+		}
+		for _, sf := range reflect.VisibleFields(it) {
+			if sf.Type == reflect.TypeOf(In{}) {
+				return fmt.Errorf("fx.In structs cannot be annotated")
+			}
+		}
+	}
+	return nil
 }
 
 // parameters returns the type for the parameters of the annotated function,

--- a/annotated.go
+++ b/annotated.go
@@ -326,10 +326,8 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if ot.Kind() != reflect.Struct {
 			continue
 		}
-		for _, sf := range reflect.VisibleFields(ot) {
-			if sf.Type == reflect.TypeOf(Out{}) {
-				return fmt.Errorf("fx.Out structs cannot be annotated")
-			}
+		if ot.NumField() > 0 && ot.Field(0).Type == reflect.TypeOf(Out{}) {
+			return fmt.Errorf("fx.Out structs cannot be annotated")
 		}
 	}
 
@@ -338,10 +336,8 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if it.Kind() != reflect.Struct {
 			continue
 		}
-		for _, sf := range reflect.VisibleFields(it) {
-			if sf.Type == reflect.TypeOf(In{}) {
-				return fmt.Errorf("fx.In structs cannot be annotated")
-			}
+		if it.NumField() > 0 && it.Field(0).Type == reflect.TypeOf(In{}) {
+			return fmt.Errorf("fx.In structs cannot be annotated")
 		}
 	}
 	return nil

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -879,7 +879,7 @@ func TestAnnotate(t *testing.T) {
 		t.Parallel()
 
 		type A struct {
-			s string
+			S string
 		}
 		type B struct {
 			fx.In
@@ -887,14 +887,14 @@ func TestAnnotate(t *testing.T) {
 
 		app := NewForTest(t,
 			fx.Provide(
-				fx.Annotate(func(i A) string { return i.s }, fx.ParamTags(`optional:"true"`)),
+				fx.Annotate(func(i A) string { return i.S }, fx.ParamTags(`optional:"true"`)),
 				fx.Annotate(func(i B) string { return "ok" }, fx.ParamTags(`name:"problem"`)),
 			),
 		)
 		err := app.Err()
 		require.Error(t, err)
-		assert.NotContains(t, err.Error(), "error while applying annotation to function func(fx_test.A)")
-		assert.Contains(t, err.Error(), "error while applying annotation to function func(fx_test.B)")
+		assert.NotContains(t, err.Error(), "invalid annotation function func(fx_test.A) string")
+		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.B) string")
 		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated")
 	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -855,9 +855,9 @@ func TestAnnotate(t *testing.T) {
 		t.Parallel()
 
 		type A struct {
-			fx.Out
-
 			s string
+
+			fx.Out
 		}
 
 		f := func() A {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -879,14 +879,22 @@ func TestAnnotate(t *testing.T) {
 		t.Parallel()
 
 		type A struct {
+			s string
+		}
+		type B struct {
 			fx.In
 		}
 
 		app := NewForTest(t,
-			fx.Provide(fx.Annotate(func(i A) {}), fx.ParamTags(`name:"in"`)),
+			fx.Provide(
+				fx.Annotate(func(i A) string { return i.s }, fx.ParamTags(`optional:"true"`)),
+				fx.Annotate(func(i B) string { return "ok" }, fx.ParamTags(`name:"problem"`)),
+			),
 		)
 		err := app.Err()
 		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "error while applying annotation to function func(fx_test.A)")
+		assert.Contains(t, err.Error(), "error while applying annotation to function func(fx_test.B)")
 		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated")
 	})
 }

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -850,4 +850,43 @@ func TestAnnotate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must provide constructor function, got 42 (int)")
 	})
+
+	t.Run("annotate a fx.Out", func(t *testing.T) {
+		t.Parallel()
+
+		type A struct {
+			fx.Out
+
+			s string
+		}
+
+		f := func() A {
+			return A{s: "hi"}
+		}
+
+		app := NewForTest(t,
+			fx.Provide(
+				fx.Annotate(f, fx.ResultTags(`name:"out"`)),
+			),
+		)
+
+		err := app.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated")
+	})
+
+	t.Run("annotate a fx.In", func(t *testing.T) {
+		t.Parallel()
+
+		type A struct {
+			fx.In
+		}
+
+		app := NewForTest(t,
+			fx.Provide(fx.Annotate(func(i A) {}), fx.ParamTags(`name:"in"`)),
+		)
+		err := app.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated")
+	})
 }


### PR DESCRIPTION
Functions that either take in fx.In as input parameters or outputs
an fx.Out struct should not be used as parameters to fx.Annotate.

This validates the input function to fx.Annotate to check for such
case and bail out early.

Ref: GO-1087