### PR TITLE
docs/internal: Fix docstring on exectest.Command

### DIFF
--- a/docs/internal/exectest/cmd.go
+++ b/docs/internal/exectest/cmd.go
@@ -35,7 +35,7 @@ import (
 // This operates by re-running the test executable to run only the current
 // test, and hijacking that test execution to run the main function.
 //
-//	cmd := MainCmd(t, func() { fmt.Println("hello") })
+//	cmd := Command(t, func() { fmt.Println("hello") })
 //	got, err := cmd.Output()
 //	...
 //	fmt.Println(string(got) == "hello\n") // true


### PR DESCRIPTION
Fx uses exectest.Command to mock 'main' for external tests. The original prototype of this was named MainCmd.
The docstring was never updated when this got renamed to Command.