### PR TITLE
Refactor Done() to use a broadcasted Signal type for future features. 

### DIFF
--- a/app.go
+++ b/app.go
@@ -390,6 +390,7 @@ func New(opts ...Option) *App {
 		clock:        fxclock.System,
 		startTimeout: DefaultTimeout,
 		stopTimeout:  DefaultTimeout,
+		receivers:    newSignalReceivers(),
 	}
 	app.root = &module{
 		app: app,

--- a/app.go
+++ b/app.go
@@ -663,7 +663,7 @@ func (app *App) Stop(ctx context.Context) (err error) {
 // Alternatively, a signal can be broadcast to all done channels manually by
 // using the Shutdown functionality (see the Shutdowner documentation for details).
 func (app *App) Done() <-chan os.Signal {
-	return app.receivers.done()
+	return app.receivers.Done()
 }
 
 // StartTimeout returns the configured startup timeout. Apps default to using

--- a/app.go
+++ b/app.go
@@ -26,11 +26,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"reflect"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"go.uber.org/dig"
@@ -286,10 +284,9 @@ type App struct {
 	// Decides how we react to errors when building the graph.
 	errorHooks []ErrorHandler
 	validate   bool
+
 	// Used to signal shutdowns.
-	donesMu     sync.Mutex // guards dones and shutdownSig
-	dones       []chan os.Signal
-	shutdownSig os.Signal
+	receivers signalReceivers
 
 	osExit func(code int) // os.Exit override; used for testing only
 }
@@ -666,21 +663,7 @@ func (app *App) Stop(ctx context.Context) (err error) {
 // Alternatively, a signal can be broadcast to all done channels manually by
 // using the Shutdown functionality (see the Shutdowner documentation for details).
 func (app *App) Done() <-chan os.Signal {
-	c := make(chan os.Signal, 1)
-
-	app.donesMu.Lock()
-	defer app.donesMu.Unlock()
-	// If shutdown signal has been received already
-	// send it and return. If not, wait for user to send a termination
-	// signal.
-	if app.shutdownSig != nil {
-		c <- app.shutdownSig
-		return c
-	}
-
-	signal.Notify(c, os.Interrupt, _sigINT, _sigTERM)
-	app.dones = append(app.dones, c)
-	return c
+	return app.receivers.done()
 }
 
 // StartTimeout returns the configured startup timeout. Apps default to using

--- a/shutdown.go
+++ b/shutdown.go
@@ -44,7 +44,7 @@ type shutdowner struct {
 // In practice this means Shutdowner.Shutdown should not be called from an
 // fx.Invoke, but from a fx.Lifecycle.OnStart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
-	return s.app.receivers.broadcast(ShutdownSignal{OS: _sigTERM})
+	return s.app.receivers.Broadcast(ShutdownSignal{OS: _sigTERM})
 }
 
 func (app *App) shutdowner() Shutdowner {

--- a/shutdown.go
+++ b/shutdown.go
@@ -44,7 +44,7 @@ type shutdowner struct {
 // In practice this means Shutdowner.Shutdown should not be called from an
 // fx.Invoke, but from a fx.Lifecycle.OnStart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
-	return s.app.receivers.broadcast(Signal{OS: _sigTERM})
+	return s.app.receivers.broadcast(ShutdownSignal{OS: _sigTERM})
 }
 
 func (app *App) shutdowner() Shutdowner {

--- a/shutdown.go
+++ b/shutdown.go
@@ -44,7 +44,7 @@ type shutdowner struct {
 // In practice this means Shutdowner.Shutdown should not be called from an
 // fx.Invoke, but from a fx.Lifecycle.OnStart hook.
 func (s *shutdowner) Shutdown(opts ...ShutdownOption) error {
-	return s.app.receivers.Broadcast(ShutdownSignal{OS: _sigTERM})
+	return s.app.receivers.Broadcast(ShutdownSignal{Signal: _sigTERM})
 }
 
 func (app *App) shutdowner() Shutdowner {

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -64,7 +64,7 @@ func TestShutdown(t *testing.T) {
 		defer app.RequireStart().RequireStop()
 		assert.NoError(t, s.Shutdown(), "error returned from first shutdown call")
 
-		assert.EqualError(t, s.Shutdown(), "failed to send terminated signal to 1 out of 1 channels",
+		assert.EqualError(t, s.Shutdown(), "send terminated signal: 1/1 channels are blocked",
 			"unexpected error returned when shutdown is called with a blocked channel")
 		assert.NotNil(t, <-done, "done channel did not receive signal")
 	})

--- a/signal.go
+++ b/signal.go
@@ -32,7 +32,7 @@ type ShutdownSignal struct {
 	Signal os.Signal
 }
 
-// String will render a Signal type as a string suitable for printing.
+// String will render a ShutdownSignal type as a string suitable for printing.
 func (sig ShutdownSignal) String() string {
 	return fmt.Sprintf("%v", sig.Signal)
 }

--- a/signal.go
+++ b/signal.go
@@ -40,7 +40,7 @@ func (sig ShutdownSignal) String() string {
 type signalReceivers struct {
 	m     sync.Mutex
 	last  *ShutdownSignal
-	dones []chan os.Signal
+	done []chan os.Signal
 }
 
 func (recv *signalReceivers) Done() chan os.Signal {
@@ -56,7 +56,7 @@ func (recv *signalReceivers) Done() chan os.Signal {
 	}
 
 	signal.Notify(ch, os.Interrupt, _sigINT, _sigTERM)
-	recv.dones = append(recv.dones, ch)
+	recv.done = append(recv.done, ch)
 	return ch
 }
 
@@ -80,11 +80,11 @@ func (recv *signalReceivers) Broadcast(signal ShutdownSignal) error {
 
 func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (int, int) {
 	var (
-		receivers int = len(recv.dones)
+		receivers int = len(recv.done)
 		unsent    int
 	)
 
-	for _, reader := range recv.dones {
+	for _, reader := range recv.done {
 		select {
 		case reader <- signal.OS:
 		default:

--- a/signal.go
+++ b/signal.go
@@ -86,10 +86,7 @@ func (recv *signalReceivers) Broadcast(signal ShutdownSignal) error {
 }
 
 func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (int, int) {
-	var (
-		receivers int = len(recv.done)
-		unsent    int
-	)
+	var unsent int
 
 	for _, reader := range recv.done {
 		select {
@@ -99,7 +96,7 @@ func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (int, int) {
 		}
 	}
 
-	return receivers, unsent
+	return len(recv.done), unsent
 }
 
 type unsentSignalError struct {

--- a/signal.go
+++ b/signal.go
@@ -49,8 +49,10 @@ func (recv *signalReceivers) Done() chan os.Signal {
 
 	ch := make(chan os.Signal, 1)
 
-	// if we had received a signal prior to the call of done, send it's
+	// If we had received a signal prior to the call of done, send it's
 	// os.Signal to the new channel.
+	// However we still want to have the operating system notify signals to this
+	// channel should the application receive another.
 	if recv.last != nil {
 		ch <- recv.last.Signal
 	}

--- a/signal.go
+++ b/signal.go
@@ -78,8 +78,11 @@ func (recv *signalReceivers) Broadcast(signal ShutdownSignal) error {
 	return nil
 }
 
-func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (receivers, unsent int) {
-	receivers = len(recv.dones)
+func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (int, int) {
+	var (
+		receivers int = len(recv.dones)
+		unsent    int
+	)
 
 	for _, reader := range recv.dones {
 		select {
@@ -89,7 +92,7 @@ func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (receivers, un
 		}
 	}
 
-	return
+	return receivers, unsent
 }
 
 type unsentSignalError struct {

--- a/signal.go
+++ b/signal.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+)
+
+type Signal struct {
+	OS   os.Signal
+	Code int
+}
+
+func (sig Signal) String() string {
+	return fmt.Sprintf("%v (with exit code %v)", sig.OS, sig.Code)
+}
+
+type signalReceivers struct {
+	last       *Signal
+	lastLock   sync.RWMutex
+	done       []chan<- os.Signal
+	doneLock   sync.RWMutex
+	signal     []chan<- Signal
+	signalLock sync.RWMutex
+}
+
+func (recv *signalReceivers) Done() chan<- os.Signal {
+	recv.doneLock.Lock()
+	defer recv.doneLock.Unlock()
+	recv.lastLock.RLock()
+	defer recv.lastLock.RUnlock()
+
+	ch := make(chan<- os.Signal, 1)
+
+	// if we had received a signal prior to the call of Done, send it's os.Signal
+	// to the new channel.
+	if recv.last != nil {
+		ch <- recv.last.OS
+	}
+
+	signal.Notify(ch, os.Interrupt, _sigINT, _sigTERM)
+	recv.done = append(recv.done, ch)
+	return ch
+}
+
+type unsentSignalError struct {
+	Signal   Signal
+	Unsent   int
+	Channels int
+}
+
+func (err unsentSignalError) Error() string {
+	return fmt.Sprintf(
+		"send %v signal: %v/%v channels are blocked",
+		err.Signal,
+		err.Unsent,
+		err.Channels,
+	)
+}
+
+func (recv signalReceivers) broadcastDone(signal Signal) (total, unsent int) {
+	recv.doneLock.RLock()
+	defer recv.doneLock.RUnlock()
+
+	total = len(recv.done)
+
+	for _, reader := range recv.done {
+		select {
+		case reader <- signal.OS:
+		default:
+			unsent++
+		}
+	}
+
+	return
+}
+
+func (recv *signalReceivers) Broadcast(signal Signal) (err error) {
+	recv.lastLock.Lock()
+	recv.last = &signal
+	recv.lastLock.Unlock()
+
+	dones, doneUnsent := recv.broadcastDone(signal)
+
+	unsent := doneUnsent
+	channels := dones
+
+	if unsent != 0 {
+		err = &unsentSignalError{
+			Signal:   signal,
+			Channels: channels,
+			Unsent:   unsent,
+		}
+	}
+
+	return
+}

--- a/signal.go
+++ b/signal.go
@@ -89,7 +89,7 @@ func (err *unsentSignalError) Error() string {
 	)
 }
 
-func (recv *signalReceivers) broadcast(signal ShutdownSignal) error {
+func (recv *signalReceivers) Broadcast(signal ShutdownSignal) error {
 	recv.m.Lock()
 	defer recv.m.Unlock()
 	recv.last = &signal

--- a/signal.go
+++ b/signal.go
@@ -27,16 +27,14 @@ import (
 	"sync"
 )
 
-// A signal represents a operating system process signal and a proposed exit
-// code.
+// Signal represents a operating system process signal.
 type Signal struct {
-	OS   os.Signal
-	Code int
+	OS os.Signal
 }
 
-// String will render a Signal in the form of "%v (with exit code %v)"
+// String will render a Signal type as a string suitable for printing.
 func (sig Signal) String() string {
-	return fmt.Sprintf("%v (with exit code %v)", sig.OS, sig.Code)
+	return fmt.Sprintf("%v", sig.OS)
 }
 
 type signalReceivers struct {
@@ -65,7 +63,7 @@ func (recv *signalReceivers) done() chan os.Signal {
 	return ch
 }
 
-func (recv signalReceivers) broadcastDone(signal Signal) (receivers, unsent int) {
+func (recv *signalReceivers) broadcastDone(signal Signal) (receivers, unsent int) {
 	recv.doneLock.RLock()
 	defer recv.doneLock.RUnlock()
 

--- a/signal.go
+++ b/signal.go
@@ -12,7 +12,7 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPSignalE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -29,17 +29,17 @@ import (
 
 // ShutdownSignal is a signal that caused the application to exit.
 type ShutdownSignal struct {
-	OS os.Signal
+	Signal os.Signal
 }
 
 // String will render a Signal type as a string suitable for printing.
 func (sig ShutdownSignal) String() string {
-	return fmt.Sprintf("%v", sig.OS)
+	return fmt.Sprintf("%v", sig.Signal)
 }
 
 type signalReceivers struct {
-	m     sync.Mutex
-	last  *ShutdownSignal
+	m    sync.Mutex
+	last *ShutdownSignal
 	done []chan os.Signal
 }
 
@@ -52,7 +52,7 @@ func (recv *signalReceivers) Done() chan os.Signal {
 	// if we had received a signal prior to the call of done, send it's
 	// os.Signal to the new channel.
 	if recv.last != nil {
-		ch <- recv.last.OS
+		ch <- recv.last.Signal
 	}
 
 	signal.Notify(ch, os.Interrupt, _sigINT, _sigTERM)
@@ -86,7 +86,7 @@ func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (int, int) {
 
 	for _, reader := range recv.done {
 		select {
-		case reader <- signal.OS:
+		case reader <- signal.Signal:
 		default:
 			unsent++
 		}

--- a/signal.go
+++ b/signal.go
@@ -76,9 +76,9 @@ func (recv *signalReceivers) Broadcast(signal ShutdownSignal) error {
 
 	if unsent != 0 {
 		return &unsentSignalError{
-			Signal:   signal,
-			Channels: channels,
-			Unsent:   unsent,
+			Signal: signal,
+			Total:  channels,
+			Unsent: unsent,
 		}
 	}
 
@@ -100,9 +100,9 @@ func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (int, int) {
 }
 
 type unsentSignalError struct {
-	Signal   ShutdownSignal
-	Unsent   int
-	Channels int
+	Signal ShutdownSignal
+	Unsent int
+	Total  int
 }
 
 func (err *unsentSignalError) Error() string {
@@ -110,6 +110,6 @@ func (err *unsentSignalError) Error() string {
 		"send %v signal: %v/%v channels are blocked",
 		err.Signal,
 		err.Unsent,
-		err.Channels,
+		err.Total,
 	)
 }

--- a/signal.go
+++ b/signal.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 )
 
-// ShutdownSignal represents a operating system process signal.
+// ShutdownSignal is a signal that caused the application to exit.
 type ShutdownSignal struct {
 	OS os.Signal
 }

--- a/signal.go
+++ b/signal.go
@@ -43,7 +43,7 @@ type signalReceivers struct {
 	dones []chan os.Signal
 }
 
-func (recv *signalReceivers) done() chan os.Signal {
+func (recv *signalReceivers) Done() chan os.Signal {
 	recv.m.Lock()
 	defer recv.m.Unlock()
 

--- a/signal.go
+++ b/signal.go
@@ -27,19 +27,19 @@ import (
 	"sync"
 )
 
-// Signal represents a operating system process signal.
-type Signal struct {
+// ShutdownSignal represents a operating system process signal.
+type ShutdownSignal struct {
 	OS os.Signal
 }
 
 // String will render a Signal type as a string suitable for printing.
-func (sig Signal) String() string {
+func (sig ShutdownSignal) String() string {
 	return fmt.Sprintf("%v", sig.OS)
 }
 
 type signalReceivers struct {
 	m     sync.Mutex
-	last  *Signal
+	last  *ShutdownSignal
 	dones []chan os.Signal
 }
 
@@ -60,7 +60,7 @@ func (recv *signalReceivers) done() chan os.Signal {
 	return ch
 }
 
-func (recv *signalReceivers) broadcastDone(signal Signal) (receivers, unsent int) {
+func (recv *signalReceivers) broadcastDone(signal ShutdownSignal) (receivers, unsent int) {
 	receivers = len(recv.dones)
 
 	for _, reader := range recv.dones {
@@ -75,7 +75,7 @@ func (recv *signalReceivers) broadcastDone(signal Signal) (receivers, unsent int
 }
 
 type unsentSignalError struct {
-	Signal   Signal
+	Signal   ShutdownSignal
 	Unsent   int
 	Channels int
 }
@@ -89,7 +89,7 @@ func (err *unsentSignalError) Error() string {
 	)
 }
 
-func (recv *signalReceivers) broadcast(signal Signal) error {
+func (recv *signalReceivers) broadcast(signal ShutdownSignal) error {
 	recv.m.Lock()
 	defer recv.m.Unlock()
 	recv.last = &signal

--- a/signal_test.go
+++ b/signal_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fx
+
+import (
+	"github.com/stretchr/testify/assert"
+	"syscall"
+	"testing"
+)
+
+func assertUnsentSignalError(
+	t *testing.T,
+	err error,
+	expected unsentSignalError,
+) {
+	t.Helper()
+
+	var actual unsentSignalError
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "channels are blocked")
+	assert.ErrorAs(t, err, &actual, "is unsentSignalError")
+	assert.Equal(t, expected, actual)
+}
+
+func TestSignal(t *testing.T) {
+	t.Parallel()
+	recv := new(signalReceivers)
+	a := recv.done()
+	b := recv.done()
+
+	assert.NotNil(t, a)
+	assert.NotNil(t, b)
+
+	expected := Signal{
+		OS:   syscall.SIGUSR1,
+		Code: 42,
+	}
+
+	err := recv.broadcast(expected)
+
+	assert.NoError(t, err, "first broadcast should succeed")
+
+	err = recv.broadcast(expected)
+
+	assertUnsentSignalError(t, err, unsentSignalError{
+		Signal:   expected,
+		Channels: 2,
+		Unsent:   2,
+	})
+
+	actual := <-a
+	assert.Equal(t, expected.OS, actual)
+
+	assert.Equal(t, expected.OS, <-recv.done(), "expect cached signal")
+}

--- a/signal_test.go
+++ b/signal_test.go
@@ -45,8 +45,7 @@ func TestSignal(t *testing.T) {
 	t.Parallel()
 	recv := new(signalReceivers)
 	a := recv.Done()
-	b := recv.Done()
-
+	recv.Done()
 
 	expected := ShutdownSignal{
 		Signal: syscall.SIGTERM,

--- a/signal_test.go
+++ b/signal_test.go
@@ -29,11 +29,11 @@ import (
 func assertUnsentSignalError(
 	t *testing.T,
 	err error,
-	expected unsentSignalError,
+	expected *unsentSignalError,
 ) {
 	t.Helper()
 
-	var actual unsentSignalError
+	actual := new(unsentSignalError)
 
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "channels are blocked")
@@ -60,7 +60,7 @@ func TestSignal(t *testing.T) {
 
 	err = recv.broadcast(expected)
 
-	assertUnsentSignalError(t, err, unsentSignalError{
+	assertUnsentSignalError(t, err, &unsentSignalError{
 		Signal:   expected,
 		Channels: 2,
 		Unsent:   2,

--- a/signal_test.go
+++ b/signal_test.go
@@ -51,8 +51,7 @@ func TestSignal(t *testing.T) {
 	assert.NotNil(t, b)
 
 	expected := Signal{
-		OS:   syscall.SIGUSR1,
-		Code: 42,
+		OS: syscall.SIGUSR1,
 	}
 
 	err := recv.broadcast(expected)

--- a/signal_test.go
+++ b/signal_test.go
@@ -46,7 +46,7 @@ func TestSignal(t *testing.T) {
 	t.Parallel()
 	recv := new(signalReceivers)
 	a := recv.Done()
-	recv.Done()
+	_ = recv.Done() // we never listen on this
 
 	expected := ShutdownSignal{
 		Signal: syscall.SIGTERM,
@@ -60,8 +60,6 @@ func TestSignal(t *testing.T) {
 		Unsent:   2,
 	})
 
-	actual := <-a
-	assert.Equal(t, expected.Signal, actual)
-
+	assert.Equal(t, expected.Signal, <-a)
 	assert.Equal(t, expected.Signal, <-recv.Done(), "expect cached signal")
 }

--- a/signal_test.go
+++ b/signal_test.go
@@ -44,7 +44,7 @@ func assertUnsentSignalError(
 
 func TestSignal(t *testing.T) {
 	t.Parallel()
-	recv := new(signalReceivers)
+	recv := newSignalReceivers()
 	a := recv.Done()
 	_ = recv.Done() // we never listen on this
 

--- a/signal_test.go
+++ b/signal_test.go
@@ -22,6 +22,7 @@ package fx
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"syscall"
 	"testing"
 )
@@ -51,13 +52,9 @@ func TestSignal(t *testing.T) {
 		Signal: syscall.SIGTERM,
 	}
 
-	err := recv.Broadcast(expected)
+	require.NoError(t, recv.Broadcast(expected), "first broadcast should succeed")
 
-	assert.NoError(t, err, "first broadcast should succeed")
-
-	err = recv.Broadcast(expected)
-
-	assertUnsentSignalError(t, err, &unsentSignalError{
+	assertUnsentSignalError(t, recv.Broadcast(expected), &unsentSignalError{
 		Signal:   expected,
 		Channels: 2,
 		Unsent:   2,

--- a/signal_test.go
+++ b/signal_test.go
@@ -51,7 +51,7 @@ func TestSignal(t *testing.T) {
 	assert.NotNil(t, b)
 
 	expected := Signal{
-		OS: syscall.SIGUSR1,
+		OS: syscall.SIGTERM,
 	}
 
 	err := recv.broadcast(expected)

--- a/signal_test.go
+++ b/signal_test.go
@@ -44,8 +44,8 @@ func assertUnsentSignalError(
 func TestSignal(t *testing.T) {
 	t.Parallel()
 	recv := new(signalReceivers)
-	a := recv.done()
-	b := recv.done()
+	a := recv.Done()
+	b := recv.Done()
 
 	assert.NotNil(t, a)
 	assert.NotNil(t, b)
@@ -69,5 +69,5 @@ func TestSignal(t *testing.T) {
 	actual := <-a
 	assert.Equal(t, expected.OS, actual)
 
-	assert.Equal(t, expected.OS, <-recv.done(), "expect cached signal")
+	assert.Equal(t, expected.OS, <-recv.Done(), "expect cached signal")
 }

--- a/signal_test.go
+++ b/signal_test.go
@@ -54,11 +54,11 @@ func TestSignal(t *testing.T) {
 		OS: syscall.SIGTERM,
 	}
 
-	err := recv.broadcast(expected)
+	err := recv.Broadcast(expected)
 
 	assert.NoError(t, err, "first broadcast should succeed")
 
-	err = recv.broadcast(expected)
+	err = recv.Broadcast(expected)
 
 	assertUnsentSignalError(t, err, &unsentSignalError{
 		Signal:   expected,

--- a/signal_test.go
+++ b/signal_test.go
@@ -12,7 +12,7 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPSignalE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -49,7 +49,7 @@ func TestSignal(t *testing.T) {
 
 
 	expected := ShutdownSignal{
-		OS: syscall.SIGTERM,
+		Signal: syscall.SIGTERM,
 	}
 
 	err := recv.Broadcast(expected)
@@ -65,7 +65,7 @@ func TestSignal(t *testing.T) {
 	})
 
 	actual := <-a
-	assert.Equal(t, expected.OS, actual)
+	assert.Equal(t, expected.Signal, actual)
 
-	assert.Equal(t, expected.OS, <-recv.Done(), "expect cached signal")
+	assert.Equal(t, expected.Signal, <-recv.Done(), "expect cached signal")
 }

--- a/signal_test.go
+++ b/signal_test.go
@@ -50,7 +50,7 @@ func TestSignal(t *testing.T) {
 	assert.NotNil(t, a)
 	assert.NotNil(t, b)
 
-	expected := Signal{
+	expected := ShutdownSignal{
 		OS: syscall.SIGTERM,
 	}
 

--- a/signal_test.go
+++ b/signal_test.go
@@ -47,8 +47,6 @@ func TestSignal(t *testing.T) {
 	a := recv.Done()
 	b := recv.Done()
 
-	assert.NotNil(t, a)
-	assert.NotNil(t, b)
 
 	expected := ShutdownSignal{
 		OS: syscall.SIGTERM,

--- a/signal_test.go
+++ b/signal_test.go
@@ -55,9 +55,9 @@ func TestSignal(t *testing.T) {
 	require.NoError(t, recv.Broadcast(expected), "first broadcast should succeed")
 
 	assertUnsentSignalError(t, recv.Broadcast(expected), &unsentSignalError{
-		Signal:   expected,
-		Channels: 2,
-		Unsent:   2,
+		Signal: expected,
+		Total:  2,
+		Unsent: 2,
 	})
 
 	assert.Equal(t, expected.Signal, <-a)

--- a/signal_test.go
+++ b/signal_test.go
@@ -35,7 +35,6 @@ func assertUnsentSignalError(
 
 	actual := new(unsentSignalError)
 
-	assert.Error(t, err)
 	assert.ErrorContains(t, err, "channels are blocked")
 	assert.ErrorAs(t, err, &actual, "is unsentSignalError")
 	assert.Equal(t, expected, actual)

--- a/signal_test.go
+++ b/signal_test.go
@@ -36,8 +36,9 @@ func assertUnsentSignalError(
 	actual := new(unsentSignalError)
 
 	assert.ErrorContains(t, err, "channels are blocked")
-	assert.ErrorAs(t, err, &actual, "is unsentSignalError")
-	assert.Equal(t, expected, actual)
+	if assert.ErrorAs(t, err, &actual, "is unsentSignalError") {
+		assert.Equal(t, expected, actual)
+	}
 }
 
 func TestSignal(t *testing.T) {


### PR DESCRIPTION
This creates a new public struct type `ShutdownSignal` and moves broadcast of operating system signals to a standalone type in it's own source file. This allows for the cleaner expansion of signaling features. 

