### PR TITLE
Fix interface compliance verifications

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -129,7 +129,7 @@ type paramTagsAnnotation struct {
 	tags []string
 }
 
-var _ paramTagsAnnotation = paramTagsAnnotation{}
+var _ Annotation = paramTagsAnnotation{}
 
 // Given func(T1, T2, T3, ..., TN), this generates a type roughly
 // equivalent to,
@@ -165,7 +165,7 @@ type resultTagsAnnotation struct {
 	tags []string
 }
 
-var _ resultTagsAnnotation = resultTagsAnnotation{}
+var _ Annotation = resultTagsAnnotation{}
 
 // Given func(T1, T2, T3, ..., TN), this generates a type roughly
 // equivalent to,
@@ -208,6 +208,8 @@ type lifecycleHookAnnotation struct {
 	Type   _lifecycleHookAnnotationType
 	Target interface{}
 }
+
+var _ Annotation = (*lifecycleHookAnnotation)(nil)
 
 func (la *lifecycleHookAnnotation) String() string {
 	name := "UnknownHookAnnotation"
@@ -523,7 +525,7 @@ type asAnnotation struct {
 	targets []interface{}
 }
 
-var _ asAnnotation = asAnnotation{}
+var _ Annotation = asAnnotation{}
 
 // As is an Annotation that annotates the result of a function (i.e. a
 // constructor) to be provided as another interface.


### PR DESCRIPTION
There's some invalid interface compliance verification checks
in annotated.go. Fixing these.