### PR TITLE
Allow stopping app after Stop() has been called

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -267,7 +267,7 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	l.mu.Lock()
 	if l.state != started && l.state != incompleteStart {
 		defer l.mu.Unlock()
-		return fmt.Errorf("attempted to stop lifecycle when in state: %v", l.state)
+		return nil
 	}
 	l.state = stopping
 	l.mu.Unlock()

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -331,16 +331,6 @@ func TestLifecycleStop(t *testing.T) {
 		assert.Contains(t, err.Error(), "called OnStop with nil context")
 
 	})
-
-	t.Run("StopWhileStoppedErrors", func(t *testing.T) {
-		t.Parallel()
-
-		l := New(testLogger(t), fxclock.System)
-		err := l.Stop(context.Background())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "attempted to stop lifecycle when in state: stopped")
-	})
-
 }
 
 func TestHookRecordsFormat(t *testing.T) {


### PR DESCRIPTION
Starting from 1.19, calling Stop() when an app has been stopped returns an error.

This actually is an unexpected change for many users who have been using fxtest for testing their apps. Specifically, if they have a server that errors out when tests are written, these will often trigger Stop() to be called many times..