### PR TITLE
docs: Document result objects and how to extend

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -66,6 +66,7 @@ module.exports = {
         title: 'Features',
         children: [
           'parameter-objects.md',
+          'result-objects.md',
         ],
       },
     ]

--- a/docs/ex/parameter-objects/extend.go
+++ b/docs/ex/parameter-objects/extend.go
@@ -27,44 +27,33 @@ import (
 	"go.uber.org/zap"
 )
 
-// Client sends requests to a server.
-type Client struct {
-	url  string
-	http *http.Client
-	log  *zap.Logger
-}
-
-// ClientConfig defines the configuration for the client.
-type ClientConfig struct {
-	URL string
-}
-
-// ClientParams defines the parameters necessary to build a client.
-// region empty
-// region fxin
-// region fields
-type ClientParams struct {
-	// endregion empty
+// Params defines the paramters of new.
+// region start
+// region full
+type Params struct {
 	fx.In
-	// endregion fxin
 
 	Config     ClientConfig
 	HTTPClient *http.Client
-	// region empty
+	// endregion start
+	Logger *zap.Logger `optional:"true"`
+	// region start
 }
 
-// endregion fields
-// endregion empty
+// endregion start
+// endregion full
 
-// NewClient builds a new client.
-// region takeparam
+// New builds a new Client.
+// region start
 // region consume
-func NewClient(p ClientParams) (*Client, error) {
-	// endregion takeparam
-	return &Client{
-		url:  p.Config.URL,
-		http: p.HTTPClient,
-		// ...
-	}, nil
+func New(p Params) (*Client, error) {
+	// endregion start
+	log := p.Logger
+	if log == nil {
+		log = zap.NewNop()
+	}
+	// ...
 	// endregion consume
+
+	return &Client{log: log}, nil
 }

--- a/docs/ex/result-objects/define.go
+++ b/docs/ex/result-objects/define.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package resultobject
+
+import "go.uber.org/fx"
+
+// Client is a client to make requests.
+type Client struct{}
+
+// ClientResult holds the result of NewClient.
+// region empty
+// region fxout
+// region fields
+type ClientResult struct {
+	// endregion empty
+	fx.Out
+	// endregion fxout
+
+	Client *Client
+	// region empty
+}
+
+// endregion empty
+// endregion fields
+
+// NewClient builds a new Client.
+// region returnresult
+// region produce
+func NewClient() (ClientResult, error) {
+	// endregion returnresult
+	client := &Client{
+		// ...
+	}
+	return ClientResult{Client: client}, nil
+}
+
+// endregion produce

--- a/docs/ex/result-objects/define_test.go
+++ b/docs/ex/result-objects/define_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package resultobject
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestClientResult(t *testing.T) {
+	var got *Client
+	app := fxtest.New(t,
+		fx.Provide(NewClient),
+		fx.Populate(&got),
+	)
+	app.RequireStart().RequireStop()
+
+	assert.NotNil(t, got)
+}

--- a/docs/ex/result-objects/extend.go
+++ b/docs/ex/result-objects/extend.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package resultobject
+
+import "go.uber.org/fx"
+
+// Inspector inspects client state.
+type Inspector struct{}
+
+// Result is the result of this module.
+// region full
+// region start
+type Result struct {
+	fx.Out
+
+	Client *Client
+	// endregion start
+	Inspector *Inspector
+	// region start
+}
+
+// endregion start
+// endregion full
+
+// New builds a result.
+// region start
+func New() (Result, error) {
+	client := &Client{
+		// ...
+	}
+	// region produce
+	return Result{
+		Client: client,
+		// endregion start
+		Inspector: &Inspector{
+			// ...
+		},
+		// region start
+	}, nil
+	// endregion start
+	// endregion produce
+}

--- a/docs/ex/result-objects/extend_test.go
+++ b/docs/ex/result-objects/extend_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package resultobject
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestExtendResult(t *testing.T) {
+	var (
+		client    *Client
+		inspector *Inspector
+	)
+	app := fxtest.New(t,
+		fx.Provide(New),
+		fx.Populate(&client, &inspector),
+	)
+	app.RequireStart().RequireStop()
+
+	assert.NotNil(t, client)
+	assert.NotNil(t, inspector)
+}

--- a/docs/parameter-objects.md
+++ b/docs/parameter-objects.md
@@ -8,14 +8,20 @@ and is not shared with other functions.
 That is, a parameter object is not a general purpose object like "user"
 but purpose-built, like "parameters for the `GetUser` function".
 
-In Fx, parameter objects consist of exported fields exclusively,
+In Fx, parameter objects contain exported fields exclusively,
 and are always tagged with `fx.In`.
+
+**Related**
+
+- [Result objects](result-objects.md) are the result analog of
+  parameter objects.
 
 ## Using parameter objects
 
 To use parameter objects in Fx, take the following steps:
 
-1. Define a new struct type named after your constructor.
+1. Define a new struct type named after your constructor
+   with a `Params` suffix.
    If the constructor is named `NewClient`, name the struct `ClientParams`.
    If the constructor is named `New`, name the struct `Params`.
    This naming isn't strictly necessary, but it's a good convention to follow.
@@ -62,4 +68,5 @@ To use parameter objects in Fx, take the following steps:
 
 <!--
 TODO: cover various tags supported on a parameter object.
+TODO: cover adding new parameters
 -->

--- a/docs/parameter-objects.md
+++ b/docs/parameter-objects.md
@@ -68,5 +68,50 @@ To use parameter objects in Fx, take the following steps:
 
 <!--
 TODO: cover various tags supported on a parameter object.
-TODO: cover adding new parameters
 -->
+
+## Adding new parameters
+
+You can add new parameters for a constructor
+by adding new fields to a parameter object.
+For this to be backwards compatible,
+the new fields must be **optional**.
+
+1. Take an existing parameter object.
+
+   ```go mdox-exec='region ex/parameter-objects/extend.go start'
+   type Params struct {
+     fx.In
+
+     Config     ClientConfig
+     HTTPClient *http.Client
+   }
+
+   func New(p Params) (*Client, error) {
+   ```
+
+2. Add a new field to it for your new dependency
+   and **mark it optional** to keep this change backwards compatible.
+
+   ```go mdox-exec='region ex/parameter-objects/extend.go full'
+   type Params struct {
+   	fx.In
+
+   	Config     ClientConfig
+   	HTTPClient *http.Client
+   	Logger     *zap.Logger `optional:"true"`
+   }
+   ```
+
+3. In your constructor, consume this field.
+   Be sure to handle the case when this field is absent --
+   it will take the zero value of its type in that case.
+
+   ```go mdox-exec='region ex/parameter-objects/extend.go consume'
+   func New(p Params) (*Client, error) {
+     log := p.Logger
+     if log == nil {
+       log = zap.NewNop()
+     }
+     // ...
+   ```

--- a/docs/result-objects.md
+++ b/docs/result-objects.md
@@ -67,5 +67,49 @@ To use result objects in Fx, take the following steps:
 
 <!--
 TODO: cover various tags supported on a result object.
-TODO: cover adding new results
 -->
+
+## Adding new results
+
+You can add new values to an existing result object
+in a completely backwards compatible manner.
+
+1. Take an existing result object.
+
+   ```go mdox-exec='region ex/result-objects/extend.go start'
+   type Result struct {
+     fx.Out
+
+     Client *Client
+   }
+
+   func New() (Result, error) {
+     client := &Client{
+       // ...
+     }
+     return Result{
+       Client: client,
+     }, nil
+   ```
+
+2. Add a new field to it for your new result.
+
+   ```go mdox-exec='region ex/result-objects/extend.go full'
+   type Result struct {
+   	fx.Out
+
+   	Client    *Client
+   	Inspector *Inspector
+   }
+   ```
+
+3. In your constructor, set this field.
+
+   ```go mdox-exec='region ex/result-objects/extend.go produce'
+   	return Result{
+   		Client:    client,
+   		Inspector: &Inspector{
+   			// ...
+   		},
+   	}, nil
+   ```

--- a/docs/result-objects.md
+++ b/docs/result-objects.md
@@ -1,0 +1,71 @@
+# Result Objects
+
+A result object is an object with the sole purpose of carrying results
+for a specific function or method.
+
+As with [parameter objects](parameter-objects.md),
+the object is defined exclusively for a single function,
+and not shared with other functions.
+
+In Fx, result objects contain exported fields exclusively,
+and are always tagged with `fx.Out`.
+
+**Related**
+
+- [Parameter objects](parameter-objects.md) are the parameter analog of result
+  objects.
+
+## Using result objects
+
+To use result objects in Fx, take the following steps:
+
+1. Define a new struct type named after your constructor
+   with a `Result` suffix.
+   If the constructor is named `NewClient`, name the struct `ClientResult`.
+   If the constructor is named `New`, name the struct `Result`.
+   This naming isn't strictly necessary, but it's a good convention to follow.
+
+   ```go mdox-exec='region ex/result-objects/define.go empty'
+   type ClientResult struct {
+   }
+   ```
+
+2. Embed `fx.Out` into this struct.
+
+   ```go mdox-exec='region ex/result-objects/define.go fxout'
+   type ClientResult struct {
+     fx.Out
+   ```
+
+3. Use this new type as the return value of your constructor *by value*.
+
+   ```go mdox-exec='region ex/result-objects/define.go returnresult'
+   func NewClient() (ClientResult, error) {
+   ```
+
+4. Add values produced by your constructor as **exported** fields on this struct.
+
+   ```go mdox-exec='region ex/result-objects/define.go fields'
+   type ClientResult struct {
+   	fx.Out
+
+   	Client *Client
+   }
+   ```
+
+5. Set these fields and return an instance of this struct from your
+   constructor.
+
+   ```go mdox-exec='region ex/result-objects/define.go produce'
+   func NewClient() (ClientResult, error) {
+   	client := &Client{
+   		// ...
+   	}
+   	return ClientResult{Client: client}, nil
+   }
+   ```
+
+<!--
+TODO: cover various tags supported on a result object.
+TODO: cover adding new results
+-->


### PR DESCRIPTION
Add documentation on result objects,
and how to extend both, parameter objects and result objects.