### PR TITLE
docs/sidebar: Move concepts before features

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -77,6 +77,14 @@ module.exports = {
       },
       'intro.md',
       {
+        title: 'Concepts',
+        children: [
+          'container.md',
+          ['lifecycle.md', 'Lifecycle'],
+          'modules.md',
+        ],
+      },
+      {
         title: 'Features',
         children: [
           'parameter-objects.md',
@@ -96,14 +104,6 @@ module.exports = {
               },
             ],
           },
-        ],
-      },
-      {
-        title: 'Concepts',
-        children: [
-          'container.md',
-          'lifecycle.md',
-          'modules.md',
         ],
       },
       ['faq.md', 'FAQ'],


### PR DESCRIPTION
In reading order, concepts like container and lifecycle
should come before we talk about parameter objects, value groups, etc.
(It's also okay to merge concepts and features, but I'm not doing that
here.)

Separately, make the lifecycle page appear as "Lifecycle" in the sidebar
while still having the title "Application Lifecycle".
