### PR TITLE
doc(Soft value groups): Fix missing return

### DIFF
--- a/inout.go
+++ b/inout.go
@@ -206,7 +206,7 @@ import "go.uber.org/dig"
 //	 app := fx.New(
 //	   fx.Provide(
 //	     fx.Annotate(
-//	       func() (string,int) { return "hello" },
+//	       func() (string, int) { return "hello", 42 },
 //	       fx.ResultTags(`group:"strings"`),
 //	     ),
 //	   ),


### PR DESCRIPTION
The code sample included a `func(string,int)`
as an example, but did not include the `int` return.