### PR TITLE
Cleanup context.Context used in unit tests

### DIFF
--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1038,7 +1038,8 @@ func assertApp(
 	invoked *bool,
 ) {
 	t.Helper()
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	assert.False(t, *started)
 	require.NoError(t, app.Start(ctx))
 	assert.True(t, *started)
@@ -1449,7 +1450,9 @@ func TestHookAnnotationFailures(t *testing.T) {
 			}
 
 			app := NewForTest(t, opts)
-			err := app.Start(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := app.Start(ctx)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errContains)
 		})

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -97,7 +97,9 @@ func TestDataRace(t *testing.T) {
 		t,
 		fx.Populate(&s),
 	)
-	require.NoError(t, app.Start(context.Background()), "error starting app")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, app.Start(ctx), "error starting app")
 
 	const N = 50
 	ready := make(chan struct{}) // used to orchestrate goroutines for Done() and ShutdownOption()


### PR DESCRIPTION
A number of unit tests do not correctly clean up context.Context types used in tests that call `app.Start` and `app.Stop`, the expected behavior is that context's should be canceled when they are no longer needed; canceling a context should force the application lifecycle to stop.  