### PR TITLE
docs: Add release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+---
+sidebarDepth: 0
+search: false
+---
+
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -7,22 +13,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 - No changes yet.
 
-## [1.18.2] - 2022-09-28
+## [1.18.2](https://github.com/uber-go/fx/compare/v1.18.1...v1.18.2) - 2022-09-28
+
 ### Added
 - Clarify ordering of `Invoke`s in `Module`s.
 
 ### Fixed
 - Fix `Decorate` not being applied to transitive dependencies at root `App` level.
 
-  [1.18.2]: https://github.com/uber-go/fx/compare/v1.18.1...v1.18.2
+## [1.18.1](https://github.com/uber-go/fx/compare/v1.18.0...v1.18.1) - 2022-08-08
 
-## [1.18.1] - 2022-08-08
 ### Fixed
 - Fix a nil panic when `nil` is passed to `OnStart` and `OnStop` lifecycle methods.
 
-  [1.18.1]: https://github.com/uber-go/fx/compare/v1.18.0...v1.18.1
+## [1.18.0](https://github.com/uber-go/fx/compare/v1.17.1...v1.18.0) - 2022-08-05
 
-## [1.18.0] - 2022-08-05
 ### Added
 - Soft value groups that lets you specify value groups as best-effort dependencies.
 - `fx.OnStart` and `fx.OnStop` annotations which lets you annotate dependencies to provide
@@ -43,15 +48,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 - `fx.Extract` in favor of `fx.Populate`.
 
-  [1.18.0]: https://github.com/uber-go/fx/compare/v1.17.1...v1.18.0
+## [1.17.1](https://github.com/uber-go/fx/compare/v1.17.0...v1.17.1) - 2022-03-23
 
-## [1.17.1] - 2022-03-23
 ### Added
 - Logging for provide/invoke/decorate now includes the associated `fx.Module` name.
 
-[1.17.1]: https://github.com/uber-go/fx/compare/v1.17.0...v1.17.1
+## [1.17.0](https://github.com/uber-go/fx/compare/v1.16.0...v1.17.0) - 2022-02-28
 
-## [1.17.0] - 2022-02-28
 ### Added
 - Add `fx.Module` which scopes any modifications made to the dependency graph.
 - Add `fx.Decorate` and `fx.Replace` that lets you modify a dependency graph with decorators.
@@ -62,9 +65,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `fx.Annotate`: Upon failure to Provide, the error contains the actual location
   of the provided constructor.
 
-[1.17.0]: https://github.com/uber-go/fx/compare/v1.16.0...v1.17.0
+## [1.16.0](https://github.com/uber-go/fx/compare/v1.15.0...v1.16.0) - 2021-12-02
 
-## [1.16.0] - 2021-12-02
 ### Added
 - Add the ability to provide a function as multiple interfaces at once using `fx.As`.
 
@@ -75,9 +77,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix an issue where OnStop hooks weren't getting called on SIGINT on Windows.
 - Fix a data race between app.Done() and shutdown.
 
-[1.16.0]: https://github.com/uber-go/fx/compare/v1.15.0...v1.16.0
+## [1.15.0](https://github.com/uber-go/fx/compare/v1.14.2...v1.15.0) - 2021-11-08
 
-## [1.15.0] - 2021-11-08
 ### Added
 - Add `fx.Annotate` to allow users to provide parameter and result tags easily without
   having to create `fx.In` or `fx.Out` structs.
@@ -89,23 +90,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `fxevent.Started` or `fxevent.Stopped` not being logged when start or
   stop times out.
 
-[1.15.0]: https://github.com/uber-go/fx/compare/v1.14.2...v1.15.0
+## [1.14.2](https://github.com/uber-go/fx/compare/v1.14.1...v1.14.2) - 2021-08-16
 
-## [1.14.2] - 2021-08-16
 ### Changed
--  For `fxevent` console implementation: no longer log non-error case for `fxevent.Invoke`
-   event, while for zap implementation, start logging `fx.Invoking` case without stack.
+- For `fxevent` console implementation: no longer log non-error case for `fxevent.Invoke`
+  event, while for zap implementation, start logging `fx.Invoking` case without stack.
 
-[1.14.2]: https://github.com/uber-go/fx/compare/v1.14.1...v1.14.2
+## [1.14.1](https://github.com/uber-go/fx/compare/v1.14.0...v1.14.1) - 2021-08-16
 
-## [1.14.1] - 2021-08-16
 ### Changed
 - `fxevent.Invoked` was being logged at `Error` level even upon successful `Invoke`.
-   This was changed to log at `Info` level when `Invoke` succeeded.
+  This was changed to log at `Info` level when `Invoke` succeeded.
 
