### PR TITLE
Allow fx.Module-specific custom loggers

### DIFF
--- a/app.go
+++ b/app.go
@@ -193,9 +193,10 @@ type withLoggerOption struct {
 
 func (l withLoggerOption) apply(m *module) {
 	if m.parent != nil {
-		// loggers shouldn't differ based on Module.
-		m.app.err = fmt.Errorf("fx.WithLogger Option should be passed to top-level App, " +
-			"not to fx.Module")
+		m.logConstructor = &provide{
+			Target: l.constructor,
+			Stack:  l.Stack,
+		}
 	} else {
 		m.app.logConstructor = &provide{
 			Target: l.constructor,
@@ -523,6 +524,10 @@ func New(opts ...Option) *App {
 			bufferLogger.Connect(fallbackLogger)
 			return app
 		}
+	}
+
+	for _, m := range app.modules {
+		m.constructAllCustomLoggers()
 	}
 
 	// This error might have come from the provide loop above. We've

--- a/module.go
+++ b/module.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/dig"
 	"go.uber.org/fx/fxevent"
 	"go.uber.org/fx/internal/fxreflect"
+	"go.uber.org/multierr"
 )
 
 // A container represents a set of constructors to provide
@@ -79,14 +80,16 @@ func (o moduleOption) apply(mod *module) {
 }
 
 type module struct {
-	parent     *module
-	name       string
-	scope      scope
-	provides   []provide
-	invokes    []invoke
-	decorators []decorator
-	modules    []*module
-	app        *App
+	parent         *module
+	name           string
+	scope          scope
+	provides       []provide
+	invokes        []invoke
+	decorators     []decorator
+	modules        []*module
+	app            *App
+	log            fxevent.Logger
+	logConstructor *provide
 }
 
 // scope is a private wrapper interface for dig.Container and dig.Scope.
@@ -110,6 +113,15 @@ func (m *module) build(app *App, root *dig.Container) {
 	} else {
 		parentScope := m.parent.scope
 		m.scope = parentScope.Scope(m.name)
+	}
+
+	m.log = app.log
+	if m.logConstructor != nil {
+		// Since user supplied a custom logger, use a buffered logger
+		// to hold all messages until user supplied logger is
+		// instantiated. Then we flush those messages after fully
+		// constructing the custom logger.
+		m.log = new(logBuffer)
 	}
 
 	for _, mod := range m.modules {
@@ -158,7 +170,50 @@ func (m *module) provide(p provide) {
 			Err:             m.app.err,
 		}
 	}
-	m.app.log.LogEvent(ev)
+	m.log.LogEvent(ev)
+}
+
+func (m *module) constructAllCustomLoggers() {
+	if m.logConstructor != nil {
+		buffer, ok := m.log.(*logBuffer)
+		if ok {
+			// default to app logger if custom logger constructor fails
+			if err := m.constructCustomLogger(buffer); err != nil {
+				m.app.err = multierr.Append(m.app.err, err)
+				m.log = m.app.log
+				buffer.Connect(m.log)
+			}
+		}
+	}
+
+	for _, mod := range m.modules {
+		mod.constructAllCustomLoggers()
+	}
+}
+
+// Mirroring the behavior of app.constructCustomLogger
+func (m *module) constructCustomLogger(buffer *logBuffer) (err error) {
+	p := m.logConstructor
+	fname := fxreflect.FuncName(p.Target)
+	defer func() {
+		m.log.LogEvent(&fxevent.LoggerInitialized{
+			Err:             err,
+			ConstructorName: fname,
+		})
+	}()
+
+	if err := m.scope.Provide(p.Target); err != nil {
+		return fmt.Errorf("fx.WithLogger(%v) from:\n%+vFailed: %v",
+			fname, p.Stack, err)
+	}
+
+	// TODO: Use dig.FillProvideInfo to inspect the provided constructor
+	// and fail the application if its signature didn't match.
+
+	return m.scope.Invoke(func(log fxevent.Logger) {
+		m.log = log
+		buffer.Connect(log)
+	})
 }
 
 func (m *module) executeInvokes() error {
@@ -179,12 +234,12 @@ func (m *module) executeInvokes() error {
 
 func (m *module) executeInvoke(i invoke) (err error) {
 	fnName := fxreflect.FuncName(i.Target)
-	m.app.log.LogEvent(&fxevent.Invoking{
+	m.log.LogEvent(&fxevent.Invoking{
 		FunctionName: fnName,
 		ModuleName:   m.name,
 	})
 	err = runInvoke(m.scope, i)
-	m.app.log.LogEvent(&fxevent.Invoked{
+	m.log.LogEvent(&fxevent.Invoked{
 		FunctionName: fnName,
 		ModuleName:   m.name,
 		Err:          err,
@@ -203,14 +258,14 @@ func (m *module) decorate() (err error) {
 		}
 
 		if decorator.IsReplace {
-			m.app.log.LogEvent(&fxevent.Replaced{
+			m.log.LogEvent(&fxevent.Replaced{
 				ModuleName:      m.name,
 				OutputTypeNames: outputNames,
 				Err:             err,
 			})
 		} else {
 
-			m.app.log.LogEvent(&fxevent.Decorated{
+			m.log.LogEvent(&fxevent.Decorated{
 				DecoratorName:   fxreflect.FuncName(decorator.Target),
 				ModuleName:      m.name,
 				OutputTypeNames: outputNames,

--- a/module_test.go
+++ b/module_test.go
@@ -369,7 +369,7 @@ func TestModuleSuccess(t *testing.T) {
 		require.NoError(t, app.Err())
 
 		assert.Equal(t, []string{"Started", "Stopped"}, appSpy.EventTypes())
-		assert.Equal(t, 1, len(moduleSpy.EventTypes())
+		assert.Empty(t, moduleSpy.EventTypes())
 	})
 
 	t.Run("module uses parent module's logger to log events", func(t *testing.T) {
@@ -430,7 +430,7 @@ func TestModuleSuccess(t *testing.T) {
 		require.NoError(t, app.Err())
 
 		assert.Equal(t, []string{"Started", "Stopped"}, appSpy.EventTypes())
-		assert.Equal(t, []string{}, childSpy.EventTypes())
+		assert.Empty(t, childSpy.EventTypes())
 	})
 }
 

--- a/module_test.go
+++ b/module_test.go
@@ -369,7 +369,7 @@ func TestModuleSuccess(t *testing.T) {
 		require.NoError(t, app.Err())
 
 		assert.Equal(t, []string{"Started", "Stopped"}, appSpy.EventTypes())
-		assert.Equal(t, []string{}, moduleSpy.EventTypes())
+		assert.Equal(t, 1, len(moduleSpy.EventTypes())
 	})
 
 	t.Run("module uses parent module's logger to log events", func(t *testing.T) {

--- a/module_test.go
+++ b/module_test.go
@@ -362,11 +362,14 @@ func TestModuleSuccess(t *testing.T) {
 		}, appSpy.EventTypes())
 
 		appSpy.Reset()
+		moduleSpy.Reset()
+
 		app.RequireStart().RequireStop()
 
 		require.NoError(t, app.Err())
 
 		assert.Equal(t, []string{"Started", "Stopped"}, appSpy.EventTypes())
+		assert.Equal(t, []string{}, moduleSpy.EventTypes())
 	})
 
 	t.Run("module uses parent module's logger to log events", func(t *testing.T) {
@@ -420,11 +423,14 @@ func TestModuleSuccess(t *testing.T) {
 		}, appSpy.EventTypes(), "events from modules do not appear in app logger")
 
 		appSpy.Reset()
+		childSpy.Reset()
+
 		app.RequireStart().RequireStop()
 
 		require.NoError(t, app.Err())
 
 		assert.Equal(t, []string{"Started", "Stopped"}, appSpy.EventTypes())
+		assert.Equal(t, []string{}, childSpy.EventTypes())
 	})
 }
 


### PR DESCRIPTION
Currently passing fx.WithLogger option to fx.Module does not work because fx currently does not support specifying module-level custom loggers.

Now fx.WithLogger can be passed to fx.Modules for specifying custom loggers for fx.Modules. Also added some test cases to test fx.Module-specific loggers.

Fixes #894