### PR TITLE
Consolidate app and module's custom logger construction logic

### DIFF
--- a/module.go
+++ b/module.go
@@ -187,6 +187,8 @@ func (m *module) constructAllCustomLoggers() {
 			}
 		}
 		m.fallbackLogger = nil
+	} else if m.parent != nil {
+		m.log = m.parent.log
 	}
 
 	for _, mod := range m.modules {

--- a/module_test.go
+++ b/module_test.go
@@ -23,6 +23,7 @@ package fx_test
 import (
 	"bytes"
 	"errors"
+	"log"
 	"testing"
 	"time"
 
@@ -590,6 +591,10 @@ func TestModuleFailures(t *testing.T) {
 			{
 				desc: "StopTimeout Option",
 				opt:  fx.StopTimeout(time.Second),
+			},
+			{
+				desc: "Logger Option",
+				opt:  fx.Logger(log.New(&bytes.Buffer{}, "", 0)),
 			},
 		}
 


### PR DESCRIPTION
- removed app.log and app's custom logger construction logic
- updated references to app.log to use app.root.log
- update module's fallback logger for custom log construction failure

Jira: GO-1690