### PR TITLE
WithLogger: Support decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Upgrade Dig dependency to v1.14.1 to address a couple of issues with decorations. Refer to
   Dig v1.14.1 release notes for more details.
+- `fx.WithLogger` no longer ignores decorations and replacements of types that
+  it depends on.
 
 ## [1.17.1] - 2021-03-23
 ### Added

--- a/app.go
+++ b/app.go
@@ -404,7 +404,7 @@ func (app *App) constructCustomLogger(buffer *logBuffer) (err error) {
 		})
 	}()
 
-	if err := app.container.Provide(p.Target); err != nil {
+	if err := app.root.scope.Provide(p.Target); err != nil {
 		return fmt.Errorf("fx.WithLogger(%v) from:\n%+vFailed: %v",
 			fname, p.Stack, err)
 	}
@@ -412,7 +412,7 @@ func (app *App) constructCustomLogger(buffer *logBuffer) (err error) {
 	// TODO: Use dig.FillProvideInfo to inspect the provided constructor
 	// and fail the application if its signature didn't match.
 
-	return app.container.Invoke(func(log fxevent.Logger) {
+	return app.root.scope.Invoke(func(log fxevent.Logger) {
 		app.log = log
 		buffer.Connect(log)
 	})

--- a/app_test.go
+++ b/app_test.go
@@ -357,7 +357,7 @@ func TestNewApp(t *testing.T) {
 		defer app.RequireStart().RequireStop()
 
 		require.Equal(t,
-			[]string{"Provided", "Provided", "Provided", "Provided", "LoggerInitialized", "Decorated", "Invoking", "Invoked", "Started"},
+			[]string{"Provided", "Provided", "Provided", "Provided", "Decorated", "LoggerInitialized", "Invoking", "Invoked", "Started"},
 			spy.EventTypes())
 	})
 
@@ -378,7 +378,7 @@ func TestNewApp(t *testing.T) {
 		defer app.RequireStart().RequireStop()
 
 		require.Equal(t,
-			[]string{"Provided", "Provided", "Provided", "Provided", "LoggerInitialized", "Decorated", "Decorated", "Started"},
+			[]string{"Provided", "Provided", "Provided", "Provided", "Decorated", "Decorated", "LoggerInitialized", "Started"},
 			spy.EventTypes())
 	})
 }


### PR DESCRIPTION
`fx.WithLogger` does not currently respect decorations made with `fx.Decorate`
or `fx.Replace`. The reasons for this are two fold:

1. App runs decorations *after* constructing the custom logger. This means that
   dig doesn't know about the decorations at this time.
2. App provides and invokes the custom logger on the `dig.Container`, while the
   decorations begin running at the root `dig.Scope` held by Fx. So the
   container that we run the custom logger off doesn't know about the decorator
   because it's one layer down.

This PR moves decoration to run before the custom logger is constructed,
and changes the custom logger instantiation code to operate on the root scope.

Resolves #860
Refs GO-1341