### PR TITLE
doc(Decorate): Explain that decorators can not add new values to the graph

### DIFF
--- a/decorate.go
+++ b/decorate.go
@@ -123,6 +123,11 @@ import (
 //	  return r
 //	}),
 //
+// Decorators can not add new values to the graph,
+// only modify or replace existing ones.
+// Types returned by a decorator that are not already in the graph
+// will be ignored.
+//
 // # Decorator scope
 //
 // Modifications made to the Fx graph with fx.Decorate are scoped to the


### PR DESCRIPTION
I created #1144 because I was not sure whether a decorator
could add new values to the graph.

This clarifies the behavior.
We already have tests to verify this behavior.

Resolves #1144
