### PR TITLE
ci: Use golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,14 +14,12 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    name: Build and test
+
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         go: ["1.20.x", "1.21.x"]
-        include:
-        - go: 1.21.x
-          os: "ubuntu-latest"
-          latest: true
 
     steps:
     - name: Checkout code
@@ -31,21 +29,51 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
-        cache: true
 
     - name: Download Dependencies
       run: go mod download
 
-    - name: Lint
-      if: matrix.latest
-      run: make lint
-
     - name: Test
       run: make cover
 
-    - name: Test documentation
-      run: make cover COVER_MODULES=./docs
-      if: matrix.latest
-
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
+
+  doctest:
+    runs-on: ubuntu-latest
+    name: Test documentation
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.21.x
+
+    - name: Test
+      run: make cover COVER_MODULES=./docs
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.21.x
+        cache: false  # managed by golangci-lint
+
+    - uses: golangci/golangci-lint-action@v3
+      name: Install golangci-lint
+      with:
+        version: latest
+        args: --version  # make lint will run the linter
+
+    - run: make lint
+      name: Lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,70 @@
+output:
+  # Make output more digestible with quickfix in vim/emacs/etc.
+  sort-results: true
+  print-issued-lines: false
+
+linters:
+  # We'll track the golangci-lint default linters manually
+  # instead of letting them change without our control.
+  disable-all: true
+  enable:
+    # golangci-lint defaults:
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+    # Our own extras:
+    - gofumpt
+    - nolintlint # lints nolint directives
+    - revive
+    - errorlint
+
+linters-settings:
+  govet:
+    # These govet checks are disabled by default, but they're useful.
+    enable:
+      - niliness
+      - reflectvaluecompare
+      - sortslice
+      - unusedwrite
+
+issues:
+  # Print all issues reported by all linters.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Don't ignore some of the issues that golangci-lint considers okay.
+  # This includes documenting all exported entities.
+  exclude-use-default: false
+
+  exclude-rules:
+    # Don't warn on unused parameters.
+    # Parameter names are useful; replacing them with '_' is undesirable.
+    - linters: [revive]
+      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+
+    # staticcheck already has smarter checks for empty blocks.
+    # revive's empty-block linter has false positives.
+    # For example, as of writing this, the following is not allowed.
+    #   for foo() { }
+    - linters: [revive]
+      text: 'empty-block: this block is empty, you can remove it'
+
+    # It's okay if internal packages and examples in docs/
+    # don't have package comments.
+    - linters: [revive]
+      path: '.+/internal/.+|^internal/.+|^docs/.+'
+      text: 'should have a package comment'
+
+    # It's okay for tests to use dot imports.
+    - linters: [revive]
+      path: '_test\.go$'
+      text: 'should not use dot imports'
+
+    # Ignore logger.Sync() errcheck failures in example_test.go
+    # since those are intended to be uncomplicated examples.
+    - linters: [errcheck]
+      path: example_test.go
+      text: 'Error return value of `logger.Sync` is not checked'

--- a/annotated.go
+++ b/annotated.go
@@ -178,7 +178,6 @@ func verifyValueQuote(value string) (string, error) {
 		return "", errTagValueSyntaxEndingQuote
 	}
 	return value[i+1:], nil
-
 }
 
 // Check whether the tag follows valid struct.
@@ -211,7 +210,6 @@ func verifyAnnotateTag(tag string) error {
 		tag = value
 	}
 	return nil
-
 }
 
 // Given func(T1, T2, T3, ..., TN), this generates a type roughly

--- a/annotated.go
+++ b/annotated.go
@@ -117,8 +117,8 @@ type Annotation interface {
 }
 
 var (
-	_typeOfError reflect.Type = reflect.TypeOf((*error)(nil)).Elem()
-	_nilError                 = reflect.Zero(_typeOfError)
+	_typeOfError = reflect.TypeOf((*error)(nil)).Elem()
+	_nilError    = reflect.Zero(_typeOfError)
 )
 
 // annotationError is a wrapper for an error that was encountered while
