### PR TITLE
Fix race test for Start/Stop hooks

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1236,8 +1236,7 @@ func TestAppStart(t *testing.T) {
 			firstStart  bool
 			secondStart bool
 
-			firstStop  bool
-			secondStop bool
+			firstStop bool
 		)
 		app := New(
 			Invoke(func(lc Lifecycle) {
@@ -1263,7 +1262,6 @@ func TestAppStart(t *testing.T) {
 						return nil
 					},
 					OnStop: func(context.Context) error {
-						secondStop = true
 						time.Sleep(10 * time.Millisecond)
 						return nil
 					},
@@ -1278,9 +1276,8 @@ func TestAppStart(t *testing.T) {
 		require.NoError(t, app.Stop(context.Background()))
 
 		assert.True(t, firstStart)
-		assert.True(t, secondStart) // this should eventually run.
-		assert.True(t, firstStop)   // this should eventually run.
-		assert.False(t, secondStop) // this shouldn't be run since context timed out before second start hook finished running.
+		assert.True(t, secondStart)
+		assert.True(t, firstStop)
 	})
 
 	t.Run("CtxTimeoutDuringStartStillRunsStopHooks", func(t *testing.T) {


### PR DESCRIPTION
The race test that was added in Start/Stop hooks in #1062. This test can fail if the machine is sufficiently slow that the second Stop hook does not finish running before the test finishes.

This removes the check for the second hook from running - this is still adequately testing the code path we wanted to test since the race would occur on the first stop hook with the second start hook.