### PR TITLE
Fix documentation for fxevent/Decorated and fxevent/Replaced

### DIFF
--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -134,7 +134,7 @@ type Provided struct {
 	Err error
 }
 
-// Replaced is emitted when a decorator is provided to Fx.
+// Replaced is emitted when a value replaces a type in Fx.
 type Replaced struct {
 	// OutputTypeNames is a list of names of types that were replaced.
 	OutputTypeNames []string
@@ -146,7 +146,7 @@ type Replaced struct {
 	Err error
 }
 
-// Decorated is emitted when a decorator is provided to Fx.
+// Decorated is emitted when a decorator is executed in Fx.
 type Decorated struct {
 	// DecoratorName is the name of the decorator function that was
 	// provided to Fx.
@@ -159,7 +159,7 @@ type Decorated struct {
 	// this decorator.
 	OutputTypeNames []string
 
-	// Err is non-nil if we failed to provide this decorator.
+	// Err is non-nil if we failed to run this decorator.
 	Err error
 }
 


### PR DESCRIPTION
The current documentation fox fxevent/Decorated is misleading because
it says that it's emitted when a decorator is provided to the fx.App.

In fact, it is emitted when the decorator actually runs in the fx.App.
The current doc is misleading, so this fixes the wording. Also, this
fixes the description for the fxevent/Replace event as well to be more
specific to Replace.