### PR TITLE
docs-lint: don't validate Fx compare links

### DIFF
--- a/docs/.mdox-validate.yaml
+++ b/docs/.mdox-validate.yaml
@@ -6,3 +6,5 @@ validators:
   # use the GitHub API.
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)uber-go\/fx(\/pull\/|\/issues\/)'
     type: 'githubPullsIssues'
+  - regex: '^http[s]://github.com/uber-go/fx/compare/[^/]*$'
+    type: 'ignore'


### PR DESCRIPTION
The lint CI step for #1171 is failing because it adds a comparison link in the changelog that does not yet exist (the 1.20.2 tag has not been created yet).

This PR ignores these types of links when validating links during docs linting in CI.

Tested this by adding the link from #1171 into the changelog.

Before this change:
```
$ make docs-lint
Checking documentation
...
error:          changelog.md:19: "https://github.com/uber-go/fx/compare/v1.20.0...v1.20.2" not accessible; status code 404: Not Found
make[1]: *** [check] Error 1
make: *** [docs-lint] Error 2
```
After this change:
```
$ make docs-lint
Checking documentation
```