### PR TITLE
Test recent race with a channel-based test

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1236,17 +1236,7 @@ func TestAppStart(t *testing.T) {
 		firstStop   := make(chan struct{})
 		startReturn := make(chan struct{})
 
-		// Step 1: Start is called
-		// - start hook 1 finishes
-		// - start hook 2 begins
-		// Step 2: Stop is called
-		// - stop hook 1 begins
-		// - start hook 2 finishes
-		// - stop hook 1 finishes
-		// Step 3: If the race still exists, stop hook 1 will then run again
-
 		var stop1Run bool
-
 		app := New(
 			Invoke(func(lc Lifecycle) {
 				lc.Append(Hook{

--- a/app_test.go
+++ b/app_test.go
@@ -1233,7 +1233,7 @@ func TestAppStart(t *testing.T) {
 		t.Parallel()
 
 		secondStart := make(chan struct{})
-		firstStop   := make(chan struct{})
+		firstStop := make(chan struct{})
 		startReturn := make(chan struct{})
 
 		var stop1Run bool
@@ -1256,13 +1256,12 @@ func TestAppStart(t *testing.T) {
 				lc.Append(Hook{
 					OnStart: func(context.Context) error {
 						time.Sleep(time.Millisecond * 100)
-						fmt.Println("closing secondStart")
 						close(secondStart)
 						<-firstStop
 						return nil
 					},
 					OnStop: func(context.Context) error {
-						assert.Fail(t, "Stop should be called before " +
+						assert.Fail(t, "Stop should be called before "+
 							"start hook 2 finishes")
 						return nil
 					},

--- a/app_test.go
+++ b/app_test.go
@@ -1255,7 +1255,6 @@ func TestAppStart(t *testing.T) {
 				})
 				lc.Append(Hook{
 					OnStart: func(context.Context) error {
-						time.Sleep(time.Millisecond * 100)
 						close(secondStart)
 						<-firstStop
 						return nil

--- a/app_test.go
+++ b/app_test.go
@@ -1260,8 +1260,8 @@ func TestAppStart(t *testing.T) {
 						return nil
 					},
 					OnStop: func(context.Context) error {
-						assert.Fail(t, "Stop should be called before "+
-							"start hook 2 finishes")
+						assert.Fail(t, "Stop hook 2 should not be called "+
+							"if start hook 2 does not finish")
 						return nil
 					},
 				})

--- a/app_test.go
+++ b/app_test.go
@@ -1232,9 +1232,9 @@ func TestAppStart(t *testing.T) {
 	t.Run("race test", func(t *testing.T) {
 		t.Parallel()
 
-		secondStart := make(chan struct{})
-		firstStop := make(chan struct{})
-		startReturn := make(chan struct{})
+		secondStart := make(chan struct{}, 1)
+		firstStop := make(chan struct{}, 1)
+		startReturn := make(chan struct{}, 1)
 
 		var stop1Run bool
 		app := New(

--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -19,7 +19,7 @@ without manually wrapping the function to use
 
 A function that:
 
-- does not accept a [parameter object](parameter-objects.md), when 
+- does not accept a [parameter object](parameter-objects.md), when
   annotating with `fx.ParamTags`.
 - does not return a [result object](result-objects.md) when annotating
   with `fx.ResultTags`.


### PR DESCRIPTION
#1062 introduced a test for fixing a race condition introduced by #1061. #1063 tuned this race condition because it was failing on Windows machines. This PR changes the test to use channels instead of relying on timing to provide more deterministic reproduction of the race, with the caveat being that it's not triggered by context timeout or cancel anymore.

I have verified that this consistently fails pre-#1062 and consistently passes post-#1062.