### PR TITLE
Make sure Stop hooks are executed when Start times out on a long-running Start hook

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -265,7 +265,7 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	}
 
 	l.mu.Lock()
-	if l.state != started && l.state != incompleteStart {
+	if l.state != started && l.state != incompleteStart && l.state != starting {
 		defer l.mu.Unlock()
 		return nil
 	}


### PR DESCRIPTION
Currently, none of Stop hooks are run if app.Start fails with a timeout, and app's lifecycle
is stuck on waiting for a long-running Start hook to finish executing. While we cannot run Stop
hook for the long-running Start hook that caused the timeout, we can still run rest of the Stop
hooks for the Start hooks that finished running.

In this PR, this is done by just easing up the requirement for running Stop hooks to include
lifecycle's `starting` state. Ideally the app's lifecycle state should transition into
`incompleteStart` when a long-running Start hook causes the context to timeout and does
not respect the context expiration. However, this requires a bigger refactor so that all 
lifecycle hook invocations are made asynchronous.

Fixes #1035
