### PR TITLE
Adds OnStart/OnStop lifecycle Annotations

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -306,7 +306,6 @@ func (la *lifecycleHookAnnotation) resolveMap(results []reflect.Type) (
 		}
 	}
 
-	fmt.Printf("Result map %+v\n", resultMap)
 	return
 }
 
@@ -319,7 +318,7 @@ func (la *lifecycleHookAnnotation) resolveLifecycleParamField(
 	if param.Kind() == reflect.Struct {
 		nf := param.NumField()
 		if n <= nf {
-			value = param.FieldByName(fmt.Sprintf("Field%d", n-1))
+			value = param.FieldByName(fmt.Sprintf("Field%d", n))
 		}
 	}
 
@@ -375,10 +374,7 @@ func (la *lifecycleHookAnnotation) parameters(results ...reflect.Type) (
 		}
 		params = append(params, field)
 
-		resolver := func(v reflect.Value, pos int) (value reflect.Value) {
-			value = la.resolveLifecycleParamField(v, i)
-			return
-		}
+		resolver := la.resolveLifecycleParamField
 
 		resolverIdx = append(resolverIdx, argSource{
 			pos:     i,

--- a/annotated.go
+++ b/annotated.go
@@ -223,7 +223,7 @@ func (la *lifecycleHookAnnotation) String() string {
 func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
 	if la.Target == nil {
 		return fmt.Errorf(
-			"cannot use nil function for %v hook annotation",
+			"cannot use nil function for %q hook annotation",
 			la,
 		)
 	}
@@ -231,7 +231,7 @@ func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
 	for _, h := range ann.Hooks {
 		if la.Type == h.Type {
 			return fmt.Errorf(
-				"cannot apply more than one %v hook annotation",
+				"cannot apply more than one %q hook annotation",
 				la,
 			)
 		}
@@ -240,7 +240,8 @@ func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
 	ft := la.targetType()
 	if ft.Kind() != reflect.Func {
 		return fmt.Errorf(
-			"must provide function for hook, got %v (%T)",
+			"must provide function for %q hook, got %v (%T)",
+			la,
 			la.Target,
 			la.Target,
 		)
@@ -319,8 +320,7 @@ func (la *lifecycleHookAnnotation) resolveLifecycleParamField(
 	value reflect.Value,
 ) {
 	if param.Kind() == reflect.Struct {
-		nf := param.NumField()
-		if n <= nf {
+		if n <= param.NumField() {
 			value = param.FieldByName(fmt.Sprintf("Field%d", n))
 		}
 	}
@@ -471,7 +471,9 @@ func (la *lifecycleHookAnnotation) Build(results ...reflect.Type) (reflect.Value
 //    }),
 //  )
 //
-// Only one OnStart annotation may be applied to a given function at a time.
+// Only one OnStart annotation may be applied to a given function at a time,
+// however functions may be annotated with other types of lifecylce Hooks, such
+// as OnStop.
 func OnStart(onStart interface{}) Annotation {
 	return &lifecycleHookAnnotation{
 		Type:   _onStartHookType,
@@ -491,7 +493,9 @@ func OnStart(onStart interface{}) Annotation {
 //    }),
 //  )
 //
-// Only one OnStop annotation may be applied to a given function at a time.
+// Only one OnStop annotation may be applied to a given function at a time,
+// however functions may be annotated with other types of lifecylce Hooks, such
+// as OnStart.
 func OnStop(onStop interface{}) Annotation {
 	return &lifecycleHookAnnotation{
 		Type:   _onStopHookType,

--- a/annotated.go
+++ b/annotated.go
@@ -730,10 +730,10 @@ func (ann *annotated) parameters(results ...reflect.Type) (
 
 	// append required types for hooks to types field, but do not
 	// include them as params in constructor call
-	for h, t := range ann.Hooks {
+	for i, t := range ann.Hooks {
 		params, _ := t.parameters(results...)
 		field := reflect.StructField{
-			Name: fmt.Sprintf("Hook%d", h),
+			Name: fmt.Sprintf("Hook%d", i),
 			Type: params,
 		}
 		inFields = append(inFields, field)

--- a/annotated.go
+++ b/annotated.go
@@ -395,7 +395,12 @@ func (la *lifecycleHookAnnotation) parameters(results ...reflect.Type) (
 		if len(args) != 0 {
 
 			p := args[0]
-			results := args[1]
+
+			var results reflect.Value
+
+			if len(args) > 1 {
+				results = args[1]
+			}
 
 			lc, _ = p.FieldByName("Lifecycle").Interface().(Lifecycle)
 

--- a/annotated.go
+++ b/annotated.go
@@ -732,7 +732,6 @@ func (ann *annotated) parameters(results ...reflect.Type) (
 	}
 
 	types = []reflect.Type{reflect.StructOf(inFields)}
-
 	remap = func(args []reflect.Value) []reflect.Value {
 		params := args[0]
 		args = args[:0]
@@ -744,27 +743,21 @@ func (ann *annotated) parameters(results ...reflect.Type) (
 
 	hookValueMap = func(hook int, args []reflect.Value, results []reflect.Value) (out []reflect.Value) {
 		params := args[0]
-
 		if params.Kind() == reflect.Struct {
 			var zero reflect.Value
-			value := params.FieldByNameFunc(func(name string) bool {
-				return name == fmt.Sprintf("Hook%d", hook)
-			})
+			value := params.FieldByName(fmt.Sprintf("Hook%d", hook))
 
 			if value != zero {
 				out = append(out, value)
 			}
 		}
-
 		for _, r := range results {
 			if r.Type() != _typeOfError {
 				out = append(out, r)
 			}
 		}
-
 		return
 	}
-
 	return
 }
 

--- a/annotated.go
+++ b/annotated.go
@@ -427,7 +427,7 @@ func (la *lifecycleHookAnnotation) buildHook(fn func(context.Context) error) (ho
 	return
 }
 
-func (la *lifecycleHookAnnotation) Build(results ...reflect.Type) (reflect.Value, error) {
+func (la *lifecycleHookAnnotation) Build(results ...reflect.Type) reflect.Value {
 	in, paramMap := la.parameters(results...)
 	params := []reflect.Type{in}
 	for _, r := range results {
@@ -456,7 +456,7 @@ func (la *lifecycleHookAnnotation) Build(results ...reflect.Type) (reflect.Value
 		return []reflect.Value{}
 	})
 
-	return newFn, nil
+	return newFn
 }
 
 // OnStart is an Annotation that appends an OnStart Hook to the application
@@ -612,9 +612,7 @@ func (ann *annotated) Build() (interface{}, error) {
 
 	var hooks []reflect.Value
 	for _, hook := range ann.Hooks {
-		if hookFn, err := hook.Build(resultTypes...); err == nil {
-			hooks = append(hooks, hookFn)
-		}
+		hooks = append(hooks, hook.Build(resultTypes...))
 	}
 
 	newFnType := reflect.FuncOf(paramTypes, resultTypes, false)

--- a/annotated.go
+++ b/annotated.go
@@ -209,7 +209,7 @@ type lifecycleHookAnnotation struct {
 	Target interface{}
 }
 
-func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
+func (la *lifecycleHookAnnotation) String() string {
 	name := "UnknownHookAnnotation"
 	switch la.Type {
 	case _onStartHookType:
@@ -217,11 +217,14 @@ func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
 	case _onStopHookType:
 		name = _onStopHook
 	}
+	return name
+}
 
+func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
 	if la.Target == nil {
 		return fmt.Errorf(
 			"cannot use nil function for %v hook annotation",
-			name,
+			la,
 		)
 	}
 
@@ -229,7 +232,7 @@ func (la *lifecycleHookAnnotation) apply(ann *annotated) error {
 		if la.Type == h.Type {
 			return fmt.Errorf(
 				"cannot apply more than one %v hook annotation",
-				name,
+				la,
 			)
 		}
 	}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1334,7 +1334,7 @@ func TestHookAnnotationFailures(t *testing.T) {
 		},
 		{
 			name:        "with with multiple hooks of the same type",
-			errContains: "cannot apply more than one OnStart hook annotation",
+			errContains: "cannot apply more than one \"OnStart\" hook annotation",
 			annotation: fx.Annotate(
 				func() A { return nil },
 				fx.OnStart(func(context.Context) error { return nil }),

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1313,7 +1313,7 @@ func TestHookAnnotationFailures(t *testing.T) {
 		},
 		{
 			name:        "with hook that errors",
-			errContains: "OnStart hook failed",
+			errContains: "hook failed",
 			useNew:      true,
 			annotation: fx.Annotate(
 				func() (A, error) { return nil, nil },

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -994,8 +994,11 @@ func TestHookAnnotations(t *testing.T) {
 		t.Parallel()
 
 		var called bool
+		var invoked bool
 		hook := fx.Annotate(
-			func() {},
+			func() {
+				invoked = true
+			},
 			fx.OnStart(func(context.Context) error {
 				called = true
 				return nil
@@ -1006,6 +1009,7 @@ func TestHookAnnotations(t *testing.T) {
 		require.False(t, called)
 		require.NoError(t, app.Start(context.Background()))
 		require.True(t, called)
+		require.True(t, invoked)
 	})
 
 	t.Run("depend on result interface of target", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1394,7 +1394,7 @@ func TestHookAnnotationFailures(t *testing.T) {
 			errContains: "cannot use nil function",
 			annotation: fx.Annotate(
 				func() A { return nil },
-				fx.OnStart(nil),
+				fx.OnStop(nil),
 			),
 		},
 	}

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -990,6 +990,24 @@ func TestAnnotate(t *testing.T) {
 func TestHookAnnotations(t *testing.T) {
 	t.Parallel()
 
+	t.Run("with hook on invoke", func(t *testing.T) {
+		t.Parallel()
+
+		var called bool
+		hook := fx.Annotate(
+			func() {},
+			fx.OnStart(func(context.Context) error {
+				called = true
+				return nil
+			}),
+		)
+		app := fxtest.New(t, fx.Invoke(hook))
+
+		require.False(t, called)
+		require.NoError(t, app.Start(context.Background()))
+		require.True(t, called)
+	})
+
 	t.Run("depend on result interface of target", func(t *testing.T) {
 		type stub interface {
 			String() string


### PR DESCRIPTION
This provides two new annotations, OnStart and OnStop. Each will append their respective hooks into the application Lifecycle when the provided option function is executed. 

Usage:
```go
type Interface interface {
    Start(context.Context) error
    Stop(context.Context) error
}

func New() (Interface, error)

var Module = fx.Provide(fx.Annotate(
    New,
    fx.OnStart(func(ctx context.Context, server Interface) error {
      return server.Start(ctx)
    }),
    fx.OnStop(func(ctx context.Context, server Interface) error {
       return server.Stop(ctx)
   }),
))   
```
Which is functionally equivalent to:

```go
var Module = fx.Provide(
  func(lifecycle fx.Lifecycle) (Interface, error) {
    server, err := New()
    lifecycle.Append(fx.Hook{
      OnStart: func(ctx context.Context) error { return server.Start(ctx) }, 
      OnStop: func(ctx context.Context) error { return server.Stop(ctx) },
    }
    return server, err
  },
)  
``` 

Note for reviewers:
* The underlying implementation is unified for each hook type and may be easily extended should additional hook fields be added to the Hook type.
* This slightly modifies the parameter implementation of the private annotation type, this was required in order to make the hook annotation types able to detect when a given annotated function provides a required hook (closure) parameter. Without this any hook that takes a dependency on a type that is constructed in the same annotation would trigger a circular dependency. 
