### PR TITLE
Implements ShutdownCode option and ShutdownSignal os.Signal wrapper

### DIFF
--- a/app.go
+++ b/app.go
@@ -686,7 +686,7 @@ func (app *App) Done() <-chan os.Signal {
 	return c
 }
 
-func (app *App) wait() <-chan ShutdownSignal {
+func (app *App) Wait() <-chan ShutdownSignal {
 	c := make(chan ShutdownSignal, 1)
 
 	app.waitsMu.Lock()
@@ -699,16 +699,6 @@ func (app *App) wait() <-chan ShutdownSignal {
 
 	app.waits = append(app.waits, c)
 	return c
-}
-
-func (app *App) Wait(ctx context.Context) (ShutdownSignal, error) {
-	c := app.wait()
-	select {
-	case s := <-c:
-		return s, nil
-	case <-ctx.Done():
-		return ShutdownSignal{}, ctx.Err()
-	}
 }
 
 // StartTimeout returns the configured startup timeout. Apps default to using

--- a/app_internal_test.go
+++ b/app_internal_test.go
@@ -22,7 +22,6 @@ package fx
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestAppRun(t *testing.T) {
 	app := New(
 		WithLogger(func() fxevent.Logger { return spy }),
 	)
-	done := make(chan os.Signal)
+	done := make(chan ShutdownSignal)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -50,7 +49,7 @@ func TestAppRun(t *testing.T) {
 		app.run(done)
 	}()
 
-	done <- _sigINT
+	done <- ShutdownSignal{Signal: _sigINT}
 	wg.Wait()
 
 	assert.Equal(t, []string{

--- a/app_test.go
+++ b/app_test.go
@@ -917,7 +917,7 @@ func TestAppRunTimeout(t *testing.T) {
 
 			err, _ := errv.Interface().(error)
 			assert.ErrorIs(t, err, context.DeadlineExceeded,
-				"should fail because of a timeout")
+				"should fail because of a timeout: %v", err)
 		})
 	}
 }

--- a/shutdown.go
+++ b/shutdown.go
@@ -105,9 +105,11 @@ func (app *App) broadcastDoneSignal(signal os.Signal) error {
 	}
 
 	if unsent != 0 {
-		return fmt.Errorf("failed to send %v signal to %v out of %v channels",
-			signal, unsent, len(app.dones),
-		)
+		return ErrOnUnsentSignal{
+			Signal:   signal,
+			Unsent:   unsent,
+			Channels: len(app.dones),
+		}
 	}
 
 	return nil
@@ -134,10 +136,30 @@ func (app *App) broadcastWaitSignal(signal os.Signal, code int) error {
 	}
 
 	if unsent != 0 {
-		return fmt.Errorf("failed to send %v codes to %v out of %v channels",
-			signal, unsent, len(app.waits),
-		)
+		return ErrOnUnsentSignal{
+			Signal:   signal,
+			Unsent:   unsent,
+			Code:     code,
+			Channels: len(app.waits),
+		}
 	}
 
 	return nil
+}
+
+// ErrOnUnsentSignal ... TBD
+type ErrOnUnsentSignal struct {
+	Signal   os.Signal
+	Unsent   int
+	Code     int
+	Channels int
+}
+
+func (err ErrOnUnsentSignal) Error() string {
+	return fmt.Sprintf(
+		"failed to send %v signal to %v out of %v channels",
+		err.Signal,
+		err.Unsent,
+		err.Channels,
+	)
 }

