### PR TITLE
Clarify documentation on fx.Annotate

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -955,11 +955,11 @@ func (ann *annotated) results() (
 //	  fx.Out
 //
 //	  GW *Gateway `name:"foo"`
-//	 }
+//	}
 //
-//	 fx.Provide(func(p params) result {
+//	fx.Provide(func(p params) result {
 //	   return result{GW: NewGateway(p.RO, p.RW)}
-//	 })
+//	})
 //
 // Annotate cannot be used on functions that takes in or returns
 // [In] or [Out] structs.

--- a/annotated.go
+++ b/annotated.go
@@ -961,6 +961,9 @@ func (ann *annotated) results() (
 //	   return result{GW: NewGateway(p.RO, p.RW)}
 //	 })
 //
+// Annotate cannot be used on functions that takes in or returns
+// [In] or [Out] structs.
+//
 // Using the same annotation multiple times is invalid.
 // For example, the following will fail with an error:
 //


### PR DESCRIPTION
Some people are getting confused why fx.Annotate doesn't work with
fx.In or fx.Out struct and may think this is a bug.

Clarify in the documentation that this is not meant to be used with
fx.In or fx.Out structs - it replaces their usages.