### PR TITLE
Do not run lifecycle hooks with expired context

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -22,7 +22,6 @@ package lifecycle
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -79,7 +78,7 @@ func (l *Lifecycle) Start(ctx context.Context) error {
 
 	for _, hook := range l.hooks {
 		// if ctx has cancelled, bail out of the loop.
-		if err := ctx.Err(); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
@@ -137,7 +136,7 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	// Run backward from last successful OnStart.
 	var errs []error
 	for ; l.numStarted > 0; l.numStarted-- {
-		if err := ctx.Err(); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		hook := l.hooks[l.numStarted-1]

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -22,6 +22,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -78,7 +79,7 @@ func (l *Lifecycle) Start(ctx context.Context) error {
 
 	for _, hook := range l.hooks {
 		// if ctx has cancelled, bail out of the loop.
-		if err := ctx.Err(); err == context.Canceled || err == context.DeadlineExceeded {
+		if err := ctx.Err(); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 
@@ -136,8 +137,8 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	// Run backward from last successful OnStart.
 	var errs []error
 	for ; l.numStarted > 0; l.numStarted-- {
-		if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
-			return ctx.Err()
+		if err := ctx.Err(); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
 		}
 		hook := l.hooks[l.numStarted-1]
 		if hook.OnStop == nil {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -77,6 +77,11 @@ func (l *Lifecycle) Start(ctx context.Context) error {
 	l.mu.Unlock()
 
 	for _, hook := range l.hooks {
+		// if ctx has cancelled, bail out of the loop.
+		if err := ctx.Err(); err == context.Canceled || err == context.DeadlineExceeded {
+			return err
+		}
+
 		if hook.OnStart != nil {
 			l.mu.Lock()
 			l.runningHook = hook
@@ -131,6 +136,9 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	// Run backward from last successful OnStart.
 	var errs []error
 	for ; l.numStarted > 0; l.numStarted-- {
+		if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+			return ctx.Err()
+		}
 		hook := l.hooks[l.numStarted-1]
 		if hook.OnStop == nil {
 			continue


### PR DESCRIPTION
Currently, the lifecycle hooks are still run even when the context
passed as parameter to Start/Stop calls has expired/DeadlineExceeded.

This changes the fx lifecycle hook execution loop to check for expired
context before executing each hook, and bailing out of the exec loop
upon encountering context expiration.

Refs GO-1026.