### PR TITLE
[docs] link to Lifecycle core concepts doc from http-server

### DIFF
--- a/docs/get-started/http-server.md
+++ b/docs/get-started/http-server.md
@@ -119,6 +119,12 @@ and it will stop running when the application receives a stop signal.
 We used `fx.Invoke` to request that the HTTP server is always instantiated,
 even if none of the other components in the application reference it directly.
 
+
+**Related Resources**
+
+* [Application lifecycle](/lifecycle.md) further explains what Fx lifecycles are,
+  and how to use them.
+
 <!-- 
 TODO: when the docs exist
 
@@ -126,6 +132,5 @@ TODO: when the docs exist
 
 * TODO: link to fx.Provide
 * TODO: link to fx.Invoke
-* TODO: link to Fx application lifecycle
 
 -->


### PR DESCRIPTION
This adds link to fx.Lifecycle concept doc after we've introduced them in the writing http server part of getting started tutorial.

Docs for Provide/Invoke are currently in progress.