### PR TITLE
Pin Dig dependency to v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- No changes yet.
+### Fixed
+- Upgrade Dig dependency to v1.14.1 to address a couple of issues with decorations. Refer to
+  Dig v1.14.1 release notes for more details.
 
 ## [1.17.1] - 2021-03-23
 ### Added
 - Logging for provide/invoke/decorate now includes the associated `fx.Module` name.
-
-### Fixed
-- Upgrade Dig dependency to v1.14.1 to address a couple of issues with decorations. Refer to
-  Dig v1.14.1 release notes for more details.
 
 [1.17.1]: https://github.com/uber-go/fx/compare/v1.17.0...v1.17.1
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.0
-	go.uber.org/dig v1.14.0
+	go.uber.org/dig v1.14.1
 	go.uber.org/goleak v1.1.11
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/dig v1.14.0 h1:VmGvIH45/aapXPQkaOrK5u4B5B7jxZB98HM/utx0eME=
-go.uber.org/dig v1.14.0/go.mod h1:jHAn/z1Ld1luVVyGKOAIFYz/uBFqKjjEEdIqVAqfQ2o=
+go.uber.org/dig v1.14.1 h1:fyakRgZDdi2F8FgwJJoRGangMSPTIxPSLGzR3Oh0/54=
+go.uber.org/dig v1.14.1/go.mod h1:52EKx/Vjdpz9EzeNcweC4YMsTrDdFn9mS/+Uw5ZnVTI=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=


### PR DESCRIPTION
Update Dig dependency to v1.14.1 which contains various fixes for
fx.Decorate issues. This was accidentally omitted from the previous release...