### PR TITLE
Use wrap errors and update tests

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -131,7 +131,7 @@ type annotationError struct {
 }
 
 func (e *annotationError) Error() string {
-	return fmt.Sprintf("%+v", e.err)
+	return e.err.Error()
 }
 
 // Unwrap the wrapped error.

--- a/annotated.go
+++ b/annotated.go
@@ -131,7 +131,12 @@ type annotationError struct {
 }
 
 func (e *annotationError) Error() string {
-	return e.err.Error()
+	return fmt.Sprintf("%+v", e.err)
+}
+
+// Unwrap the wrapped error.
+func (e *annotationError) Unwrap() error {
+	return e.err
 }
 
 type paramTagsAnnotation struct {

--- a/app.go
+++ b/app.go
@@ -762,7 +762,7 @@ type withTimeoutParams struct {
 }
 
 // errHookCallbackExited is returned when a hook callback does not finish executing
-var errHookCallbackExited = fmt.Errorf("goroutine exited without returning")
+var errHookCallbackExited = errors.New("goroutine exited without returning")
 
 func withTimeout(ctx context.Context, param *withTimeoutParams) error {
 	c := make(chan error, 1)

--- a/app_internal_test.go
+++ b/app_internal_test.go
@@ -21,6 +21,7 @@
 package fx
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -104,4 +105,14 @@ func (o withClockOption) apply(m *module) {
 
 func (o withClockOption) String() string {
 	return fmt.Sprintf("WithClock(%v)", o.clock)
+}
+
+func TestAnnotationError(t *testing.T) {
+	wantErr := errors.New("want error")
+	err := &annotationError{
+		err: wantErr,
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), wantErr.Error())
 }

--- a/provide.go
+++ b/provide.go
@@ -131,18 +131,18 @@ func runProvide(c container, p provide, opts ...dig.ProvideOption) error {
 	case annotationError:
 		// fx.Annotate failed. Turn it into an Fx error.
 		return fmt.Errorf(
-			"encountered error while applying annotation using fx.Annotate to %s: %+v",
+			"encountered error while applying annotation using fx.Annotate to %s: %w",
 			fxreflect.FuncName(constructor.target), constructor.err)
 
 	case annotated:
 		ctor, err := constructor.Build()
 		if err != nil {
-			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", constructor, p.Stack, err)
+			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %w", constructor, p.Stack, err)
 		}
 
 		opts = append(opts, dig.LocationForPC(constructor.FuncPtr))
 		if err := c.Provide(ctor, opts...); err != nil {
-			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", constructor, p.Stack, err)
+			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %w", constructor, p.Stack, err)
 		}
 
 	case Annotated:
@@ -159,7 +159,7 @@ func runProvide(c container, p provide, opts ...dig.ProvideOption) error {
 		}
 
 		if err := c.Provide(ann.Target, opts...); err != nil {
-			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", ann, p.Stack, err)
+			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %w", ann, p.Stack, err)
 		}
 
 	default:
@@ -180,7 +180,7 @@ func runProvide(c container, p provide, opts ...dig.ProvideOption) error {
 		}
 
 		if err := c.Provide(constructor, opts...); err != nil {
-			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %v", fxreflect.FuncName(constructor), p.Stack, err)
+			return fmt.Errorf("fx.Provide(%v) from:\n%+vFailed: %w", fxreflect.FuncName(constructor), p.Stack, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Use wrap error verb (`%w`) in some `fmt.Errorf` calls and update some test to avoid confusion about how to get errors and compared them. 

This resolves #988