### PR TITLE
Fix lint error in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No changes yet.
 
 ## [1.19.1](https://github.com/uber-go/fx/compare/v1.18.0...v1.19.1) - 2023-01-10
+
 ### Changed
 - Calling `fx.Stop()` after the `App` has already stopped no longer errors out.
 
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after running for startTimeout duration.
 
 ## [1.19.0](https://github.com/uber-go/fx/compare/v1.18.2...v1.19.0) - 2023-01-03
+
 ### Added
 - `fx.RecoverFromPanics` Option which allows Fx to recover from user-provided constructors
   and invoked functions.

--- a/docs/get-started/http-server.md
+++ b/docs/get-started/http-server.md
@@ -119,7 +119,6 @@ and it will stop running when the application receives a stop signal.
 We used `fx.Invoke` to request that the HTTP server is always instantiated,
 even if none of the other components in the application reference it directly.
 
-
 **Related Resources**
 
 * [Application lifecycle](/lifecycle.md) further explains what Fx lifecycles are,


### PR DESCRIPTION
When we run make lint on the repo, the documentation check (mdox CLI) fails with error :

``` error: fmt command failed: files not formatted: ``` 
<img width="643" alt="Screenshot 2023-03-03 at 11 56 44 AM" src="https://user-images.githubusercontent.com/108087018/222814480-eab0e480-44d6-4b83-9da5-4f14f5cc0948.png">

as the files `fx/docs/changelog.md` and `fx/docs/get-started/http-server.md` are not correctly formatted.

This change adds an extra line after line 16 &  24 in `fx/CHANGELOG.md` and removes an extra line at line 122 in `fx/docs/get-started/http-server.md`