### PR TITLE
README/Getting Started: Link to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go get go.uber.org/fx@v1
 
 ## Getting started
 
-To get started with Fx, [start here](docs/get-started/README.md).
+To get started with Fx, [start here](https://uber-go.github.io/fx/get-started/).
 
 ## Stability
 


### PR DESCRIPTION
Don't link to the Markdown file directly since on GitHub that'll take to the on-GitHub version of the file, rather than the rendered website.