### PR TITLE
Prepare for v1.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.17.0] - 2021-02-28
+### Added
+- Add `fx.Module` which scopes any modifications made to the dependency graph.
+- Add `fx.Decorate` and `fx.Replace` that lets you modify a dependency graph with decorators.
+- Add `fxevent.Decorated` event which gets emitted upon a dependency getting decorated.
+
+### Changed
+- `fx.Annotate`: Validate that `fx.In` or `fx.Out` structs are not passed to it.
+- `fx.Annotate`: Upon failure to Provide, the error contains the actual location
+  of the provided constructor.
+
+[1.17.0]: https://github.com/uber-go/fx/compare/v1.16.0...v1.17.0
 
 ## [1.16.0] - 2021-12-02
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.13
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.0
-	go.uber.org/dig v1.12.0
+	go.uber.org/dig v1.14.0
 	go.uber.org/goleak v1.1.11
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/sys v0.0.0-20210903071746-97244b99971b
 )
-
-replace go.uber.org/dig => github.com/uber-go/dig v1.13.1-0.20220225222603-677f64b9c694

--- a/go.sum
+++ b/go.sum
@@ -22,11 +22,11 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uber-go/dig v1.13.1-0.20220225222603-677f64b9c694 h1:0PS9oNOB6x8htJywKfuZ2jx3Ax9F8YlImH31Rb/Hc2E=
-github.com/uber-go/dig v1.13.1-0.20220225222603-677f64b9c694/go.mod h1:jHAn/z1Ld1luVVyGKOAIFYz/uBFqKjjEEdIqVAqfQ2o=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/dig v1.14.0 h1:VmGvIH45/aapXPQkaOrK5u4B5B7jxZB98HM/utx0eME=
+go.uber.org/dig v1.14.0/go.mod h1:jHAn/z1Ld1luVVyGKOAIFYz/uBFqKjjEEdIqVAqfQ2o=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.17.0-dev"
+const Version = "1.17.0"


### PR DESCRIPTION
This adds changelog and version number changes to prepare for v1.17.0 release.

Also updates the Dig dependency to v1.14.0.