### PR TITLE
Fix Start ctx expiration making app unstoppable

### DIFF
--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1500,6 +1500,8 @@ func assertApp(
 		require.NoError(t, app.Stop(ctx))
 		assert.True(t, *stopped)
 	}
+
+	defer app.Stop(ctx)
 }
 
 func TestHookAnnotations(t *testing.T) {

--- a/app_test.go
+++ b/app_test.go
@@ -918,43 +918,6 @@ func TestTimeoutOptions(t *testing.T) {
 	assert.True(t, stopped, "app wasn't stopped")
 }
 
-func TestRecoverFromPanicsOption(t *testing.T) {
-	t.Parallel()
-
-	t.Run("CannotGiveToModule", func(t *testing.T) {
-		t.Parallel()
-		mod := Module("MyModule", RecoverFromPanics())
-		err := New(mod).Err()
-		require.Error(t, err)
-		require.Contains(t, err.Error(),
-			"fx.RecoverFromPanics Option should be passed to top-level App, "+
-				"not to fx.Module")
-	})
-
-	run := func(withOption bool) {
-		opts := []Option{
-			Provide(func() int {
-				panic("terrible sorrow")
-			}),
-			Invoke(func(a int) {}),
-		}
-		if withOption {
-			opts = append(opts, RecoverFromPanics())
-			app := New(opts...)
-			err := app.Err()
-			require.Error(t, err)
-			assert.Contains(t, err.Error(),
-				`panic: "terrible sorrow" in func: "go.uber.org/fx_test".TestRecoverFromPanicsOption.`)
-		} else {
-			assert.Panics(t, func() { New(opts...) },
-				"expected panic without RecoverFromPanics() option")
-		}
-	}
-
-	t.Run("WithoutOption", func(t *testing.T) { run(false) })
-	t.Run("WithOption", func(t *testing.T) { run(true) })
-}
-
 func TestAppRunTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -1461,6 +1424,7 @@ func TestAppStart(t *testing.T) {
 		}
 		app.Stop(ctx)
 		assert.NoError(t, app.Start(ctx))
+		app.Stop(ctx)
 	})
 }
 

--- a/internal/leaky_test/leaky_test.go
+++ b/internal/leaky_test/leaky_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// leaky_test contains tests that are explicitly leaking goroutines because they
+// trigger a panic on purpose.
+// To prevent these from making it difficult for us to use goleak for tests in
+// fx_test, we contain these here.
+package leaky_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestRecoverFromPanicsOption(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CannotGiveToModule", func(t *testing.T) {
+		t.Parallel()
+		mod := fx.Module("MyModule", fx.RecoverFromPanics())
+		err := fx.New(mod).Err()
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"fx.RecoverFromPanics Option should be passed to top-level App, "+
+				"not to fx.Module")
+	})
+	run := func(withOption bool) {
+		opts := []fx.Option{
+			fx.Provide(func() int {
+				panic("terrible sorrow")
+			}),
+			fx.Invoke(func(a int) {}),
+		}
+		if withOption {
+			opts = append(opts, fx.RecoverFromPanics())
+			app := fx.New(opts...)
+			err := app.Err()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(),
+				`panic: "terrible sorrow" in func: "go.uber.org/fx/internal/leaky_test_test".TestRecoverFromPanicsOption.`)
+		} else {
+			assert.Panics(t, func() { fx.New(opts...) },
+				"expected panic without RecoverFromPanics() option")
+		}
+	}
+
+	t.Run("WithoutOption", func(t *testing.T) { run(false) })
+	t.Run("WithOption", func(t *testing.T) { run(true) })
+}

--- a/signal.go
+++ b/signal.go
@@ -87,8 +87,6 @@ func (recv *signalReceivers) relayer(ctx context.Context) {
 	select {
 	case <-recv.shutdown:
 		return
-	case <-ctx.Done():
-		return
 	case signal := <-recv.signals:
 		recv.Broadcast(ShutdownSignal{
 			Signal: signal,


### PR DESCRIPTION
This fixes #1015.

When Start() is called, it passes StartTimeout to the relayer goroutine, which is monitoring the Stop signal, as well as the OS signal handler.

It then exits the goroutine if the start context expires, which would naturally happen if the user uses the default setting (15s timeout) or any finite amount of timeout value.

This causes the app to then be not responsive to any OS signals such as SIGTERM or SIGINT.

This was a regression introduced in 1.19 release via #989 .

To fix this, this commit simply removes the relayer goroutine from selecting on the start context being completed.

Verified that all tests are still passing without any goroutine leak, except one test that was triggering a panic to test the panic handler.

To prevent that one test from opting out every single test into goleak.VerifyNone(t) in every sub test, I pulled out that panic test into a separate test package so that we can continue to use goleak.VerifyNone() method in app_test.