### PR TITLE
Fix decorator not being applied to transient dependencies

### DIFF
--- a/decorate_test.go
+++ b/decorate_test.go
@@ -313,6 +313,39 @@ func TestDecorateSuccess(t *testing.T) {
 		)
 		defer app.RequireStart().RequireStop()
 	})
+
+	t.Run("decoration must execute when required by a member of group", func(t *testing.T) {
+		type Drinks interface {
+		}
+		type Coffee struct {
+			Type  string
+			Name  string
+			Price int
+		}
+		type PriceService struct {
+			DefaultPrice int
+		}
+		app := fxtest.New(t,
+			fx.Provide(func() *PriceService {
+				return &PriceService{DefaultPrice: 3}
+			}),
+			fx.Decorate(func(service *PriceService) *PriceService {
+				service.DefaultPrice = 10
+				return service
+			}),
+			fx.Provide(fx.Annotate(func(service *PriceService) Drinks {
+				assert.Equal(t, 10, service.DefaultPrice)
+				return &Coffee{Type: "coffee", Name: "Americano", Price: service.DefaultPrice}
+			}, fx.ResultTags(`group:"drinks"`))),
+			fx.Provide(fx.Annotated{Group: "drinks", Target: func() Drinks {
+				return &Coffee{Type: "coffee", Name: "Cold Brew", Price: 4}
+			}}),
+			fx.Invoke(fx.Annotate(func(drinks []Drinks) {
+				assert.Len(t, drinks, 2)
+			}, fx.ParamTags(`group:"drinks"`))),
+		)
+		defer app.RequireStart().RequireStop()
+	})
 }
 
 func TestDecorateFailure(t *testing.T) {


### PR DESCRIPTION
There is a bug that only manifests when decorating objects in Fx where transient dependency types are not properly decorated. For example, if type A depends on type B, and type B depends on type C which has a decorator, it fails to recognize that.

This only occurs when all constructors and the decorators for all these types are provided at the "root" level fx.App.

This happens because fx injects a fake "root" Scope between the actual root Container (which is where constructors are provided to by default).

Fixed by making fx stop create this fake root Scope and use the dig.Container directly.

Fixes #940.