### PR TITLE
Add documentation and tests for soft group values

### DIFF
--- a/annotated_test.go
+++ b/annotated_test.go
@@ -450,12 +450,8 @@ func TestAnnotatedWrongUsage(t *testing.T) {
 
 		app := NewForTest(t,
 			fx.Provide(
-				fx.Annotated{
-					Group: "foo,soft",
-					Target: func() string {
-						return "sad times"
-					},
-				},
+				fx.Annotate(func() string { return "sad times" },
+					fx.ResultTags(`group:"foo,soft"`)),
 			),
 		)
 		assert.Contains(t, app.Err().Error(), "cannot use soft with result value groups", "expected error when invalid group option is provided")

--- a/inout.go
+++ b/inout.go
@@ -169,22 +169,22 @@ import "go.uber.org/dig"
 // A soft group will be populated only with values from already-executed
 // constructors.
 //
-//   type Params struct {
-//     fx.In
+//	 type Params struct {
+//	   fx.In
 //
-//     Handlers []Handler `group:"server"`
-//     Logger   *zap.Logger
-//   }
+//	   Handlers []Handler `group:"server"`
+//	   Logger   *zap.Logger
+//	 }
 //
-//   NewHandlerAndLogger := func() (Handler, *zap.Logger) { ... }
-//   NewHandler := func() Handler { ... }
-//   Foo := func(Params) { ... }
+//	 NewHandlerAndLogger := func() (Handler, *zap.Logger) { ... }
+//	 NewHandler := func() Handler { ... }
+//	 Foo := func(Params) { ... }
 //
-//  app := fx.New(
-//    fx.Provide(NewHandlerAndLogger),
-//    fx.Provide(NewHandler),
-//    fx.Invoke(Foo),
-//  )
+//	app := fx.New(
+//	  fx.Provide(NewHandlerAndLogger),
+//	  fx.Provide(NewHandler),
+//	  fx.Invoke(Foo),
+//	)
 //
 // The only constructor called is `NewHandler`, because this also provides
 // `*zap.Logger` needed in the `Params` struct received by `foo`
@@ -192,47 +192,47 @@ import "go.uber.org/dig"
 // In the next example, the slice `s` isn't populated as the provider would be
 // called only because of `strings` soft group value
 //
-//    app := fx.New(
-//      fx.Provide(
-//        fx.Annotate(
-//          func() (string,int) { return "hello" },
-//          fx.ResultTags(`group:"strings"`),
-//        ),
-//      ),
-//      fx.Invoke(
-//        fx.Annotate(func(s []string) {
-//               // s will be an empty slice
-//		    },
-//          fx.ParamTags(`group:"strings,soft"`),
-//        ),
-//      ),
-//   )
+//	   app := fx.New(
+//	     fx.Provide(
+//	       fx.Annotate(
+//	         func() (string,int) { return "hello" },
+//	         fx.ResultTags(`group:"strings"`),
+//	       ),
+//	     ),
+//	     fx.Invoke(
+//	       fx.Annotate(func(s []string) {
+//	              // s will be an empty slice
+//			    },
+//	         fx.ParamTags(`group:"strings,soft"`),
+//	       ),
+//	     ),
+//	  )
 //
-//  In the next example, the slice `s` will be populated because there is a
-//  consumer for the same type which hasn't a `soft` dependency
+//	 In the next example, the slice `s` will be populated because there is a
+//	 consumer for the same type which hasn't a `soft` dependency
 //
-//    app := fx.New(
-//      fx.Provide(
-//        fx.Annotate(
-//          func() string { "hello" },
-//          fx.ResultTags(`group:"strings"`),
-//        ),
-//      ),
-//      fx.Invoke(
-//        fx.Annotate(func(b []string) {
-//               // b will be ["hello"]
-//		    },
-//          fx.ParamTags(`group:"strings"`),
-//        ),
-//      ),
-//      fx.Invoke(
-//        fx.Annotate(func(s []string) {
-//               // s will be ["hello"]
-//		    },
-//          fx.ParamTags(`group:"strings,soft"`),
-//        ),
-//      ),
-//   )
+//	   app := fx.New(
+//	     fx.Provide(
+//	       fx.Annotate(
+//	         func() string { "hello" },
+//	         fx.ResultTags(`group:"strings"`),
+//	       ),
+//	     ),
+//	     fx.Invoke(
+//	       fx.Annotate(func(b []string) {
+//	              // b will be ["hello"]
+//			    },
+//	         fx.ParamTags(`group:"strings"`),
+//	       ),
+//	     ),
+//	     fx.Invoke(
+//	       fx.Annotate(func(s []string) {
+//	              // s will be ["hello"]
+//			    },
+//	         fx.ParamTags(`group:"strings,soft"`),
+//	       ),
+//	     ),
+//	  )
 //
 // # Unexported fields
 //

--- a/inout.go
+++ b/inout.go
@@ -192,41 +192,41 @@ import "go.uber.org/dig"
 // In the next example, the slice `s` isn't populated as the provider would be
 // called only because of `strings` soft group value
 //
-//	   app := fx.New(
-//	     fx.Provide(
-//	       fx.Annotate(
-//	         func() (string,int) { return "hello" },
-//	         fx.ResultTags(`group:"strings"`),
-//	       ),
-//	     ),
-//	     fx.Invoke(
-//	       fx.Annotate(func(s []string) {
-//	         // s will be an empty slice
-//	       }, fx.ParamTags(`group:"strings,soft"`)),
-//	     ),
-//	  )
+//	  app := fx.New(
+//	    fx.Provide(
+//	      fx.Annotate(
+//	        func() (string,int) { return "hello" },
+//	        fx.ResultTags(`group:"strings"`),
+//	      ),
+//	    ),
+//	    fx.Invoke(
+//	      fx.Annotate(func(s []string) {
+//	        // s will be an empty slice
+//	      }, fx.ParamTags(`group:"strings,soft"`)),
+//	    ),
+//	 )
 //
-//	 In the next example, the slice `s` will be populated because there is a
-//	 consumer for the same type which hasn't a `soft` dependency
+//	In the next example, the slice `s` will be populated because there is a
+//	consumer for the same type which hasn't a `soft` dependency
 //
-//	   app := fx.New(
-//	     fx.Provide(
-//	       fx.Annotate(
-//	         func() string { "hello" },
-//	         fx.ResultTags(`group:"strings"`),
-//	       ),
-//	     ),
-//	     fx.Invoke(
-//	       fx.Annotate(func(b []string) {
-//	         // b will be ["hello"]
-//	       }, fx.ParamTags(`group:"strings"`)),
-//	     ),
-//	     fx.Invoke(
-//	       fx.Annotate(func(s []string) {
-//	         // s will be ["hello"]
-//	       }, fx.ParamTags(`group:"strings,soft"`)),
-//	     ),
-//	  )
+//	  app := fx.New(
+//	    fx.Provide(
+//	      fx.Annotate(
+//	        func() string { "hello" },
+//	        fx.ResultTags(`group:"strings"`),
+//	      ),
+//	    ),
+//	    fx.Invoke(
+//	      fx.Annotate(func(b []string) {
+//	        // b will be ["hello"]
+//	      }, fx.ParamTags(`group:"strings"`)),
+//	    ),
+//	    fx.Invoke(
+//	      fx.Annotate(func(s []string) {
+//	        // s will be ["hello"]
+//	      }, fx.ParamTags(`group:"strings,soft"`)),
+//	    ),
+//	 )
 //
 // # Unexported fields
 //

--- a/inout.go
+++ b/inout.go
@@ -163,6 +163,26 @@ import "go.uber.org/dig"
 // Note that values in a value group are unordered. Fx makes no guarantees
 // about the order in which these values will be produced.
 //
+// To declare a soft relationship between a group an its constructors, use the
+// `soft` option on the group tag (`group:"[groupname],soft"`). A soft group
+// will be populated only with values from already-executed constructors, this
+// means constructors of soft value groups will be called only if they provide
+// another requested value.
+//
+//   type Params struct {
+//	  fx.In
+//
+//    Handlers []Handler `group:"server"`
+//    Logger   *zap.Logger
+//   }
+//   func NewHandlerAndLogger() (Handler, *zap.Logger) { ... }
+//   func NewHandler() Handler { ... }
+//   func Foo(Params) { ... }
+//
+// When `NewHandlerAndLogger` and `NewHandler`are provided, and `Foo` invoked,
+// the only constructor called is `NewHandler`, because this also provides
+// `*zap.Logger` needed in the `Params` struct.
+//
 // # Unexported fields
 //
 // By default, a type that embeds fx.In may not have any unexported fields. The

--- a/inout.go
+++ b/inout.go
@@ -201,10 +201,8 @@ import "go.uber.org/dig"
 //	     ),
 //	     fx.Invoke(
 //	       fx.Annotate(func(s []string) {
-//	              // s will be an empty slice
-//			    },
-//	         fx.ParamTags(`group:"strings,soft"`),
-//	       ),
+//	         // s will be an empty slice
+//	       }, fx.ParamTags(`group:"strings,soft"`)),
 //	     ),
 //	  )
 //
@@ -220,17 +218,13 @@ import "go.uber.org/dig"
 //	     ),
 //	     fx.Invoke(
 //	       fx.Annotate(func(b []string) {
-//	              // b will be ["hello"]
-//			    },
-//	         fx.ParamTags(`group:"strings"`),
-//	       ),
+//	         // b will be ["hello"]
+//	       }, fx.ParamTags(`group:"strings"`)),
 //	     ),
 //	     fx.Invoke(
 //	       fx.Annotate(func(s []string) {
-//	              // s will be ["hello"]
-//			    },
-//	         fx.ParamTags(`group:"strings,soft"`),
-//	       ),
+//	         // s will be ["hello"]
+//	       }, fx.ParamTags(`group:"strings,soft"`)),
 //	     ),
 //	  )
 //

--- a/inout.go
+++ b/inout.go
@@ -163,25 +163,76 @@ import "go.uber.org/dig"
 // Note that values in a value group are unordered. Fx makes no guarantees
 // about the order in which these values will be produced.
 //
-// To declare a soft relationship between a group an its constructors, use the
-// `soft` option on the group tag (`group:"[groupname],soft"`). A soft group
-// will be populated only with values from already-executed constructors, this
-// means constructors of soft value groups will be called only if they provide
-// another requested value.
+// To declare a soft relationship between a group and its constructors, use
+// the `soft` option on the group tag (`group:"[groupname],soft"`), this
+// option can only be used for input parameters, e.g. `fx.In` structures.
+// A soft group will be populated only with values from already-executed
+// constructors.
 //
 //   type Params struct {
-//	  fx.In
+//     fx.In
 //
-//    Handlers []Handler `group:"server"`
-//    Logger   *zap.Logger
+//     Handlers []Handler `group:"server"`
+//     Logger   *zap.Logger
 //   }
-//   func NewHandlerAndLogger() (Handler, *zap.Logger) { ... }
-//   func NewHandler() Handler { ... }
-//   func Foo(Params) { ... }
 //
-// When `NewHandlerAndLogger` and `NewHandler`are provided, and `Foo` invoked,
-// the only constructor called is `NewHandler`, because this also provides
-// `*zap.Logger` needed in the `Params` struct.
+//   NewHandlerAndLogger := func() (Handler, *zap.Logger) { ... }
+//   NewHandler := func() Handler { ... }
+//   Foo := func(Params) { ... }
+//
+//  app := fx.New(
+//    fx.Provide(NewHandlerAndLogger),
+//    fx.Provide(NewHandler),
+//    fx.Invoke(Foo),
+//  )
+//
+// The only constructor called is `NewHandler`, because this also provides
+// `*zap.Logger` needed in the `Params` struct received by `foo`
+//
+// In the next example, the slice `s` isn't populated as the provider would be
+// called only because of `strings` soft group value
+//
+//    app := fx.New(
+//      fx.Provide(
+//        fx.Annotate(
+//          func() (string,int) { return "hello" },
+//          fx.ResultTags(`group:"strings"`),
+//        ),
+//      ),
+//      fx.Invoke(
+//        fx.Annotate(func(s []string) {
+//               // s will be an empty slice
+//		    },
+//          fx.ParamTags(`group:"strings,soft"`),
+//        ),
+//      ),
+//   )
+//
+//  In the next example, the slice `s` will be populated because there is a
+//  consumer for the same type which hasn't a `soft` dependency
+//
+//    app := fx.New(
+//      fx.Provide(
+//        fx.Annotate(
+//          func() string { "hello" },
+//          fx.ResultTags(`group:"strings"`),
+//        ),
+//      ),
+//      fx.Invoke(
+//        fx.Annotate(func(b []string) {
+//               // b will be ["hello"]
+//		    },
+//          fx.ParamTags(`group:"strings"`),
+//        ),
+//      ),
+//      fx.Invoke(
+//        fx.Annotate(func(s []string) {
+//               // s will be ["hello"]
+//		    },
+//          fx.ParamTags(`group:"strings,soft"`),
+//        ),
+//      ),
+//   )
 //
 // # Unexported fields
 //

--- a/module_test.go
+++ b/module_test.go
@@ -112,6 +112,21 @@ func TestModuleSuccess(t *testing.T) {
 		defer app.RequireStart().RequireStop()
 		require.NoError(t, app.Err())
 	})
