### PR TITLE
chore: app_test.go: New->NewForTest

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -401,7 +401,7 @@ func TestPrivateProvide(t *testing.T) {
 	t.Run("CantUsePrivateFromSubModule", func(t *testing.T) {
 		t.Parallel()
 
-		app := New(
+		app := NewForTest(t,
 			Module("SubModule", Provide(func() int { return 0 }, Private)),
 			Invoke(func(a int) {}),
 		)
@@ -447,7 +447,7 @@ func TestPrivateProvideWithDecorators(t *testing.T) {
 			if private {
 				provideOpts = append(provideOpts, Private)
 			}
-			app := New(
+			app := NewForTest(t,
 				Module("SubModule",
 					Provide(provideOpts...),
 					Decorate(func(a int) int { return a + 2 }),
@@ -500,7 +500,7 @@ func TestPrivateProvideWithDecorators(t *testing.T) {
 	t.Run("CannotDecoratePrivateChildType", func(t *testing.T) {
 		t.Parallel()
 
-		app := New(
+		app := NewForTest(t,
 			Module("Child",
 				Provide(func() int { return 0 }, Private),
 			),


### PR DESCRIPTION
The tests that cover error cases for private provides were using New(opts...) rather than NewForTest(t, opts...) which caused the error logs to be present in the tests when those tests run.

This changes those to use NewForTest instead.