### PR TITLE
TestDataRace: Fix leak

### DIFF
--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -138,7 +138,7 @@ func TestDataRace(t *testing.T) {
 		t,
 		fx.Populate(&s),
 	)
-	require.NoError(t, app.Start(context.Background()), "error starting app")
+	defer app.RequireStart().RequireStop()
 
 	const N = 50
 	ready := make(chan struct{}) // used to orchestrate goroutines for Done() and ShutdownOption()


### PR DESCRIPTION
TestDataRace never calls App.Stop, which can cause a resource leak.
This currently passes because of the implementation detail that
Shutdowner.Shutdown happens to call signalReceivers.Stop
instead of just Shutdown, which may not always be true.