-[1.14.1]: https://github.com/uber-go/fx/compare/v1.14.0...v1.14.1
+## [1.14.0](https://github.com/uber-go/fx/compare/v1.13.1...v1.14.0) - 2021-08-12
 
-## [1.14.0] - 2021-08-12
 ### Added
 - Introduce the new `fx.WithLogger` option. Provide a constructor for
   `fxevent.Logger` objects with it to customize how Fx logs events.
@@ -120,23 +118,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `fxtest.Lifecycle` now logs to the provided `testing.TB` instead of stderr.
 - `fx.In` and `fx.Out` are now type aliases instead of structs.
 
-[1.14.0]: https://github.com/uber-go/fx/compare/v1.13.1...v1.14.0
+## [1.13.1](https://github.com/uber-go/fx/compare/v1.13.0...v1.13.1) - 2020-08-19
 
-## [1.13.1] - 2020-08-19
 ### Fixed
 - Fix minimum version constraint for dig. `fx.ValidateGraph` requires at least
   dig 1.10.
 
-[1.13.1]: https://github.com/uber-go/fx/compare/v1.13.0...v1.13.1
+## [1.13.0](https://github.com/uber-go/fx/compare/v1.12.0...v1.13.0) - 2020-06-16
 
-## [1.13.0] - 2020-06-16
 ### Added
 - Added `fx.ValidateGraph` which allows graph cycle validation and dependency correctness
- without running anything. This is useful if `fx.Invoke` has side effects, does I/O, etc.
+  without running anything. This is useful if `fx.Invoke` has side effects, does I/O, etc.
 
-[1.13.0]: https://github.com/uber-go/fx/compare/v1.12.0...v1.13.0
+## [1.12.0](https://github.com/uber-go/fx/compare/v1.11.0...v1.12.0) - 2020-04-09
 
-## [1.12.0] - 2020-04-09
 ### Added
 - Added `fx.Supply` to provide externally created values to Fx containers
   without building anonymous constructors.
@@ -144,17 +139,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Drop library dependency on development tools.
 
-[1.12.0]: https://github.com/uber-go/fx/compare/v1.11.0...v1.12.0
+## [1.11.0](https://github.com/uber-go/fx/compare/v1.10.0...v1.11.0) - 2020-04-01
 
-## [1.11.0] - 2020-04-01
 ### Added
 - Value groups can use the `flatten` option to indicate values in a slice should
   be provided individually rather than providing the slice itself. See package
   documentation for details.
 
-[1.11.0]: https://github.com/uber-go/fx/compare/v1.10.0...1.11.0
+## [1.10.0](https://github.com/uber-go/fx/compare/v1.9.0...v1.10.0) - 2019-11-20
 
-## [1.10.0] - 2019-11-20
 ### Added
 - All `fx.Option`s now include readable string representations.
 - Report stack traces when `fx.Provide` and `fx.Invoke` calls fail. This
@@ -163,24 +156,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Migrated to Go modules.
 
-[1.10.0]: https://github.com/uber-go/fx/compare/v1.9.0...v1.10.0
+## [1.9.0](https://github.com/uber-go/fx/compare/v1.8.0...v1.9.0) - 2019-01-22
 
-## [1.9.0] - 2019-01-22
 ### Added
 - Add the ability to shutdown Fx applications from inside the container. See
   the Shutdowner documentation for details.
 - Add `fx.Annotated` to allow users to provide named values without creating a
   new constructor.
 
-[1.9.0]: https://github.com/uber-go/fx/compare/v1.8.0...v1.9.0
+## [1.8.0](https://github.com/uber-go/fx/compare/v1.7.1...v1.8.0) - 2018-11-06
 
-## [1.8.0] - 2018-11-06
 ### Added
 - Provide DOT graph of dependencies in the container.
 
-[1.8.0]: https://github.com/uber-go/fx/compare/v1.7.1...v1.8.0
+## [1.7.1](https://github.com/uber-go/fx/compare/v1.7.0...v1.7.1) - 2018-09-26
 
