### PR TITLE
Fix comment typos

### DIFF
--- a/annotated_test.go
+++ b/annotated_test.go
@@ -913,7 +913,7 @@ func TestAnnotate(t *testing.T) {
 		err := app.Err()
 		require.Error(t, err)
 
-		// Exmaple:
+		// Example:
 		// fx.Provide(fx.Annotate(42, fx.ResultTags(["name:\"buf\""])) from:
 		// go.uber.org/fx_test.TestAnnotate.func17
 		//     /Users/abg/dev/fx/annotated_test.go:697

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -173,7 +173,7 @@ type Invoking struct {
 }
 
 // Invoked is emitted after we invoke a function specified with fx.Invoke,
-// whether it succeded or failed.
+// whether it succeeded or failed.
 type Invoked struct {
 	// Functionname is the name of the function that was invoked.
 	FunctionName string
@@ -219,7 +219,7 @@ type RollingBack struct {
 }
 
 // RolledBack is emitted after a service has been rolled back, whether it
-// succeded or not.
+// succeeded or not.
 type RolledBack struct {
 	// Err is non-nil if the rollback failed.
 	Err error

--- a/fxtest/lifecycle.go
+++ b/fxtest/lifecycle.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/fx/internal/testutil"
 )
 
-// If a testing.T is unspecified, degarde to printing to stderr to provide
+// If a testing.T is unspecified, degrade to printing to stderr to provide
 // meaningful messages.
 type panicT struct {
 	W io.Writer // stream to which we'll write messages


### PR DESCRIPTION
Fix a couple typos in comments.
These typos were reported by https://goreportcard.com/.

```
fxevent/event.go
Line 163: warning: "succeded" is a misspelling of "succeeded" (misspell)
Line 209: warning: "succeded" is a misspelling of "succeeded" (misspell)

fxtest/lifecycle.go
Line 36: warning: "degarde" is a misspelling of "degrade" (misspell)

annotated_test.go
Line 915: warning: "Exmaple" is a misspelling of "Example" (misspell)
```