### PR TITLE
docs: Drop "Last Updated"

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -93,7 +93,6 @@ module.exports = {
    * Apply plugins，ref：https://v1.vuepress.vuejs.org/zh/plugin/
    */
   plugins: [
-    '@vuepress/last-updated',
     '@vuepress/plugin-back-to-top',
     '@vuepress/plugin-medium-zoom',
     'fulltext-search',


### PR DESCRIPTION
The last updated at the bottom reports when the
file was last updated.
However, because we generate and upload the site
anew each time,
this will always report the time of the latest upload.
Drop it rather than be inaccurate.
