### PR TITLE
Allow fx.Annotate on In/Out structs with ResultTags/ParamTags, respectively

### DIFF
--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -19,8 +19,10 @@ without manually wrapping the function to use
 
 A function that:
 
-- does not accept a [parameter object](parameter-objects.md)
-- does not return a [result object](result-objects.md)
+- does not accept a [parameter object](parameter-objects.md), when 
+  annotating with `fx.ParamTags`.
+- does not return a [result object](result-objects.md) when annotating
+  with `fx.ResultTags`.
 
 **Steps**
 


### PR DESCRIPTION
It is currently not possible for fx.Annotate to be used on a function that takes in or returns fx.In and fx.Out structs.

This limitation, however, is not necessary when the annotation is different from the struct defined annotations, such as using fx.In with fx.ResultTags Annotation or fx.Out with fx.ParamTags Annotation.

This loosens the constraint so that these combinations of Annotations become valid.

Fixes #980.