### PR TITLE
Add support for context- and error-less annotated hook funcs

### DIFF
--- a/error_example_test.go
+++ b/error_example_test.go
@@ -39,7 +39,7 @@ func ExampleError() {
 			return fx.Error(errors.New("$PORT is not set"))
 		}
 		return fx.Provide(&http.Server{
-			Addr: fmt.Sprintf(":%s", port),
+			Addr: fmt.Sprintf("127.0.0.1:%s", port),
 		})
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -122,7 +122,7 @@ func NewMux(lc fx.Lifecycle, logger *log.Logger) *http.ServeMux {
 	// until all handlers are registered.
 	mux := http.NewServeMux()
 	server := &http.Server{
-		Addr:    ":8080",
+		Addr:    "127.0.0.1:8080",
 		Handler: mux,
 	}
 	// If NewMux is called, we know that another function is using the mux. In

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.1
+	go.uber.org/atomic v1.6.0
 	go.uber.org/dig v1.15.0
 	go.uber.org/goleak v1.1.11
 	go.uber.org/multierr v1.5.0
@@ -15,6 +16,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Similar to #952, this adds support for any `HookFunc`-compatible funcs as part of `fx.OnStart`/`fx.OnStop` annotations.

~Unrelated change: also changes bind addresses for tests to be localhost.~ Was done in #960 