### PR TITLE
Make fx.Populate work with fx.Annotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No changes yet.
 
 ## [1.19.3](https://github.com/uber-go/fx/compare/v1.19.2...v1.19.3) - 2023-04-17
+
 ### Changed
 - Fixed several typos in docs.
 - WASM build support.

--- a/populate.go
+++ b/populate.go
@@ -30,6 +30,34 @@ import (
 // values that must be populated. Pointers to structs that embed In are
 // supported, which can be used to populate multiple values in a struct.
 //
+// Annotating each pointer with ParamTags is also supported as a shorthand
+// to passing a pointer to a struct that embeds In with field tags. For example:
+//
+//	 var a A
+//	 var b B
+//	 fx.Populate(
+//		fx.Annotate(
+//				&a,
+//				fx.ParamTags(`name:"A"`)
+//	 	),
+//		fx.Annotate(
+//				&b,
+//				fx.ParamTags(`name:"B"`)
+//	 	)
+//	 )
+//
+// Code above is equivalent to the following:
+//
+//	type Target struct {
+//		fx.In
+//
+//		a A `name:"A"`
+//		b B `name:"B"`
+//	}
+//	var target Target
+//	...
+//	fx.Populate(&target)
+//
 // This is most helpful in unit tests: it lets tests leverage Fx's automatic
 // constructor wiring to build a few structs, but then extract those structs
 // for further testing.
@@ -49,12 +77,11 @@ func Populate(targets ...interface{}) Option {
 			rt  reflect.Type
 			tag reflect.StructTag
 		)
-		switch t.(type) {
+		switch t := t.(type) {
 		case annotated:
-			ann := t.(annotated)
-			rt = reflect.TypeOf(ann.Target)
-			tag = reflect.StructTag(ann.ParamTags[0])
-			targets[i] = ann.Target
+			rt = reflect.TypeOf(t.Target)
+			tag = reflect.StructTag(t.ParamTags[0])
+			targets[i] = t.Target
 		default:
 			rt = reflect.TypeOf(t)
 		}

--- a/populate_test.go
+++ b/populate_test.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.uber.org/fx"
 	. "go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 )
@@ -200,11 +198,11 @@ func TestPopulate(t *testing.T) {
 		var v1, v2 *t1
 		app := fxtest.New(t,
 			Provide(
-				fx.Annotate(
+				Annotate(
 					func() (*t1, *t1) {
 						return &t1{}, &t1{}
 					},
-					fx.ResultTags(`name:"n1"`, `name:"n2"`),
+					ResultTags(`name:"n1"`, `name:"n2"`),
 				),
 			),
 			Populate(

--- a/populate_test.go
+++ b/populate_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.uber.org/fx"
 	. "go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 )
@@ -175,6 +176,37 @@ func TestPopulate(t *testing.T) {
 					V2: &t1{},
 				}
 			}),
+			Populate(
+				Annotate(
+					&v1,
+					ParamTags(`name:"n1"`),
+				),
+				Annotate(
+					&v2,
+					ParamTags(`name:"n2"`),
+				),
+			),
+		)
+		app.RequireStart().RequireStop()
+
+		require.NotNil(t, v1, "did not populate argument 1")
+		require.NotNil(t, v2, "did not populate argument 2")
+		// Cannot use assert.Equal here as we want to compare pointers.
+		assert.False(t, v1 == v2, "values should be different")
+	})
+
+	t.Run("annotated populate with annotated provide", func(t *testing.T) {
+		t.Parallel()
+		var v1, v2 *t1
+		app := fxtest.New(t,
+			Provide(
+				fx.Annotate(
+					func() (*t1, *t1) {
+						return &t1{}, &t1{}
+					},
+					fx.ResultTags(`name:"n1"`, `name:"n2"`),
+				),
+			),
 			Populate(
 				Annotate(
 					&v1,

--- a/populate_test.go
+++ b/populate_test.go
@@ -158,6 +158,42 @@ func TestPopulate(t *testing.T) {
 		assert.False(t, targets.V1 == targets.V2, "fields should be different")
 	})
 
+	t.Run("annotated populate", func(t *testing.T) {
+		t.Parallel()
+
+		type result struct {
+			Out
+
+			V1 *t1 `name:"n1"`
+			V2 *t1 `name:"n2"`
+		}
+		var v1, v2 *t1
+		app := fxtest.New(t,
+			Provide(func() result {
+				return result{
+					V1: &t1{},
+					V2: &t1{},
+				}
+			}),
+			Populate(
+				Annotate(
+					&v1,
+					ParamTags(`name:"n1"`),
+				),
+				Annotate(
+					&v2,
+					ParamTags(`name:"n2"`),
+				),
+			),
+		)
+		app.RequireStart().RequireStop()
+
+		require.NotNil(t, v1, "did not populate argument 1")
+		require.NotNil(t, v2, "did not populate argument 2")
+		// Cannot use assert.Equal here as we want to compare pointers.
+		assert.False(t, v1 == v2, "values should be different")
+	})
+
 	t.Run("populate group", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
This PR makes fx.Populate work with fx.Annotate. Previously, to fx.Populate a
named dependency, users would have to create a struct that embeds fx.In and has
a field with a tag and pass a pointer to that struct. This could be cumbersome
in cases where the user is intersted in only one named value. With this PR,
users will be able to use fx.Annotate to get the same effect:

```
var a A
...
fx.Populate(
  fx.Annotate(
    &a,
    fx.ParamTags(`name:"A"`),
  ),
)
```