@@ -642,8 +642,8 @@ func (la *lifecycleHookAnnotation) build(ann *annotated) (interface{}, error) {
 }
 
 var (
-	_typeOfLifecycle reflect.Type = reflect.TypeOf((*Lifecycle)(nil)).Elem()
-	_typeOfContext   reflect.Type = reflect.TypeOf((*context.Context)(nil)).Elem()
+	_typeOfLifecycle = reflect.TypeOf((*Lifecycle)(nil)).Elem()
+	_typeOfContext   = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
 
 // buildHookInstaller returns a function that appends a hook to Lifecycle when called,

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -1701,8 +1701,8 @@ func TestAnnotateApplySuccess(t *testing.T) {
 			require.NoError(t, app.Err())
 		})
 	}
-
 }
+
 func assertApp(
 	t *testing.T,
 	app interface {

--- a/app.go
+++ b/app.go
@@ -547,8 +547,11 @@ func (err errorWithGraph) Error() string {
 
 // VisualizeError returns the visualization of the error if available.
 func VisualizeError(err error) (string, error) {
-	if e, ok := err.(errWithGraph); ok && e.Graph() != "" {
-		return string(e.Graph()), nil
+	var erg errWithGraph
+	if errors.As(err, &erg) {
+		if g := erg.Graph(); g != "" {
+			return string(g), nil
+		}
 	}
 	return "", errors.New("unable to visualize error")
 }

--- a/app_unixes.go
+++ b/app_unixes.go
@@ -25,5 +25,7 @@ package fx
 
 import "golang.org/x/sys/unix"
 
-const _sigINT = unix.SIGINT
-const _sigTERM = unix.SIGTERM
+const (
+	_sigINT  = unix.SIGINT
+	_sigTERM = unix.SIGTERM
+)

--- a/app_wasm.go
+++ b/app_wasm.go
@@ -25,5 +25,7 @@ package fx
 
 import "syscall"
 
-const _sigINT = syscall.SIGINT
-const _sigTERM = syscall.SIGTERM
+const (
+	_sigINT  = syscall.SIGINT
+	_sigTERM = syscall.SIGTERM
+)

--- a/app_windows.go
+++ b/app_windows.go
@@ -25,5 +25,7 @@ package fx
 
 import "golang.org/x/sys/windows"
 
-const _sigINT = windows.SIGINT
-const _sigTERM = windows.SIGTERM
+const (
+	_sigINT  = windows.SIGINT
+	_sigTERM = windows.SIGTERM
+)

--- a/decorate.go
+++ b/decorate.go
@@ -216,7 +216,7 @@ func runDecorator(c container, d decorator, opts ...dig.DecorateOption) (err err
 	decorator := d.Target
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("fx.Decorate(%v) from:\n%+vFailed: %v", decorator, d.Stack, err)
+			err = fmt.Errorf("fx.Decorate(%v) from:\n%+vFailed: %w", decorator, d.Stack, err)
 		}
 	}()
 

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -315,8 +315,7 @@ func TestDecorateSuccess(t *testing.T) {
 	})
 
 	t.Run("decoration must execute when required by a member of group", func(t *testing.T) {
-		type Drinks interface {
-		}
+		type Drinks interface{}
 		type Coffee struct {
 			Type  string
 			Name  string

--- a/fxevent/doc.go
+++ b/fxevent/doc.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package fxevent defines a means of changing how Fx logs internal events.
+//
+// # Changing the Logger
+//
+// By default, the [ConsoleLogger] is used, writing readable logs to stderr.
+//
+// You can use the fx.WithLogger option to change this behavior
+// by providing a constructor that returns an alternative implementation
+// of the [Logger] interface.
+//
+//	fx.WithLogger(func(cfg *Config) Logger {
+//		return &MyFxLogger{...}
+//	})
+//
+// Because WithLogger accepts a constructor,
+// you can pull any other types and values from inside the container,
+// allowing use of the same logger that your application uses.
+//
+// For example, if you're using Zap inside your application,
+// you can use the [ZapLogger] implementation of the interface.
+//
+//	fx.New(
+//		fx.Provide(
+//			zap.NewProduction, // provide a *zap.Logger
+//		),
+//		fx.WithLogger(
+//			func(log *zap.Logger) fxevent.Logger {
+//				return &fxevent.ZapLogger{Logger: log}
+//			},
+//		),
+//	)
+//
+// # Implementing a Custom Logger
+//
+// To implement a custom logger, you need to implement the [Logger] interface.
+// The Logger.LogEvent method accepts an [Event] object.
+//
+// [Event] is a union type that represents all the different events that Fx can emit.
+// You can use a type switch to handle each event type.
+// See 'event.go' for a list of all the possible events.
+//
+//	func (l *MyFxLogger) LogEvent(e fxevent.Event) {
+//		switch e := e.(type) {
+//		case *fxevent.OnStartExecuting:
+//			// ...
+//		// ...
+//		}
+//	}
+//
+// The events contain enough information for observability and debugging purposes.
+// If you need more information in them,
+// feel free to open an issue to discuss the addition.
+package fxevent

--- a/fxevent/zap_test.go
+++ b/fxevent/zap_test.go
@@ -71,7 +71,6 @@ func TestZapLogger(t *testing.T) {
 			},
 		},
 		{
-
 			name: "OnStopExecuted/Error",
 			give: &OnStopExecuted{
 				FunctionName: "hook.onStart1",
@@ -100,7 +99,6 @@ func TestZapLogger(t *testing.T) {
 			},
 		},
 		{
-
 			name: "OnStartExecuted/Error",
 			give: &OnStartExecuted{
 				FunctionName: "hook.onStart1",

--- a/fxtest/doc.go
+++ b/fxtest/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2024 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,20 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// fxlint is a linter that verifies correct usage of Fx.
-//
-// Currently, the following passes are provided:
-//
-// - allfxevents: Verifies that all Fx events are handled by an fxevent.Logger.
-package main
-
-import (
-	"go.uber.org/fx/tools/analysis/passes/allfxevents"
-	"golang.org/x/tools/go/analysis/multichecker"
-)
-
-func main() {
-	multichecker.Main(
-		allfxevents.Analyzer,
-	)
-}
+// Package fxtest provides utilities for testing Fx modules,
+// and code that directly uses Fx.
+package fxtest

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -195,7 +195,7 @@ func (l *Lifecycle) Start(ctx context.Context) error {
 	l.startRecords = make(HookRecords, 0, len(l.hooks))
 	l.mu.Unlock()
 
-	var returnState appState = incompleteStart
+	returnState := incompleteStart
 	defer func() {
 		l.mu.Lock()
 		l.state = returnState

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -329,7 +329,6 @@ func TestLifecycleStop(t *testing.T) {
 		err = l.Stop(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "called OnStop with nil context")
-
 	})
 }
 

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -320,13 +320,11 @@ func TestLifecycleStop(t *testing.T) {
 				return nil
 			},
 		})
-		//lint:ignore SA1012 this test specifically tests for the lint failure
-		err := l.Start(nil)
+		err := l.Start(nil) //nolint:staticcheck // SA1012 this test specifically tests for the lint failure
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "called OnStart with nil context")
 
-		//lint:ignore SA1012 this test specifically tests for the lint failure
-		err = l.Stop(nil)
+		err = l.Stop(nil) //nolint:staticcheck // SA1012 this test specifically tests for the lint failure
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "called OnStop with nil context")
 	})

--- a/invoke.go
+++ b/invoke.go
@@ -89,6 +89,7 @@ func (o invokeOption) String() string {
 	}
 	return fmt.Sprintf("fx.Invoke(%s)", strings.Join(items, ", "))
 }
