### PR TITLE
Modify non compliant decoration test

### DIFF
--- a/decorate_test.go
+++ b/decorate_test.go
@@ -233,34 +233,6 @@ func TestDecorateSuccess(t *testing.T) {
 		)
 		defer app.RequireStart().RequireStop()
 	})
-
-	t.Run("transitive and scoped decorations", func(t *testing.T) {
-		type Config struct {
-			Scope string
-		}
-		type Logger struct {
-			Cfg *Config
-		}
-		app := fxtest.New(t,
-			fx.Provide(func() *Config {
-				return &Config{Scope: "root"}
-			}),
-			fx.Provide(func(cfg *Config) *Logger {
-				return &Logger{Cfg: &Config{
-					Scope: cfg.Scope + " logger",
-				}}
-			}),
-			fx.Module("child",
-				fx.Decorate(func() *Config {
-					return &Config{Scope: "child"}
-				}),
-				fx.Invoke(func(l *Logger) {
-					assert.Equal(t, "child logger", l.Cfg.Scope)
-				}),
-			),
-		)
-		defer app.RequireStart().RequireStop()
-	})
 }
 
 func TestDecorateFailure(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 	golang.org/x/sys v0.0.0-20210903071746-97244b99971b
 )
 
-replace go.uber.org/dig => github.com/uber-go/dig v1.13.1-0.20220217170604-a7e23e31e975
+replace go.uber.org/dig => github.com/uber-go/dig v1.13.1-0.20220225222603-677f64b9c694

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uber-go/dig v1.13.1-0.20220217170604-a7e23e31e975 h1:DThTt5qayrILkBHJQIu19u38oTPaWH/LU+RxMLz0/tA=
-github.com/uber-go/dig v1.13.1-0.20220217170604-a7e23e31e975/go.mod h1:jHAn/z1Ld1luVVyGKOAIFYz/uBFqKjjEEdIqVAqfQ2o=
+github.com/uber-go/dig v1.13.1-0.20220225222603-677f64b9c694 h1:0PS9oNOB6x8htJywKfuZ2jx3Ax9F8YlImH31Rb/Hc2E=
+github.com/uber-go/dig v1.13.1-0.20220225222603-677f64b9c694/go.mod h1:jHAn/z1Ld1luVVyGKOAIFYz/uBFqKjjEEdIqVAqfQ2o=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
This modifies a test that was added in a previous commit which highlights
a problematic transitive decoration of a parent-module provided-type.

Specifically, consider the following case:
* Parent Module provides type A, and type B which depends on type A.
* Child Module decorates type A and invokes something that depends on type B.

In such case, the invoked function in child Module should not see a version of
type B created with a decorated type A.

This is because the constructor for the type B lives outside the scope of the
decoration. The decoration can only affect child Scope's providers, and should
not affect parent-provided constructor directly.

This test case is not compliant with such case, so it should be modified.

This also pins Dig dependency to latest commit of Dig's master branch to take
in the fix made in https://github.com/uber-go/dig/pull/325.