### PR TITLE
add fx.InvokeChain to synchronously invoke a chain of targets.

### DIFF
--- a/app.go
+++ b/app.go
@@ -320,7 +320,7 @@ type provide struct {
 // invoke is a single invocation request to Fx.
 type invoke struct {
 	// Function to invoke.
-	Target interface{}
+	Targets []interface{}
 
 	// Stack trace of where this invoke was made.
 	Stack fxreflect.Stack

--- a/module.go
+++ b/module.go
@@ -166,7 +166,15 @@ func (m *module) executeInvokes() error {
 }
 
 func (m *module) executeInvoke(i invoke) (err error) {
-	fnName := fxreflect.FuncName(i.Target)
+	if len(i.Targets) == 0 {
+		return nil
+	}
+
+	fnName := fxreflect.FuncName(i.Targets)
+	if len(i.Targets) > 1 {
+			fnName += " and more..."
+	}
+	
 	m.app.log.LogEvent(&fxevent.Invoking{
 		FunctionName: fnName,
 		ModuleName:   m.name,


### PR DESCRIPTION
with `fx.InvokeChain` you can register a chain of functions which need to be executed synchronously but which all need to be have their arguments provided from the container.

I think this should help people who are having a hard time creating some form of synchronization between a couple of invoke, 
without the need to add code inside the actual functions.  
for example: https://github.com/uber-go/fx/issues/884