### PR TITLE
make: Cover submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,11 @@ test:
 
 .PHONY: cover
 cover:
-	go test -race -coverprofile=cover.out -coverpkg=./... ./...
-	go tool cover -html=cover.out -o cover.html
+	@$(foreach dir,$(MODULES), \
+		(cd $(dir) && \
+		echo "[cover] $(dir)" && \
+		go test -race -coverprofile=cover.out -coverpkg=./... ./... && \
+		go tool cover -html=cover.out -o cover.html) &&) true
 
 $(GOLINT): tools/go.mod
 	cd tools && go install golang.org/x/lint/golint


### PR DESCRIPTION
In CI, we ccurrently only run `make cover`, not `make test`,
which means we don't run tests for tools/ in CI.

This resolves that by running coverage for all submodules.