-## [1.7.1] - 2018-09-26
 ### Fixed
 - Make `fxtest.New` ensure that the app was created successfully. Previously,
   it would return the app (similar to `fx.New`, which expects the user to verify
@@ -189,23 +179,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   startup time should improve proportional to the size of the dependency graph.
 - Fix a goroutine leak in `fxtest.Lifecycle`.
 
-[1.7.1]: https://github.com/uber-go/fx/compare/v1.7.0...v1.7.1
+## [1.7.0](https://github.com/uber-go/fx/compare/v1.6.0...v1.7.0) - 2018-08-16
 
-## [1.7.0] - 2018-08-16
 ### Added
 - Add `fx.ErrorHook` option to allow users to provide `ErrorHandler`s on invoke
   failures.
 - `VisualizeError` returns the visualization wrapped in the error if available.
 
-[1.7.0]: https://github.com/uber-go/fx/compare/v1.6.0...v1.7.0
+## [1.6.0](https://github.com/uber-go/fx/compare/v1.5.0...v1.6.0) - 2018-06-12
 
-## [1.6.0] - 2018-06-12
 ### Added
 - Add `fx.Error` option to short-circuit application startup.
 
-[1.6.0]: https://github.com/uber-go/fx/compare/v1.5.0...v1.6.0
+## [1.5.0](https://github.com/uber-go/fx/compare/v1.4.0...v1.5.0) - 2018-04-11
 
-## [1.5.0] - 2018-04-11
 ### Added
 - Add `fx.StartTimeout` and `fx.StopTimeout` to make configuring application
   start and stop timeouts easier.
@@ -214,16 +201,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Make `fxtest` respect the application's start and stop timeouts.
 
-[1.5.0]: https://github.com/uber-go/fx/compare/v1.4.0...v1.5.0
+## [1.4.0](https://github.com/uber-go/fx/compare/v1.3.0...v1.4.0) - 2017-12-07
 
-## [1.4.0] - 2017-12-07
 ### Added
 - Add `fx.Populate` to populate variables with values from the dependency
   injection container without requiring intermediate structs.
 
-[1.4.0]: https://github.com/uber-go/fx/compare/v1.3.0...v1.4.0
+## [1.3.0](https://github.com/uber-go/fx/compare/v1.2.0...v1.3.0) - 2017-11-28
 
-## [1.3.0] - 2017-11-28
 ### Changed
 - Improve readability of hook logging in addition to provide and invoke.
 
@@ -231,22 +216,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix bug which caused the OnStop for a lifecycle hook to be called even if it
   failed to start.
 
-[1.3.0]: https://github.com/uber-go/fx/compare/v1.2.0...v1.3.0
+## [1.2.0](https://github.com/uber-go/fx/compare/v1.1.0...v1.2.0) - 2017-09-06
 
-## [1.2.0] - 2017-09-06
 ### Added
 - Add `fx.NopLogger` which disables the Fx application's log output.
 
-[1.2.0]: https://github.com/uber-go/fx/compare/v1.1.0...v1.2.0
-
-## [1.1.0] - 2017-08-22
+## [1.1.0](https://github.com/uber-go/fx/compare/v1.0.0...v1.1.0) - 2017-08-22
 
 ### Changed
 - Improve readability of start up logging.
 
-[1.1.0]: https://github.com/uber-go/fx/compare/v1.0.0...v1.1.0
+## [1.0.0](https://github.com/uber-go/fx/compare/v1.0.0-rc2...v1.0.0) - 2017-07-31
 
-## [1.0.0] - 2017-07-31
 First stable release: no breaking changes will be made in the 1.x series.
 
 ### Added
@@ -259,9 +240,7 @@ First stable release: no breaking changes will be made in the 1.x series.
 ### Removed
 - **[Breaking]** Remove `fx.Timeout` and `fx.DefaultTimeout`.
 
-[1.0.0]: https://github.com/uber-go/fx/compare/v1.0.0-rc2...v1.0.0
-
-## [1.0.0-rc2] - 2017-07-21
+## [1.0.0-rc2](https://github.com/uber-go/fx/compare/v1.0.0-rc1...v1.0.0-rc2) - 2017-07-21
 
 - **[Breaking]** Lifecycle hooks now take a context.
 - Add `fx.In` and `fx.Out` which exposes optional and named types.
@@ -276,9 +255,7 @@ First stable release: no breaking changes will be made in the 1.x series.
 - Add `fxtest.App`, which redirects log output to the user's `testing.TB` and
   provides some lifecycle helpers.
 
-[1.0.0-rc2]: https://github.com/uber-go/fx/compare/v1.0.0-rc1...v1.0.0-rc2
-
-## [1.0.0-rc1] - 2017-06-20
+## [1.0.0-rc1](https://github.com/uber-go/fx/compare/v1.0.0-beta4...v1.0.0-rc1) - 2017-06-20
 
 - **[Breaking]** Providing types into `fx.App` and invoking functions are now
   options passed during application construction. This makes users'
@@ -286,9 +263,7 @@ First stable release: no breaking changes will be made in the 1.x series.
 - **[Breaking]** `TestLifecycle` is now in a separate `fxtest` subpackage.
 - Add `fx.Inject()` to pull values from the container into a struct.
 
-[1.0.0-rc1]: https://github.com/uber-go/fx/compare/v1.0.0-beta4...v1.0.0-rc1
-
-## [1.0.0-beta4] - 2017-06-12
+## [1.0.0-beta4](https://github.com/uber-go/fx/compare/v1.0.0-beta3...v1.0.0-beta4) - 2017-06-12
 
 - **[Breaking]** Monolithic framework, as released in initial betas, has been
   broken into smaller pieces as a result of recent advances in `dig` library.
@@ -305,13 +280,11 @@ First stable release: no breaking changes will be made in the 1.x series.
   (configuration, metrics, tracing) has been deprecated in favor of
   `fx.App`.
 
-[1.0.0-beta4]: https://github.com/uber-go/fx/compare/v1.0.0-beta3...v1.0.0-beta4
-
-## [1.0.0-beta3] - 2017-03-28
+## [1.0.0-beta3](https://github.com/uber-go/fx/compare/v1.0.0-beta2...v1.0.0-beta3) - 2017-03-28
 
 - **[Breaking]** Environment config provider was removed. If you were using
-  environment variables to override YAML values, see
-  [config documentation](config/README.md) for more information.
+  environment variables to override YAML values, see config documentation for
+  more information.
 - **[Breaking]** Simplify Provider interface: remove `Scope` method from the
   `config.Provider` interface, one can use either ScopedProvider and Value.Get()
   to access sub fields.
@@ -332,16 +305,14 @@ First stable release: no breaking changes will be made in the 1.x series.
 - **[Breaking]** Pass a tracer the `uhttp/uhttpclient` constructor explicitly, instead
   of using a global tracer. This will allow to use http client in parallel tests.
 
-[1.0.0-beta3]: https://github.com/uber-go/fx/compare/v1.0.0-beta2...v1.0.0-beta3
-
-## [1.0.0-beta2] - 2017-03-09
+## [1.0.0-beta2](https://github.com/uber-go/fx/compare/v1.0.0-beta1...v1.0.0-beta2) - 2017-03-09
 
 - **[Breaking]** Remove `ulog.Logger` interface and expose `*zap.Logger` directly.
 - **[Breaking]** Rename config and module from `modules.rpc` to `modules.yarpc`
 - **[Breaking]** Rename config key from `modules.http` to `modules.uhttp` to match
   the module name
 - **[Breaking]** Upgrade `zap` to `v1.0.0-rc.3` (now go.uber.org/zap, was
-    github.com/uber-go/zap)
+  github.com/uber-go/zap)
 - Remove now-unused `config.IsDevelopmentEnv()` helper to encourage better
   testing practices. Not a breaking change as nobody is using this func
   themselves according to our code search tool.
