### PR TITLE
Emit a separate log for fx.Replace

### DIFF
--- a/decorate.go
+++ b/decorate.go
@@ -205,6 +205,9 @@ type decorator struct {
 
 	// Stack trace of where this provide was made.
 	Stack fxreflect.Stack
+
+	// Whether this decorator was specified via fx.Replace
+	IsReplace bool
 }
 
 func runDecorator(c container, d decorator, opts ...dig.DecorateOption) (err error) {

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -88,7 +88,7 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 			}
 		}
 		if e.Err != nil {
-			l.logf("ERROR\tFailed to replace: %v", e.Err)
+			l.logf("ERROR\tFailed to replace: %+v", e.Err)
 		}
 	case *Decorated:
 		for _, rtype := range e.OutputTypeNames {

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -78,6 +78,18 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		if e.Err != nil {
 			l.logf("Error after options were applied: %v", e.Err)
 		}
+
+	case *Replaced:
+		for _, rtype := range e.OutputTypeNames {
+			if e.ModuleName != "" {
+				l.logf("REPLACE\t%v from module %q", rtype, e.ModuleName)
+			} else {
+				l.logf("REPLACE\t%v", rtype)
+			}
+		}
+		if e.Err != nil {
+			l.logf("ERROR\tFailed to replace: %v", e.Err)
+		}
 	case *Decorated:
 		for _, rtype := range e.OutputTypeNames {
 			if e.ModuleName != "" {

--- a/fxevent/console_test.go
+++ b/fxevent/console_test.go
@@ -117,6 +117,19 @@ func TestConsoleLogger(t *testing.T) {
 			want: "[Fx] PROVIDE	*bytes.Buffer <= bytes.NewBuffer() from module \"myModule\"\n",
 		},
 		{
+			name: "Replaced",
+			give: &Replaced{
+				ModuleName:      "myModule",
+				OutputTypeNames: []string{"*bytes.Buffer"},
+			},
+			want: "[Fx] REPLACE	*bytes.Buffer from module \"myModule\"\n",
+		},
+		{
+			name: "ReplacedError",
+			give: &Replaced{Err: errors.New("some error")},
+			want: "[Fx] ERROR	Failed to replace: some error\n",
+		},
+		{
 			name: "Decorated",
 			give: &Decorated{
 				DecoratorName:   "bytes.NewBuffer()",

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -136,8 +136,7 @@ type Provided struct {
 
 // Replaced is emitted when a decorator is provided to Fx.
 type Replaced struct {
-	// OutputTypeNames is a list of names of types that are decorated by
-	// this replacement.
+	// OutputTypeNames is a list of names of types that were replaced.
 	OutputTypeNames []string
 
 	// ModuleName is the name of the module in which the value was added to.

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -37,6 +37,7 @@ func (*OnStopExecuting) event()   {}
 func (*OnStopExecuted) event()    {}
 func (*Supplied) event()          {}
 func (*Provided) event()          {}
+func (*Replaced) event()          {}
 func (*Decorated) event()         {}
 func (*Invoking) event()          {}
 func (*Invoked) event()           {}
@@ -130,6 +131,19 @@ type Provided struct {
 	ModuleName string
 
 	// Err is non-nil if we failed to provide this constructor.
+	Err error
+}
+
+// Replaced is emitted when a decorator is provided to Fx.
+type Replaced struct {
+	// OutputTypeNames is a list of names of types that are decorated by
+	// this replacement.
+	OutputTypeNames []string
+
+	// ModuleName is the name of the module in which the value was added to.
+	ModuleName string
+
+	// Err is non-nil if we failed to supply the value.
 	Err error
 }
 

--- a/fxevent/event_test.go
+++ b/fxevent/event_test.go
@@ -37,6 +37,7 @@ func TestForCoverage(t *testing.T) {
 		&OnStopExecuted{},
 		&Supplied{},
 		&Provided{},
+		&Replaced{},
 		&Decorated{},
 		&Invoking{},
 		&Invoked{},

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -92,6 +92,18 @@ func (l *ZapLogger) LogEvent(event Event) {
 				moduleField(e.ModuleName),
 				zap.Error(e.Err))
 		}
+	case *Replaced:
+		for _, rtype := range e.OutputTypeNames {
+			l.Logger.Info("replaced",
+				moduleField(e.ModuleName),
+				zap.String("type", rtype),
+			)
+		}
+		if e.Err != nil {
+			l.Logger.Error("error encountered while replacing",
+				moduleField(e.ModuleName),
+				zap.Error(e.Err))
+		}
 	case *Decorated:
 		for _, rtype := range e.OutputTypeNames {
 			l.Logger.Info("decorated",

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -166,6 +166,27 @@ func TestZapLogger(t *testing.T) {
 			},
 		},
 		{
+			name: "Replace",
+			give: &Replaced{
+				ModuleName:      "myModule",
+				OutputTypeNames: []string{"*bytes.Buffer"},
+			},
+			wantMessage: "replaced",
+			wantFields: map[string]interface{}{
+				"type":   "*bytes.Buffer",
+				"module": "myModule",
+			},
+		},
+		{
+			name: "Replace/Error",
+			give: &Replaced{Err: someError},
+
+			wantMessage: "error encountered while replacing",
+			wantFields: map[string]interface{}{
+				"error": "some error",
+			},
+		},
+		{
 			name: "Decorate",
 			give: &Decorated{
 				DecoratorName:   "bytes.NewBuffer()",

--- a/module.go
+++ b/module.go
@@ -190,12 +190,21 @@ func (m *module) decorate() (err error) {
 			outputNames[i] = o.String()
 		}
 
-		m.app.log.LogEvent(&fxevent.Decorated{
-			DecoratorName:   fxreflect.FuncName(decorator.Target),
-			ModuleName:      m.name,
-			OutputTypeNames: outputNames,
-			Err:             err,
-		})
+		if decorator.IsReplace {
+			m.app.log.LogEvent(&fxevent.Replaced{
+				ModuleName:      m.name,
+				OutputTypeNames: outputNames,
+				Err:             err,
+			})
+		} else {
+
+			m.app.log.LogEvent(&fxevent.Decorated{
+				DecoratorName:   fxreflect.FuncName(decorator.Target),
+				ModuleName:      m.name,
+				OutputTypeNames: outputNames,
+				Err:             err,
+			})
+		}
 		if err != nil {
 			return err
 		}

--- a/replace.go
+++ b/replace.go
@@ -105,8 +105,9 @@ type replaceOption struct {
 func (o replaceOption) apply(m *module) {
 	for _, target := range o.Targets {
 		m.decorators = append(m.decorators, decorator{
-			Target: target,
-			Stack:  o.Stack,
+			Target:    target,
+			Stack:     o.Stack,
+			IsReplace: true,
 		})
 	}
 }


### PR DESCRIPTION
This adds a new type fxevent.Replaced, which is used for logging
values that are being decorated via fx.Replace. Currently, these
are being emitted as part of the fxevent.Decorated log, but that
can be misleading and confusing since the decorator name for such
values is not properly provided (they are generated at runtime using
reflection).

The new log entry for fx.Replace-d types contains the types being
replaced, as well as the module name (if there is one).