+
 func runInvoke(c container, i invoke) error {
 	fn := i.Target
 	switch fn := fn.(type) {

--- a/module_test.go
+++ b/module_test.go
@@ -414,7 +414,7 @@ func TestModuleSuccess(t *testing.T) {
 
 		assert.Equal(t, []string{
 			"Supplied", "Provided", "Replaced", "Run", "Run", "LoggerInitialized",
-			//Invoke logged twice, once from child and another from grandchild
+			// Invoke logged twice, once from child and another from grandchild
 			"Invoking", "Run", "Invoked", "Invoking", "Invoked",
 		}, childSpy.EventTypes(), "events from grandchild also logged in child logger")
 

--- a/module_test.go
+++ b/module_test.go
@@ -234,12 +234,12 @@ func TestModuleSuccess(t *testing.T) {
 			}),
 			fx.Invoke(func(p *person) {
 				assert.Equal(t, 2, p.age)
-				p.age += 1
+				p.age++
 			}),
 			fx.Module("module",
 				fx.Invoke(func(p *person) {
 					assert.Equal(t, 1, p.age)
-					p.age += 1
+					p.age++
 				}),
 			),
 			fx.Invoke(func(p *person) {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,13 +4,10 @@ go 1.20
 
 require (
 	github.com/bwplotka/mdox v0.9.0
-	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/tools v0.17.0
-	honnef.co/go/tools v0.4.6
 )
 
 require (
-	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Kunde21/markdownfmt/v2 v2.1.1-0.20221212171616-95b15aa5ffe4 // indirect
 	github.com/PuerkitoBio/goquery v1.5.1 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
@@ -73,7 +70,7 @@ require (
 	github.com/theckman/yacspin v0.8.0 // indirect
 	github.com/yuin/goldmark v1.4.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
-	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -57,8 +57,6 @@ github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/Azure/go-autorest/tracing v0.1.0/go.mod h1:ROEEAFwXycQw7Sn3DXNtEedEvdeRAgDr0izn4z5Ij88=
 github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
-github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
@@ -721,8 +719,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a h1:Jw5wfR+h9mnIYH+OtGT2im5wV1YGGDora5vTv/aa5bE=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20191214001246-9130b4cfad52/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1111,8 +1107,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.4.6 h1:oFEHCKeID7to/3autwsWfnuv69j3NsfcXbvJKuIcep8=
-honnef.co/go/tools v0.4.6/go.mod h1:+rnGS1THNh8zMwnd2oVOTL9QF6vmfyG6ZXBULae2uc0=
 pack.ag/amqp v0.8.0/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 pack.ag/amqp v0.11.0/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -26,6 +26,4 @@ package fx
 import (
 	// Tools we use during development.
 	_ "github.com/bwplotka/mdox"
-	_ "golang.org/x/lint/golint"
-	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
**Commits are individually reviewable**

---

We've been using a hand-rolled lint setup for a while.
It's limiting, and so we've neglected to keep our lints up to date.

This PR switches to using golangci-lint to run linters.
staticcheck is included and enabled by default.
We add revive and a few others.

This also allows the linter to run in parallel with the tests.

See also uber-go/zap#1323 for a similar change to Zap.

Commits after the first one are fixes to the lints found by golangci-lint.
Some of these are:

- Files should be gofumpt-ed.

- Shouldn't add type in `var x T = y` when type of `y` is `T`.

    ```
    annotated.go:120:15: var-declaration: should omit type reflect.Type from declaration of var _typeOfError; it will be inferred from the right-hand side (revive)
    annotated.go:645:19: var-declaration: should omit type reflect.Type from declaration of var _typeOfLifecycle; it will be inferred from the right-hand side (revive)
    annotated.go:646:19: var-declaration: should omit type reflect.Type from declaration of var _typeOfContext; it will be inferred from the right-hand side (revive)
    internal/lifecycle/lifecycle.go:198:18: var-declaration: should omit type appState from declaration of var returnState; it will be inferred from the right-hand side (revive)
    ```

- Should use `errors.As` and `%w` when wrapping and unwrapping errors.

    ```
    app.go:550:14: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
    decorate.go:219:81: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
    ```

- All public packages should have doc comments.

- `x += 1` should be `x++`.

    ```
    module_test.go:237:5: increment-decrement: should replace p.age += 1 with p.age++ (revive)
    module_test.go:242:6: increment-decrement: should replace p.age += 1 with p.age++ (revive)
    ```
