### PR TITLE
Panic Recovery Option

### DIFF
--- a/app.go
+++ b/app.go
@@ -165,8 +165,8 @@ func (t stopTimeoutOption) String() string {
 	return fmt.Sprintf("fx.StopTimeout(%v)", time.Duration(t))
 }
 
-// RecoverFromPanics causes panics that occur in provided, decorated, and
-// invoked functions to be recovered from and wrapped in an dig.PanicError.
+// RecoverFromPanics causes panics that occur in functions given to [Provide],
+// [Decorate], and [Invoke] to be recovered from.
 // This error can be retrieved as any other error, by using (*App).Err().
 func RecoverFromPanics() Option {
 	return recoverFromPanicsOption{}

--- a/app.go
+++ b/app.go
@@ -165,6 +165,28 @@ func (t stopTimeoutOption) String() string {
 	return fmt.Sprintf("fx.StopTimeout(%v)", time.Duration(t))
 }
 
+// RecoverFromPanics causes panics that occur in provided, decorated, and
+// invoked functions to be recovered from and wrapped in an dig.PanicError.
+// This error can be retrieved as any other error, by using (*App).Err().
+func RecoverFromPanics() Option {
+	return recoverFromPanicsOption{}
+}
+
+type recoverFromPanicsOption struct {}
+
+func (o recoverFromPanicsOption) apply(m *module) {
+	if m.parent != nil {
+		m.app.err = fmt.Errorf("fx.RecoverFromPanics Option should be passed to top-level " +
+			"App, not to fx.Module")
+	} else {
+		m.app.recoverFromPanics = true
+	}
+}
+
+func (o recoverFromPanicsOption) String() string {
+	return "fx.RecoverFromPanics()"
+}
+
 // WithLogger specifies how Fx should build an fxevent.Logger to log its events
 // to. The argument must be a constructor with one of the following return
 // types.
@@ -284,6 +306,8 @@ type App struct {
 	// Decides how we react to errors when building the graph.
 	errorHooks []ErrorHandler
 	validate   bool
+	// Whether to recover from panics in Dig container
+	recoverFromPanics bool
 
 	// Used to signal shutdowns.
 	receivers signalReceivers
@@ -427,10 +451,16 @@ func New(opts ...Option) *App {
 		lifecycle.New(appLogger{app}, app.clock),
 	}
 
-	app.container = dig.New(
+	containerOptions := []dig.Option{
 		dig.DeferAcyclicVerification(),
 		dig.DryRun(app.validate),
-	)
+	}
+
+	if app.recoverFromPanics {
+		containerOptions = append(containerOptions, dig.RecoverFromPanics())
+	}
+
+	app.container = dig.New(containerOptions...)
 
 	for _, m := range app.modules {
 		m.build(app, app.container)

--- a/app.go
+++ b/app.go
@@ -172,7 +172,7 @@ func RecoverFromPanics() Option {
 	return recoverFromPanicsOption{}
 }
 
-type recoverFromPanicsOption struct {}
+type recoverFromPanicsOption struct{}
 
 func (o recoverFromPanicsOption) apply(m *module) {
 	if m.parent != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -922,7 +922,7 @@ func TestTimeoutOptions(t *testing.T) {
 func TestRecoverFromPanicsOption(t *testing.T) {
 	t.Parallel()
 
-	t.Run("CanNotGiveToModule", func(t *testing.T) {
+	t.Run("CannotGiveToModule", func(t *testing.T) {
 		t.Parallel()
 		mod := Module("MyModule", RecoverFromPanics())
 		err := New(mod).Err()

--- a/app_test.go
+++ b/app_test.go
@@ -928,8 +928,8 @@ func TestRecoverFromPanicsOption(t *testing.T) {
 		err := New(mod).Err()
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"fx.RecoverFromPanics Option should be passed to top-level App, " +
-			"not to fx.Module")
+			"fx.RecoverFromPanics Option should be passed to top-level App, "+
+				"not to fx.Module")
 	})
 
 	run := func(withOption bool) {
@@ -947,7 +947,7 @@ func TestRecoverFromPanicsOption(t *testing.T) {
 			assert.Contains(t, err.Error(),
 				`panic: "terrible sorrow" in func: "go.uber.org/fx_test".TestRecoverFromPanicsOption.`)
 		} else {
-			assert.Panics(t, func() { New(opts...) }, 
+			assert.Panics(t, func() { New(opts...) },
 				"expected panic without RecoverFromPanics() option")
 		}
 	}

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -19,3 +19,5 @@ require (
 )
 
 replace go.uber.org/fx => ../
+
+replace go.uber.org/dig => github.com/uber-go/dig v1.15.1-0.20221213190814-6ef87c8bcb68

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -11,10 +11,10 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/uber-go/dig v1.15.1-0.20221213190814-6ef87c8bcb68 h1:lCRB/UCzzaj+o5obu4qVC3MuInDt7g2mDVSJvHWSKYc=
+github.com/uber-go/dig v1.15.1-0.20221213190814-6ef87c8bcb68/go.mod h1:557JTAUZT5bUK0SvCwikmLPPtdQhfvLYtO5tJgQSbnk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/dig v1.15.0 h1:vq3YWr8zRj1eFGC7Gvf907hE0eRjPTZ1d3xHadD6liE=
-go.uber.org/dig v1.15.0/go.mod h1:pKHs0wMynzL6brANhB2hLMro+zalv1osARTviTcqHLM=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.7.0
-	go.uber.org/dig v1.15.1-0.20221213190814-6ef87c8bcb68
+	go.uber.org/dig v1.15.0
 	go.uber.org/goleak v1.1.11
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.23.0
@@ -18,3 +18,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace go.uber.org/dig => github.com/uber-go/dig v1.15.1-0.20221213190814-6ef87c8bcb68

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.7.0
-	go.uber.org/dig v1.15.0
+	go.uber.org/dig v1.15.1-0.20221213190814-6ef87c8bcb68
 	go.uber.org/goleak v1.1.11
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -18,11 +18,11 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/uber-go/dig v1.15.1-0.20221213190814-6ef87c8bcb68 h1:lCRB/UCzzaj+o5obu4qVC3MuInDt7g2mDVSJvHWSKYc=
+github.com/uber-go/dig v1.15.1-0.20221213190814-6ef87c8bcb68/go.mod h1:557JTAUZT5bUK0SvCwikmLPPtdQhfvLYtO5tJgQSbnk=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/dig v1.15.1-0.20221213190814-6ef87c8bcb68 h1:Ep35GvmJxXyWpLtwiKnYzVtPxt+FMtZxCLvV+eWGKpc=
-go.uber.org/dig v1.15.1-0.20221213190814-6ef87c8bcb68/go.mod h1:557JTAUZT5bUK0SvCwikmLPPtdQhfvLYtO5tJgQSbnk=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/dig v1.15.0 h1:vq3YWr8zRj1eFGC7Gvf907hE0eRjPTZ1d3xHadD6liE=
-go.uber.org/dig v1.15.0/go.mod h1:pKHs0wMynzL6brANhB2hLMro+zalv1osARTviTcqHLM=
+go.uber.org/dig v1.15.1-0.20221213190814-6ef87c8bcb68 h1:Ep35GvmJxXyWpLtwiKnYzVtPxt+FMtZxCLvV+eWGKpc=
+go.uber.org/dig v1.15.1-0.20221213190814-6ef87c8bcb68/go.mod h1:557JTAUZT5bUK0SvCwikmLPPtdQhfvLYtO5tJgQSbnk=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=


### PR DESCRIPTION
Since https://github.com/uber-go/dig/pull/364 was merged into Dig, we can now built upon it to add the ability to recover from panics in user-provided code into Fx, by providing a `fx.RecoverFromPanics()` option into their application. This is disallowed on the module level, only on the application level.

```go
app := fx.New(
    fx.Provide(func() int {
        panic("terrible sorrow")
    }),
    fx.Invoke(func(a int) {}),
    fx.RecoverFromPanics(), // panic will be set to app.Err now
)

err := app.Err()
var pe dig.PanicError
if errors.As(err, &pe) { // panic happened when we invoke
    // handle panic
}
```