### PR TITLE
Fix golangci-lint installation step in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,7 +75,7 @@ jobs:
       name: Install golangci-lint
       with:
         version: latest
-        args: --version  # make lint will run the linter
+        args: --help  # make lint will run the linter
 
     - run: make lint
       name: Lint


### PR DESCRIPTION
Following https://github.com/uber-go/zap/pull/1424 as an example, fix CI to use `--help` flag since `--version` is no longer accepted.

(example issue: https://github.com/uber-go/fx/actions/runs/8469190208/job/23203935028?pr=1182)