### PR TITLE
Allow modules to be provided multiple times #892

### DIFF
--- a/module.go
+++ b/module.go
@@ -44,20 +44,26 @@ func Module(name string, opts ...Option) Option {
 	mo := moduleOption{
 		name:    name,
 		options: opts,
+		applied: false,
 	}
-	return mo
+	return &mo
 }
 
 type moduleOption struct {
 	name    string
 	options []Option
+	applied bool
 }
 
 func (o moduleOption) String() string {
 	return fmt.Sprintf("fx.Module(%q, %v)", o.name, o.options)
 }
 
-func (o moduleOption) apply(mod *module) {
+func (o *moduleOption) apply(mod *module) {
+	if o.applied {
+		return
+	}
+	o.applied = true
 	// This get called on any submodules' that are declared
 	// as part of another module.
 


### PR DESCRIPTION
Naive implementation preventing modules from being processed multiple times by the container.

I find quite difficult to implement this feature in other points of the initialization process such as `func (m *module) build`  because `Option`s were (until my PR) value objects with no unique identity.

This PR probably won't be merged, but raise awareness that the feature can be implemented without breaking the library and its tests.