--- a/shutdown.go
+++ b/shutdown.go
@@ -169,7 +169,7 @@ type errOnUnsentSignal struct {
 
 func (err *errOnUnsentSignal) Error() string {
 	return fmt.Sprintf(
-		"failed to send %v signal to %v out of %v channels",
+		"send %v signal: %v/%v channels are blocked",
 		err.Signal,
 		err.Unsent,
 		err.Channels,

--- a/shutdown.go
+++ b/shutdown.go
@@ -150,7 +150,7 @@ func (app *App) broadcastSignal(signal os.Signal, code int) error {
 	}
 
 	if unsent != 0 {
-		resultErr = multierr.Append(resultErr, &ErrOnUnsentSignal{
+		resultErr = multierr.Append(resultErr, &errOnUnsentSignal{
 			Signal:   signal,
 			Unsent:   unsent,
 			Channels: len(app.sigReceivers),
@@ -160,15 +160,14 @@ func (app *App) broadcastSignal(signal os.Signal, code int) error {
 	return resultErr
 }
 
-// ErrOnUnsentSignal ... TBD
-type ErrOnUnsentSignal struct {
+type errOnUnsentSignal struct {
 	Signal   os.Signal
 	Unsent   int
 	Code     int
 	Channels int
 }
 
-func (err *ErrOnUnsentSignal) Error() string {
+func (err *errOnUnsentSignal) Error() string {
 	return fmt.Sprintf(
 		"failed to send %v signal to %v out of %v channels",
 		err.Signal,

--- a/shutdown_code_example_test.go
+++ b/shutdown_code_example_test.go
@@ -21,10 +21,7 @@
 package fx_test
 
 import (
-	"context"
 	"fmt"
-	"time"
-
 	"go.uber.org/fx"
 )
 
@@ -39,16 +36,11 @@ func ExampleShutdownCode() {
 
 	app.Run()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	wait := app.Wait()
 
-	shutdown, err := app.Wait(ctx)
+	signal := <-wait
 
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("os.Exit(%v)\n", shutdown.ExitCode)
+	fmt.Printf("os.Exit(%v)\n", signal.ExitCode)
 
 	// Output:
 	// os.Exit(1)

--- a/shutdown_code_example_test.go
+++ b/shutdown_code_example_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+func ExampleShutdownCode() {
+	app := fx.New(
+		fx.Invoke(func(shutdowner fx.Shutdowner) {
+			// Call the shutdowner Shutdown method with a shutdown code
+			// option
+			shutdowner.Shutdown(fx.ShutdownCode(1))
+		}),
+	)
+
+	app.Run()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	shutdown, err := app.Wait(ctx)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("os.Exit(%v)\n", shutdown.ExitCode)
+
+	// Output:
+	// os.Exit(1)
+}

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -131,7 +131,7 @@ func TestShutdown(t *testing.T) {
 
 			err := s.Shutdown()
 			assert.Error(t, err)
-			var o fx.ErrOnUnsentSignal
+			var o *fx.ErrOnUnsentSignal
 			assert.True(t, errors.As(err, &o))
 
 			assert.Equal(t, 1, o.Unsent)

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -22,7 +22,6 @@ package fx_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -131,11 +130,6 @@ func TestShutdown(t *testing.T) {
 
 			err := s.Shutdown()
 			assert.Error(t, err)
-			var o *fx.ErrOnUnsentSignal
-			assert.True(t, errors.As(err, &o))
-
-			assert.Equal(t, 1, o.Unsent)
-			assert.Equal(t, 1, o.Channels)
 			assert.NotNil(t, <-wait)
 		})
 

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -65,7 +65,7 @@ func TestShutdown(t *testing.T) {
 		defer app.RequireStart().RequireStop()
 		assert.NoError(t, s.Shutdown(), "error returned from first shutdown call")
 
-		assert.EqualError(t, s.Shutdown(), "failed to send terminated signal to 1 out of 1 channels",
+		assert.EqualError(t, s.Shutdown(), "send terminated signal: 1/1 channels are blocked",
 			"unexpected error returned when shutdown is called with a blocked channel")
 		assert.NotNil(t, <-done, "done channel did not receive signal")
 	})

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -171,6 +171,7 @@ func TestDataRace(t *testing.T) {
 		fx.Populate(&s),
 	)
 	require.NoError(t, app.Start(context.Background()), "error starting app")
+	defer require.NoError(t, app.Stop(context.Background()), "error stopping app")
 
 	const N = 50
 	ready := make(chan struct{}) // used to orchestrate goroutines for Done() and ShutdownOption()


### PR DESCRIPTION
Provides API for users of the `Shutdowner` interface to specify an exit code that should be used to exit an application.
Addresses issue #763

* Adds `ShutdownCode` shutdown option
* Adds `ShutdownSignal` type which includes fields for both os.Signal and exit code
* Adds `Wait()` method which operates like `Done()` but instead of returning a os.Signal channel, returns a `ShutdownSignal` channel
* Adds `ShutdownCode` option example test
* Includes broadcast signaling refactor by @abhinav 



```go
	app := fx.New(
		fx.Invoke(func(shutdowner fx.Shutdowner) {
			// Call the shutdowner Shutdown method with a shutdown code
			// option
			shutdowner.Shutdown(fx.ShutdownCode(1))
		}),
	)

	app.Run()

	wait := app.Wait()

	signal := <-wait

	os.Exit(signal.ExitCode)
```