### PR TITLE
Annotated test: Use NewForTest

### DIFF
--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1443,9 +1443,8 @@ func TestHookAnnotationFailures(t *testing.T) {
 				return
 			}
 
-			app := fx.New(opts)
-			ctx := context.Background()
-			err := app.Start(ctx)
+			app := NewForTest(t, opts)
+			err := app.Start(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errContains)
 		})


### PR DESCRIPTION
The table tests in fx OnStart/OnStop hooks tests weren't using
NewForTest so they end up polluting the failure logs when there
are tests failing.