### PR TITLE
fx.Extract: Deprecate in favor of populate

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -33,8 +33,7 @@ var _typeOfIn = reflect.TypeOf(In{})
 // container on application initialization. The target MUST be a pointer to a
 // struct. Only exported fields will be filled.
 //
-// Extract will be deprecated soon: use Populate instead, which doesn't
-// require defining a container struct.
+// Deprecated: Use Populate instead.
 func Extract(target interface{}) Option {
 	v := reflect.ValueOf(target)
 


### PR DESCRIPTION
fx.Extract is an older, poorer version of fx.Populate.
fx.Populate works on any value type, and fx.Extract requires building a
placeholder struct.

We meant to deprecate it right away, but because of widespread use of
staticcheck at the time, we marked it as "will be deprecated".

This finally deprecates it.