### PR TITLE
Ensure OnStart/OnStop hooks can only be called once

### DIFF
--- a/app.go
+++ b/app.go
@@ -300,9 +300,9 @@ type App struct {
 	dones       []chan os.Signal
 	shutdownSig os.Signal
 
-	// Used to make sure Stop is called only once.
-	stoppedMu sync.Mutex
-	stopped   bool
+	// Used to make sure Start/Stop is called only once.
+	runStart sync.Once
+	runStop  sync.Once
 
 	osExit func(code int) // os.Exit override; used for testing only
 }
@@ -662,21 +662,25 @@ var (
 // Note that Start short-circuits immediately if the New constructor
 // encountered any errors in application initialization.
 func (app *App) Start(ctx context.Context) (err error) {
-	defer func() {
-		app.log.LogEvent(&fxevent.Started{Err: err})
-	}()
+	app.runStart.Do(func() {
+		defer func() {
+			app.log.LogEvent(&fxevent.Started{Err: err})
+		}()
 
-	if app.err != nil {
-		// Some provides failed, short-circuit immediately.
-		return app.err
-	}
+		if app.err != nil {
+			// Some provides failed, short-circuit immediately.
+			err = app.err
+			return
+		}
 
-	return withTimeout(ctx, &withTimeoutParams{
-		hook:      _onStartHook,
-		callback:  app.start,
-		lifecycle: app.lifecycle,
-		log:       app.log,
+		err = withTimeout(ctx, &withTimeoutParams{
+			hook:      _onStartHook,
+			callback:  app.start,
+			lifecycle: app.lifecycle,
+			log:       app.log,
+		})
 	})
+	return
 }
 
 func (app *App) start(ctx context.Context) error {
@@ -704,25 +708,20 @@ func (app *App) start(ctx context.Context) error {
 // called are executed. However, all those hooks are executed, even if some
 // fail.
 func (app *App) Stop(ctx context.Context) (err error) {
-	// Protect the Stop hooks from being called multiple times.
-	app.stoppedMu.Lock()
-	if app.stopped {
-		app.stoppedMu.Unlock()
-		return errors.New("app has already been stopped")
-	}
-	app.stopped = true
-	app.stoppedMu.Unlock()
+	app.runStop.Do(func() {
+		// Protect the Stop hooks from being called multiple times.
+		defer func() {
+			app.log.LogEvent(&fxevent.Stopped{Err: err})
+		}()
 
-	defer func() {
-		app.log.LogEvent(&fxevent.Stopped{Err: err})
-	}()
-
-	return withTimeout(ctx, &withTimeoutParams{
-		hook:      _onStopHook,
-		callback:  app.lifecycle.Stop,
-		lifecycle: app.lifecycle,
-		log:       app.log,
+		err = withTimeout(ctx, &withTimeoutParams{
+			hook:      _onStopHook,
+			callback:  app.lifecycle.Stop,
+			lifecycle: app.lifecycle,
+			log:       app.log,
+		})
 	})
+	return
 }
 
 // Done returns a channel of signals to block on after starting the

--- a/app_test.go
+++ b/app_test.go
@@ -1306,8 +1306,8 @@ func TestAppStart(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				app.Start(context.Background())
-				wg.Done()
 			}()
 		}
 		wg.Wait()
@@ -1315,8 +1315,8 @@ func TestAppStart(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				app.Stop(context.Background())
-				wg.Done()
 			}()
 		}
 		wg.Wait()


### PR DESCRIPTION
It is possible for a user to erroneously call app.Run() then
follow up by calling app.Stop(). In such a case, it is possible
for the app.Stop() method to be called by two goroutines concurrently,
resulting in a race.

This adds a state in the App to keep track of whether Stop() has been
invoked so that such a race can be prevented.

Fix #930
Internal Ref: GO-1606