### PR TITLE
typo: getting-started docs

### DIFF
--- a/docs/get-started/minimal.md
+++ b/docs/get-started/minimal.md
@@ -42,7 +42,7 @@ This application won't do anything yet except print a bunch of logs.
 
 **What did we just do?**
 
-We build an empty Fx application by calling `fx.New` with no arguments.
+We built an empty Fx application by calling `fx.New` with no arguments.
 Applications will normally pass arguments to `fx.New` to set up their
 components.
 


### PR DESCRIPTION
"We build an" -> "We built an"  (past tense)