### PR TITLE
Align Spacing for Private Provides Docs

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -53,7 +53,6 @@ To write an Fx module:
      ),
      fx.Invoke(startServer),
      fx.Decorate(wrapLogger),
-
    )
    ```
 
@@ -63,15 +62,15 @@ To write an Fx module:
 
    ```go mdox-exec='region ex/modules/module.go private'
    var Module = fx.Module("server",
-   	fx.Provide(
-   		New,
-   	),
-   	fx.Provide(
-   		fx.Private,
-   		parseConfig,
-   	),
-   	fx.Invoke(startServer),
-   	fx.Decorate(wrapLogger),
+     fx.Provide(
+       New,
+     ),
+     fx.Provide(
+       fx.Private,
+       parseConfig,
+     ),
+     fx.Invoke(startServer),
+     fx.Decorate(wrapLogger),
    )
    ```
 


### PR DESCRIPTION
By the time #995 was merged in, #1000 had changed the spacing for code snippets in the docs. This makes the additions to the docs in #995 correctly spaced.