### PR TITLE
docs: Add Intro and Parameter Objects

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -62,6 +62,12 @@ module.exports = {
         ],
       },
       'intro.md',
+      {
+        title: 'Features',
+        children: [
+          'parameter-objects.md',
+        ],
+      },
     ]
   },
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -38,6 +38,10 @@ module.exports = {
     lastUpdated: true,
     nav: [
       {
+        text: 'Guide',
+        link: '/intro',
+      },
+      {
         text: 'API Reference',
         link: 'https://pkg.go.dev/go.uber.org/fx'
       }
@@ -57,6 +61,7 @@ module.exports = {
           'get-started/conclusion.md',
         ],
       },
+      'intro.md',
     ]
   },
 

--- a/docs/ex/parameter-objects/define.go
+++ b/docs/ex/parameter-objects/define.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package paramobject
+
+import (
+	"net/http"
+
+	"go.uber.org/fx"
+)
+
+// Client sends requests to a server.
+type Client struct {
+	url  string
+	http *http.Client
+}
+
+// ClientConfig defines the configuration for the client.
+type ClientConfig struct {
+	URL string
+}
+
+// ClientParams defines the parameters necessary to build a client.
+// region empty
+// region fxin
+// region fields
+type ClientParams struct {
+	// endregion empty
+	fx.In
+	// endregion fxin
+
+	Config     ClientConfig
+	HTTPClient *http.Client
+	// region empty
+}
+
+// endregion fields
+// endregion empty
+
+// NewClient builds a new client.
+// region takeparam
+// region consume
+func NewClient(p ClientParams) (*Client, error) {
+	// endregion takeparam
+	return &Client{
+		url:  p.Config.URL,
+		http: p.HTTPClient,
+		// ...
+	}, nil
+	// endregion consume
+}

--- a/docs/ex/parameter-objects/define_test.go
+++ b/docs/ex/parameter-objects/define_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package paramobject
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestClientParams(t *testing.T) {
+	client := new(http.Client)
+	var got *Client
+	app := fxtest.New(t,
+		fx.Supply(
+			ClientConfig{URL: "http://example.com"},
+			client,
+		),
+		fx.Provide(NewClient),
+		fx.Populate(&got),
+	)
+	app.RequireStart().RequireStop()
+
+	assert.Equal(t, "http://example.com", got.url)
+
+	// == instead of assert.Equal to match pointers.
+	assert.True(t, client == got.http, "HTTP client did not match")
+}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,12 @@
+# Introduction
+
+Fx is a dependency injection system for Go.
+With Fx you can:
+
+- reduce boilerplate in setting up your application
+- eliminate global state in your application
+- add new components and have them instantly accessible across the application
+- build general purpose shareable modules that just work
+
+If this is your first time with Fx,
+check out our [getting started tutorial](get-started/).

--- a/docs/parameter-objects.md
+++ b/docs/parameter-objects.md
@@ -1,0 +1,65 @@
+# Parameter Objects
+
+A parameter object is an objects with the sole purpose of carrying parameters
+for a specific function or method.
+
+The object is typically defined exclusively for that function,
+and is not shared with other functions.
+That is, a parameter object is not a general purpose object like "user"
+but purpose-built, like "parameters for the `GetUser` function".
+
+In Fx, parameter objects consist of exported fields exclusively,
+and are always tagged with `fx.In`.
+
+## Using parameter objects
+
+To use parameter objects in Fx, take the following steps:
+
+1. Define a new struct type named after your constructor.
+   If the constructor is named `NewClient`, name the struct `ClientParams`.
+   If the constructor is named `New`, name the struct `Params`.
+   This naming isn't strictly necessary, but it's a good convention to follow.
+
+   ```go mdox-exec='region ex/parameter-objects/define.go empty'
+   type ClientParams struct {
+   }
+   ```
+
+2. Embed `fx.In` into this struct.
+
+   ```go mdox-exec='region ex/parameter-objects/define.go fxin'
+   type ClientParams struct {
+     fx.In
+   ```
+
+3. Add this new type as a parameter to your constructor *by value*.
+
+   ```go mdox-exec='region ex/parameter-objects/define.go takeparam'
+   func NewClient(p ClientParams) (*Client, error) {
+   ```
+
+4. Add dependencies of your constructor as **exported** fields on this struct.
+
+   ```go mdox-exec='region ex/parameter-objects/define.go fields'
+   type ClientParams struct {
+   	fx.In
+
+   	Config     ClientConfig
+   	HTTPClient *http.Client
+   }
+   ```
+
+5. Consume these fields in your constructor.
+
+   ```go mdox-exec='region ex/parameter-objects/define.go consume'
+   func NewClient(p ClientParams) (*Client, error) {
+     return &Client{
+       url:  p.Config.URL,
+       http: p.HTTPClient,
+       // ...
+     }, nil
+   ```
+
+<!--
+TODO: cover various tags supported on a parameter object.
+-->


### PR DESCRIPTION
This builds upon the website added in #962
with two new pages:

- introduction: this is pretty bare
- parameter objects: this explains parameter objects to users
  with the goal of helping them build understanding,
  and includes a small how-to section on how to use them.
  
The parameter objects page is nested inside a "features" section.
We can add other top level features here.

---

Screenshot: 
<img width="896" alt="image" src="https://user-images.githubusercontent.com/41730/195267634-28f39644-b23c-45e2-bf8e-dba7af2711ff.png">

