### PR TITLE
Disallow using In/Out structs with From/As annotations

### DIFF
--- a/annotated.go
+++ b/annotated.go
@@ -1138,7 +1138,7 @@ var _ Annotation = (*asAnnotation)(nil)
 //	  return w, r
 //	}
 //
-// As annotation cannot be used in a function that returns an fx.Out struct as a return type.
+// As annotation cannot be used in a function that returns an [Out] struct as a return type.
 func As(interfaces ...interface{}) Annotation {
 	return &asAnnotation{targets: interfaces}
 }
@@ -1325,7 +1325,7 @@ var _ Annotation = (*fromAnnotation)(nil)
 //	  return NewRunnerWraps(r1, r2)
 //	})
 //
-// From annotation cannot be used in a function that takes an fx.In struct as a
+// From annotation cannot be used in a function that takes an [In] struct as a
 // parameter.
 func From(interfaces ...interface{}) Annotation {
 	return &fromAnnotation{targets: interfaces}
@@ -1596,7 +1596,7 @@ func (ann *annotated) cleanUpAsResults() {
 }
 
 // checks and returns a non-nil error if the target function:
-// - returns an fx.Out struct as a result and has either of ResultTags or As annotation
+// - returns an fx.Out struct as a result and has either a ResultTags or an As annotation
 // - takes in an fx.In struct as a parameter and has either of ParamTags or From annotation
 // - has an error result not as the last result.
 func (ann *annotated) typeCheckOrigFn() error {
@@ -1617,7 +1617,7 @@ func (ann *annotated) typeCheckOrigFn() error {
 			continue
 		}
 		if len(ann.ResultTags) > 0 || len(ann.As) > 0 {
-			return errors.New("fx.Out structs cannot be annotated with either of fx.ResultTags or fx.As")
+			return errors.New("fx.Out structs cannot be annotated with fx.ResultTags or fx.As")
 		}
 	}
 	for i := 0; i < ft.NumIn(); i++ {
@@ -1629,7 +1629,7 @@ func (ann *annotated) typeCheckOrigFn() error {
 			continue
 		}
 		if len(ann.ParamTags) > 0 || len(ann.From) > 0 {
-			return errors.New("fx.In structs cannot be annotated with either of fx.ParamTags or fx.From")
+			return errors.New("fx.In structs cannot be annotated with fx.ParamTags or fx.From")
 		}
 	}
 	return nil

--- a/annotated.go
+++ b/annotated.go
@@ -1137,9 +1137,8 @@ var _ Annotation = (*asAnnotation)(nil)
 //	  w, r := a()
 //	  return w, r
 //	}
-// 
-// As annotation cannot be used in a function that takes an fx.In struct as a
-// parameter or returns an fx.Out struct as a return type.
+//
+// As annotation cannot be used in a function that returns an fx.Out struct as a return type.
 func As(interfaces ...interface{}) Annotation {
 	return &asAnnotation{targets: interfaces}
 }
@@ -1327,7 +1326,7 @@ var _ Annotation = (*fromAnnotation)(nil)
 //	})
 //
 // From annotation cannot be used in a function that takes an fx.In struct as a
-// parameter or returns an fx.Out struct as a return type.
+// parameter.
 func From(interfaces ...interface{}) Annotation {
 	return &fromAnnotation{targets: interfaces}
 }
@@ -1597,8 +1596,8 @@ func (ann *annotated) cleanUpAsResults() {
 }
 
 // checks and returns a non-nil error if the target function:
-// - returns an fx.Out struct as a result and has either of ResultTags, As or From annotation
-// - takes in an fx.In struct as a parameter and has either of ParamTags, As or From annotation
+// - returns an fx.Out struct as a result and has either of ResultTags or As annotation
+// - takes in an fx.In struct as a parameter and has either of ParamTags or From annotation
 // - has an error result not as the last result.
 func (ann *annotated) typeCheckOrigFn() error {
 	ft := reflect.TypeOf(ann.Target)
@@ -1617,12 +1616,10 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if !dig.IsOut(reflect.New(ft.Out(i)).Elem().Interface()) {
 			continue
 		}
-		if len(ann.ResultTags) > 0 || len(ann.As) > 0 || len(ann.From) > 0 {
-			return errors.New("fx.Out structs cannot be annotated with either of fx.ResultTags, fx.As or fx.From")
+		if len(ann.ResultTags) > 0 || len(ann.As) > 0 {
+			return errors.New("fx.Out structs cannot be annotated with either of fx.ResultTags or fx.As")
 		}
-		
 	}
-
 	for i := 0; i < ft.NumIn(); i++ {
 		it := ft.In(i)
 		if it.Kind() != reflect.Struct {
@@ -1631,8 +1628,8 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if !dig.IsIn(reflect.New(ft.In(i)).Elem().Interface()) {
 			continue
 		}
-		if len(ann.ParamTags) > 0 || len(ann.As) > 0 || len(ann.From) > 0 {
-			return errors.New("fx.In structs cannot be annotated with either of fx.ParamTags, fx.As or fx.From")
+		if len(ann.ParamTags) > 0 || len(ann.From) > 0 {
+			return errors.New("fx.In structs cannot be annotated with either of fx.ParamTags or fx.From")
 		}
 	}
 	return nil

--- a/annotated.go
+++ b/annotated.go
@@ -1597,7 +1597,7 @@ func (ann *annotated) cleanUpAsResults() {
 
 // checks and returns a non-nil error if the target function:
 // - returns an fx.Out struct as a result and has either a ResultTags or an As annotation
-// - takes in an fx.In struct as a parameter and has either of ParamTags or From annotation
+// - takes in an fx.In struct as a parameter and has either a ParamTags or a From annotation
 // - has an error result not as the last result.
 func (ann *annotated) typeCheckOrigFn() error {
 	ft := reflect.TypeOf(ann.Target)

--- a/annotated.go
+++ b/annotated.go
@@ -1137,6 +1137,9 @@ var _ Annotation = (*asAnnotation)(nil)
 //	  w, r := a()
 //	  return w, r
 //	}
+// 
+// As annotation cannot be used in a function that takes an fx.In struct as a
+// parameter or returns an fx.Out struct as a return type.
 func As(interfaces ...interface{}) Annotation {
 	return &asAnnotation{targets: interfaces}
 }
@@ -1322,6 +1325,9 @@ var _ Annotation = (*fromAnnotation)(nil)
 //	fx.Provide(func(r1 *FooRunner, r2 *BarRunner) *RunnerWraps {
 //	  return NewRunnerWraps(r1, r2)
 //	})
+//
+// From annotation cannot be used in a function that takes an fx.In struct as a
+// parameter or returns an fx.Out struct as a return type.
 func From(interfaces ...interface{}) Annotation {
 	return &fromAnnotation{targets: interfaces}
 }
@@ -1591,8 +1597,8 @@ func (ann *annotated) cleanUpAsResults() {
 }
 
 // checks and returns a non-nil error if the target function:
-// - returns an fx.Out struct as a result.
-// - takes in an fx.In struct as a parameter.
+// - returns an fx.Out struct as a result and has either of ResultTags, As or From annotation
+// - takes in an fx.In struct as a parameter and has either of ParamTags, As or From annotation
 // - has an error result not as the last result.
 func (ann *annotated) typeCheckOrigFn() error {
 	ft := reflect.TypeOf(ann.Target)
@@ -1608,9 +1614,13 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if ot.Kind() != reflect.Struct {
 			continue
 		}
-		if len(ann.ResultTags) > 0 && dig.IsOut(reflect.New(ft.Out(i)).Elem().Interface()) {
-			return errors.New("fx.Out structs cannot be annotated with fx.ResultTags")
+		if !dig.IsOut(reflect.New(ft.Out(i)).Elem().Interface()) {
+			continue
 		}
+		if len(ann.ResultTags) > 0 || len(ann.As) > 0 || len(ann.From) > 0 {
+			return errors.New("fx.Out structs cannot be annotated with either of fx.ResultTags, fx.As or fx.From")
+		}
+		
 	}
 
 	for i := 0; i < ft.NumIn(); i++ {
@@ -1618,8 +1628,11 @@ func (ann *annotated) typeCheckOrigFn() error {
 		if it.Kind() != reflect.Struct {
 			continue
 		}
-		if len(ann.ParamTags) > 0 && dig.IsIn(reflect.New(ft.In(i)).Elem().Interface()) {
-			return errors.New("fx.In structs cannot be annotated with fx.ParamTags")
+		if !dig.IsIn(reflect.New(ft.In(i)).Elem().Interface()) {
+			continue
+		}
+		if len(ann.ParamTags) > 0 || len(ann.As) > 0 || len(ann.From) > 0 {
+			return errors.New("fx.In structs cannot be annotated with either of fx.ParamTags, fx.As or fx.From")
 		}
 	}
 	return nil

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1448,7 +1448,7 @@ func TestAnnotate(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags, fx.As or fx.From")
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags or fx.As")
 	})
 
 	t.Run("annotate a fx.Out with As", func(t *testing.T) {
@@ -1478,7 +1478,7 @@ func TestAnnotate(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags, fx.As or fx.From")
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags or fx.As")
 	})
 
 	t.Run("annotate a fx.In with ParamTags", func(t *testing.T) {
@@ -1501,7 +1501,7 @@ func TestAnnotate(t *testing.T) {
 		require.Error(t, err)
 		assert.NotContains(t, err.Error(), "invalid annotation function func(fx_test.A) string")
 		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.B) string")
-		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags, fx.As or fx.From")
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags or fx.From")
 	})
 
 	t.Run("annotate a fx.In with From", func(t *testing.T) {
@@ -1526,7 +1526,7 @@ func TestAnnotate(t *testing.T) {
 		err := app.Err()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.Param) string")
-		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags, fx.As or fx.From")
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags or fx.From")
 	})
 
 	t.Run("annotate fx.In with fx.ResultTags", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1478,7 +1478,7 @@ func TestAnnotate(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags or fx.As")
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with fx.ResultTags or fx.As")
 	})
 
 	t.Run("annotate a fx.In with ParamTags", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1427,7 +1427,7 @@ func TestAnnotate(t *testing.T) {
 		assert.Contains(t, err.Error(), "must provide constructor function, got 42 (int)")
 	})
 
-	t.Run("annotate a fx.Out", func(t *testing.T) {
+	t.Run("annotate a fx.Out with ResultTags", func(t *testing.T) {
 		t.Parallel()
 
 		type A struct {
@@ -1448,10 +1448,40 @@ func TestAnnotate(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated")
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags, fx.As or fx.From")
 	})
 
-	t.Run("annotate a fx.In", func(t *testing.T) {
+	t.Run("annotate a fx.Out with As", func(t *testing.T) {
+		t.Parallel()
+
+		type I interface{}
+
+		type B struct {
+			// implents I
+		}
+
+		type Res struct {
+			fx.Out
+
+			AB B
+		}
+
+		f := func() Res {
+			return Res{AB: B{}}
+		}
+
+		app := NewForTest(t,
+			fx.Provide(
+				fx.Annotate(f, fx.As(new(I))),
+			),
+		)
+
+		err := app.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags, fx.As or fx.From")
+	})
+
+	t.Run("annotate a fx.In with ParamTags", func(t *testing.T) {
 		t.Parallel()
 
 		type A struct {
@@ -1471,7 +1501,32 @@ func TestAnnotate(t *testing.T) {
 		require.Error(t, err)
 		assert.NotContains(t, err.Error(), "invalid annotation function func(fx_test.A) string")
 		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.B) string")
-		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated")
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags, fx.As or fx.From")
+	})
+
+	t.Run("annotate a fx.In with From", func(t *testing.T) {
+		t.Parallel()
+
+		type I interface{}
+
+		type B struct {
+			// implements I
+		}
+
+		type Param struct {
+			fx.In
+			BInterface I
+		}
+
+		app := NewForTest(t,
+			fx.Provide(
+				fx.Annotate(func(p Param) string { return "ok" }, fx.From(new(B))),
+			),
+		)
+		err := app.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.Param) string")
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags, fx.As or fx.From")
 	})
 
 	t.Run("annotate fx.In with fx.ResultTags", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1448,7 +1448,7 @@ func TestAnnotate(t *testing.T) {
 
 		err := app.Err()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with either of fx.ResultTags or fx.As")
+		assert.Contains(t, err.Error(), "fx.Out structs cannot be annotated with fx.ResultTags or fx.As")
 	})
 
 	t.Run("annotate a fx.Out with As", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1501,7 +1501,7 @@ func TestAnnotate(t *testing.T) {
 		require.Error(t, err)
 		assert.NotContains(t, err.Error(), "invalid annotation function func(fx_test.A) string")
 		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.B) string")
-		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags or fx.From")
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with fx.ParamTags or fx.From")
 	})
 
 	t.Run("annotate a fx.In with From", func(t *testing.T) {

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1457,7 +1457,7 @@ func TestAnnotate(t *testing.T) {
 		type I interface{}
 
 		type B struct {
-			// implents I
+			// implements I
 		}
 
 		type Res struct {
@@ -1526,7 +1526,7 @@ func TestAnnotate(t *testing.T) {
 		err := app.Err()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid annotation function func(fx_test.Param) string")
-		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with either of fx.ParamTags or fx.From")
+		assert.Contains(t, err.Error(), "fx.In structs cannot be annotated with fx.ParamTags or fx.From")
 	})
 
 	t.Run("annotate fx.In with fx.ResultTags", func(t *testing.T) {


### PR DESCRIPTION
In https://github.com/uber-go/fx/pull/1053, we eased up the requirement for function signature for applying annotations to allow using In/Out structs with ResultTags/ParamTags. This had an unintended change in behavior where users are now able to use In/Out structs with From/As annotations. For example, the below code used to error out:

> type Foo interface { ... }
> type Bar struct { ... } // Bar implements Foo
> struct Res {
>   fx.Out
> 
>   ABar Bar
> }
> fx.Annotate(
>   func() Res { ... },
>   fx.As(new(Foo)),
> )

Currently the code above applies the As annotation to ABar field and transforms the target function's signature accordingly. However, this was an unintended change in behavior, and we should have a design discussion about whether we actually want this before cutting a new release. Since it will require a breaking change to disable this after a new release is cut, I think the safe approach is to disable this for now and enable it after having decided that this is indeed what we want.

Fixes #1060