### PR TITLE
Remove 1.17 from test matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        go: ["1.17.x", "1.18.x", "1.19.x"]
+        go: ["1.18.x", "1.19.x"]
         include:
         - go: 1.19.x
           os: "ubuntu-latest"


### PR DESCRIPTION
We only support the latest two versions of go versions. Dropping the test matrix for 1.17.