### PR TITLE
Add support for various Hook-convertible functions

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,11 @@ import (
 	"go.uber.org/fx/internal/lifecycle"
 )
 
+// A HookFunc is a function that can be used as a [Hook].
+type HookFunc interface {
+	~func() | ~func() error | ~func(context.Context) | ~func(context.Context) error
+}
+
 // Lifecycle allows constructors to register callbacks that are executed on
 // application start and stop. See the documentation for App for details on Fx
 // applications' initialization, startup, and shutdown logic.
@@ -40,14 +45,104 @@ type Lifecycle interface {
 type Hook struct {
 	OnStart func(context.Context) error
 	OnStop  func(context.Context) error
+
+	onStartName string
+	onStopName  string
 }
 
-type lifecycleWrapper struct{ *lifecycle.Lifecycle }
+// StartHook returns a new Hook with start as its [Hook.OnStart] function,
+// wrapping its signature as needed. For example, given the following function:
+//
+//	func myhook() {
+//	  fmt.Println("hook called")
+//	}
+//
+// then calling:
+//
+//	lifecycle.Append(StartHook(myfunc))
+//
+// is functionally equivalent to calling:
+//
+//	lifecycle.Append(fx.Hook{
+//	  OnStart: func(context.Context) error {
+//	    myfunc()
+//	    return nil
+//	  },
+//	})
+//
+// The same is true for all functions that satisfy the HookFunc constraint.
+// Note that any context.Context parameter or error return will be propagated
+// as expected. If propagation is not intended, users should instead provide a
+// closure that discards the undesired value(s), or construct a Hook directly.
+func StartHook[T HookFunc](start T) Hook {
+	onstart, startname := lifecycle.Wrap(start)
+
+	return Hook{
+		OnStart:     onstart,
+		onStartName: startname,
+	}
+}
+
+// StopHook returns a new Hook with stop as its [Hook.OnStop] function,
+// wrapping its signature as needed. For example, given the following function:
+//
+//	func myhook() {
+//	  fmt.Println("hook called")
+//	}
+//
+// then calling:
+//
+//	lifecycle.Append(StopHook(myfunc))
+//
+// is functionally equivalent to calling:
+//
+//	lifecycle.Append(fx.Hook{
+//	  OnStop: func(context.Context) error {
+//	    myfunc()
+//	    return nil
+//	  },
+//	})
+//
+// The same is true for all functions that satisfy the HookFunc constraint.
+// Note that any context.Context parameter or error return will be propagated
+// as expected. If propagation is not intended, users should instead provide a
+// closure that discards the undesired value(s), or construct a Hook directly.
+func StopHook[T HookFunc](stop T) Hook {
+	onstop, stopname := lifecycle.Wrap(stop)
+
+	return Hook{
+		OnStop:     onstop,
+		onStopName: stopname,
+	}
+}
+
+// StartStopHook returns a new Hook with start as its [Hook.OnStart] function
+// and stop as its [Hook.OnStop] function, independently wrapping the signature
+// of each as needed.
+func StartStopHook[T1 HookFunc, T2 HookFunc](start T1, stop T2) Hook {
+	var (
+		onstart, startname = lifecycle.Wrap(start)
+		onstop, stopname   = lifecycle.Wrap(stop)
+	)
+
+	return Hook{
+		OnStart:     onstart,
+		OnStop:      onstop,
+		onStartName: startname,
+		onStopName:  stopname,
+	}
+}
+
+type lifecycleWrapper struct {
+	*lifecycle.Lifecycle
+}
 
 func (l *lifecycleWrapper) Append(h Hook) {
 	l.Lifecycle.Append(lifecycle.Hook{
-		OnStart: h.OnStart,
-		OnStop:  h.OnStop,
+		OnStart:     h.OnStart,
+		OnStop:      h.OnStop,
+		OnStartName: h.onStartName,
+		OnStopName:  h.onStopName,
 	})
 }
 


### PR DESCRIPTION
Adds new `Hook`-based helper functions:

- `StartHook`
- `StopHook`
- `StartStopHook`

and enables those function to accept any function of the form `func([context.Context] [error]` (see the `HookFunc` constraint), for example:

- `func()`
- `func() error`
- `func(context.Context)`
- `func(context.Context) error`

So, rather than users needing to do things like:

```go
func start() error {
  // ...
}

func stop(context.Context) {
  // ...
}

lifecycle.Append(fx.Hook{
  OnStart: func(context.Context) error {
    return start()
  },
  OnStop: func(ctx context.Context) error {
    stop(ctx)
    return nil
  },
})
```

which is an increasingly common pattern, users can now do:

```go
lifecycle.Append(fx.StartStopHook(start, stop))
```

or

```go
lifecycle.Append(fx.StartHook(start))
lifecycle.Append(fx.StopHook(stop))
```

and the provided functions will be converted to `func(context.Context) error` under the hood.