@@ -359,8 +330,6 @@ First stable release: no breaking changes will be made in the 1.x series.
 - DIG constructors now support returning a tuple with the second argument being
   an error.
 
-[1.0.0-beta2]: https://github.com/uber-go/fx/compare/v1.0.0-beta1...v1.0.0-beta2
-
 ## 1.0.0-beta1 - 2017-02-20
 
 This is the first beta release of the framework, where we invite users to start
@@ -368,4 +337,3 @@ building services on it and provide us feedback. **Warning** we are not
 promising API compatibility between beta releases and the final 1.0.0 release.
 In fact, we expect our beta user feedback to require some changes to the way
 things work. Once we reach 1.0, we will provider proper version compatibility.
-

--- a/docs/.mdox-validate.yaml
+++ b/docs/.mdox-validate.yaml
@@ -1,0 +1,8 @@
+version: 1
+timeout: 1m
+
+validators:
+  # Instead of hitting every GitHub PR/issue links manually,
+  # use the GitHub API.
+  - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)uber-go\/fx(\/pull\/|\/issues\/)'
+    type: 'githubPullsIssues'

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -75,6 +75,10 @@ module.exports = {
           'lifecycle.md',
         ],
       },
+      {
+        title: 'Release notes',
+        path: 'changelog.md',
+      },
     ]
   },
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 export PATH := $(shell pwd)/bin:$(PATH)
 
 MDOX = $(shell pwd)/../bin/mdox
-MDOX_FMT_FLAGS = --soft-wraps --links.validate
+MDOX_FMT_FLAGS = --soft-wraps --links.validate --links.validate.config-file $(shell pwd)/.mdox-validate.yaml
 MD_FILES = $(shell git ls-files '*.md')
 
 .PHONY:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md


### PR DESCRIPTION
Include release notes on our docs website
by adding a symlink of CHANGELOG.md to the docs folder.

Because this page is long and can get noisy,
it opts out of being indexed for search,
and doesn't show the list of headers in the sidebar.

Finally, this reformats the changelog with mdox.
