### PR TITLE
coverage: Don't count e2e test code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,6 @@
 ignore:
   - "docs/ex/**/*.go"
+  - "internal/e2e/**/*.go"
 
 coverage:
   range: 80..100


### PR DESCRIPTION
Don't count code for end-to-end tests
towards or against coverage.

These files are real-looking code in service of tests, and are not shipped as part of Fx.