### PR TITLE
docs/get-started: Clarify ServeMux purpose and link to annotation

### DIFF
--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -4,10 +4,12 @@ You can annotate functions and values with the `fx.Annotate` function
 before passing them to
 `fx.Provide`, `fx.Supply`, `fx.Invoke`, `fx.Decorate`, or `fx.Replace`.
 
-This allows you to re-use a plain Go function
-with features like [value groups](value-groups.md)
+This allows you to re-use a plain Go function to do the following
 without manually wrapping the function to use
 [parameter](parameter-objects.md) or [result](result-objects.md) objects.
+
+- [feed values to a value group](value-groups/feed.md#with-annotated-functions)
+- [consume values from a value group](value-groups/consume.md#with-annotated-functions)
 
 <!-- TODO: named values and optional dependencies in the list above -->
 

--- a/docs/get-started/echo-handler.md
+++ b/docs/get-started/echo-handler.md
@@ -36,9 +36,11 @@ Let's fix that.
        fx.Invoke(func(*http.Server) {}),
    ```
 
-2. Next, add a function that builds a `*http.ServeMux`
-   to route requests to this handler.
-   The new function will accept the `*EchoHandler` as an argument.
+2. Next, write a function that builds an `*http.ServeMux`.
+   The `*http.ServeMux` will route requests received by the server to different
+   handlers.
+   To begin with, it will route requests sent to `/echo` to `*EchoHandler`,
+   so its constructor should accept `*EchoHandler` as an argument.
 
    ```go mdox-exec='region ex/get-started/03-echo-handler/main.go serve-mux'
    // NewServeMux builds a ServeMux that will route requests

--- a/docs/get-started/registration.md
+++ b/docs/get-started/registration.md
@@ -87,6 +87,7 @@ Let's try to fix this.
 
 We introduced an interface to decouple the implementation
 from the consumer.
-We then annotated a previously provided constructor
-with `fx.Annotate` and `fx.As` to cast its result to that interface.
+We then [annotated](../annotate.md) a previously provided constructor
+with `fx.Annotate` and `fx.As`
+to [cast its result to that interface](../annotate.md#casting-structs-to-interfaces).
 This way, `NewEchoHandler` was able to continue returning an `*EchoHandler`.


### PR DESCRIPTION
We received feedback about the get-started tutorial that for beginners:

- it wasn't clear what a ServeMux was
- it wasn't clear how annotation worked

To address that, this change:

- clarifies that ServeMux is responsible for routing HTTP requests
- links to the annotations page in the "What did we just do" section
  of the page where we introduce annotations
- on the annotations page, links to things you can do with annotations
  with room for more to come