+	t.Run("soft provided to fx.Out struct", func(t *testing.T) {
+		t.Parallel()
+
+		type Result struct {
+			fx.Out
+
+			Bars []int `group:"bar,soft"`
+		}
+		app := NewForTest(t,
+			fx.Provide(func() Result { return Result{Bars: []int{1, 2, 3}} }),
+		)
+		err := app.Err()
+		require.Error(t, err, "failed to create app")
+		assert.Contains(t, err.Error(), "cannot use soft with result value groups")
+	})
 	t.Run("invoke from nested module", func(t *testing.T) {
 		t.Parallel()
 		invokeRan := false

--- a/module_test.go
+++ b/module_test.go
@@ -112,21 +112,7 @@ func TestModuleSuccess(t *testing.T) {
 		defer app.RequireStart().RequireStop()
 		require.NoError(t, app.Err())
 	})
-	t.Run("soft provided to fx.Out struct", func(t *testing.T) {
-		t.Parallel()
 
-		type Result struct {
-			fx.Out
-
-			Bars []int `group:"bar,soft"`
-		}
-		app := NewForTest(t,
-			fx.Provide(func() Result { return Result{Bars: []int{1, 2, 3}} }),
-		)
-		err := app.Err()
-		require.Error(t, err, "failed to create app")
-		assert.Contains(t, err.Error(), "cannot use soft with result value groups")
-	})
 	t.Run("invoke from nested module", func(t *testing.T) {
 		t.Parallel()
 		invokeRan := false
@@ -320,6 +306,22 @@ func TestModuleFailures(t *testing.T) {
 
 		assert.Contains(t, err.Error(), "encountered error while applying annotation")
 		assert.Contains(t, err.Error(), "cannot apply more than one line of ParamTags")
+	})
+
+	t.Run("soft provided to fx.Out struct", func(t *testing.T) {
+		t.Parallel()
+
+		type Result struct {
+			fx.Out
+
+			Bars []int `group:"bar,soft"`
+		}
+		app := NewForTest(t,
+			fx.Provide(func() Result { return Result{Bars: []int{1, 2, 3}} }),
+		)
+		err := app.Err()
+		require.Error(t, err, "failed to create app")
+		assert.Contains(t, err.Error(), "cannot use soft with result value groups")
 	})
 
 	t.Run("provider in Module fails", func(t *testing.T) {


### PR DESCRIPTION
This adds documentation regarding soft group values feature and also
adds test cases to check this feature works with modules, `Supply`,
`Decorate` and `Annotate`.