### PR TITLE
doc: Clarify Supply/Replace behavior with interface values

### DIFF
--- a/supply.go
+++ b/supply.go
@@ -32,6 +32,8 @@ import (
 // they had been provided using a constructor that simply returns them.
 // The most specific type of each value (as determined by reflection) is used.
 //
+// This serves a purpose similar to what fx.Replace does for fx.Decorate.
+//
 // For example, given:
 //
 //  type (
@@ -53,6 +55,28 @@ import (
 //  )
 //
 // Supply panics if a value (or annotation target) is an untyped nil or an error.
+//
+// Supply Caveats
+//
+// As mentioned above, Supply uses the most specific type of the provided
+// value. For interface values, this refers to the type of the implementation,
+// not the interface. So if you supply an http.Handler, fx.Supply will use the
+// type of the implementation.
+//
+//  var handler http.Handler = http.HandlerFunc(f)
+//  fx.Supply(handler)
+//
+// Is equivalent to,
+//
+//  fx.Provide(func() http.HandlerFunc { return f })
+//
+// This is typically NOT what you intended. To supply the handler above as an
+// http.Handler, we need to use the fx.Annotate function with the fx.As
+// annotation.
+//
+//  fx.Supply(
+//  	fx.Annotate(handler, fx.As(new(http.Handler))),
+//  )
 func Supply(values ...interface{}) Option {
 	constructors := make([]interface{}, len(values)) // one function per value
 	types := make([]reflect.Type, len(values))


### PR DESCRIPTION
Use of `fx.Replace` or `fx.Supply` with interface values can lead to
unexpected behavior. `fx.Supply((io.Reader)(r))` will use the type of
the implementation `r`, not `io.Reader`.

This clarifies the documentation for both APIs to make this explicit.

Refs GO-1253, GO-1254

---

**Previews**

fx.Replace: 
<img width="836" alt="image" src="https://user-images.githubusercontent.com/41730/157551717-bc1fde85-6d86-4f7d-8a3f-9ff8e5b946ed.png">

fx.Supply:
<img width="834" alt="image" src="https://user-images.githubusercontent.com/41730/157551756-7fb293dd-d4a8-4fda-86b1-1c662eebe428.png">
