### PR TITLE
TestReplaceSuccess: Silence output

### DIFF
--- a/replace_test.go
+++ b/replace_test.go
@@ -123,7 +123,7 @@ func TestReplaceSuccess(t *testing.T) {
 			),
 		)
 
-		fx.New(
+		fxtest.New(t,
 			fx.Module("wrapfoo",
 				foo,
 				fx.Replace(


### PR DESCRIPTION
TestReplaceSuccess currently prints its output to stderr because it uses
fx.New instead of fxtest.New or NewForTest.
