### PR TITLE
Support wasm build

### DIFF
--- a/app_wasm.go
+++ b/app_wasm.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build js && wasm
+// +build js,wasm
+
+package fx
+
+import "syscall"
+
+const _sigINT = syscall.SIGINT
+const _sigTERM = syscall.SIGTERM


### PR DESCRIPTION
Fx currently cannot be used to build wasm apps.

Fixing this is actually quite simple, since the issue is happening with our type aliases of SIGTERM and SIGINT for the OS signal handler.

This adds signal_wasm.go file to define these constants for js/wasm builds only.

Fixes #1016.