### PR TITLE
docs/features: Explain value groups

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -67,6 +67,7 @@ module.exports = {
         children: [
           'parameter-objects.md',
           'result-objects.md',
+          'value-groups.md',
         ],
       },
       {

--- a/docs/get-started/conclusion.md
+++ b/docs/get-started/conclusion.md
@@ -7,4 +7,4 @@ In this tutorial, we covered,
 - how to inject new dependencies and modify existing ones
 - how to use interfaces to decouple components
 - how to use named values
-- how to use value groups
+- how to use [value groups](/value-groups.md)

--- a/docs/get-started/many-handlers.md
+++ b/docs/get-started/many-handlers.md
@@ -97,9 +97,7 @@ Any other constructor in the application can also feed values
 into this value group as long as the result conforms to the `Route` interface.
 They will all be collected together and passed into our `ServeMux` constructor.
 
-<!--
-
 **Related Resources**
 
-* TODO: link to value groups documentation
--->
+* [Value groups](/value-groups.md) further explains what value groups are,
+  and how to use them.

--- a/docs/value-groups.md
+++ b/docs/value-groups.md
@@ -1,0 +1,99 @@
+# Value Groups
+
+A *value group* is a collection of values of the same type.
+Any number of constructors across an Fx application
+can feed values into a value group.
+Similarly, any number of consumers can read from a value group
+without knowing about the full list of producers.
+
+```mermaid
+flowchart TD
+    group{{"[]Route"}}
+    NewA & NewB & dots[...] & NewZ --> group
+    group --> server[NewServeMux]
+    group --> NewSiteMap
+
+    style dots fill:none,stroke:none
+```
+
+::: tip
+Fx produces the values fed into a value group in a random order.
+**Do not** make any assumptions about value group ordering.
+:::
+
+## Dependency strictness
+
+Dependencies formed by value groups can be:
+
+- strict: these are always consumed
+- soft: these are consumed only if the corresponding constructor
+  was requested elsewhere
+
+By default, value group dependencies are strict.
+
+### Strict value groups
+
+Strict value group dependencies are consumed by the value group
+regardless of whether their producers are otherwise used by the application.
+
+Suppose a constructor `NewFoo` produces two values: `A` and `B`.
+Value `A` feeds into the value group `[]A`,
+which is then consumed by function `Run`,
+and the application invokes function `Run` with `fx.Invoke`.
+
+With strict value groups,
+Fx will run `NewFoo` to populate the `[]A` group
+regardless of whether the application consumes the other result (`B`)
+directly or indirectly.
+
+```mermaid
+flowchart LR
+    subgraph NewFoo
+        A; B
+    end
+    subgraph "fx.Invoke"
+        Run
+    end
+    A --> group{{"[]A"}} --> Run
+```
+
+### Soft value groups
+
+Soft value group dependencies are consumed by the value group
+only if the constructors that produce them were called by Fx anyway --
+because the application consumes their other results directly or indirectly.
+
+Suppose we have a setup similar to the previous section,
+except that the value group is soft.
+
+```mermaid
+flowchart LR
+    subgraph NewFoo
+        A; B
+    end
+    subgraph "fx.Invoke"
+        Run
+    end
+    A -.-> group{{"[]A"}} --> Run
+```
+
+With soft value groups,
+Fx will run `NewFoo` to populate the `[]A` group
+only if `A` or `B` are consumed by another component in the application
+directly or indirectly.
+
+```mermaid
+flowchart LR
+    subgraph NewFoo
+        A; B
+    end
+    subgraph "fx.Invoke"
+        Run; Start
+    end
+    A -.-> group{{"[]A"}} --> Run
+    B --> C --> Start
+```
+
+<!--
+// TODO: when to use strict vs soft value groups
+-->


### PR DESCRIPTION
This adds documentation explaining value groups: both strict and soft.
This does not yet include examples of how to use them.

---

Rendered: https://github.com/uber-go/fx/blob/docs-value-groups/docs/value-groups.md