### PR TITLE
Upgrade go version to 1.19 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/fx
 
-go 1.17
+go 1.19
 
 require (
 	github.com/benbjohnson/clock v1.3.0


### PR DESCRIPTION
I upgraded Go version to 1.19 in go.mod.
I executed `go mod tidy -go=1.19`.