### PR TITLE
drop io/utils package.

### DIFF
--- a/app_windows_test.go
+++ b/app_windows_test.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -84,9 +83,9 @@ func TestWindowsCtrlCHandler(t *testing.T) {
 		"SIGINT child process")
 
 	// Drain stdout and stderr, and wait for the process to exit.
-	output, err := ioutil.ReadAll(stdout)
+	output, err := io.ReadAll(stdout)
 	require.NoError(t, err)
-	_, err = io.Copy(ioutil.Discard, stderr)
+	_, err = io.Copy(io.Discard, stderr)
 	require.NoError(t, err)
 	require.NoError(t, cmd.Wait())
 


### PR DESCRIPTION
/kind cleanup

Drop ioutil package.
As it is deprecation , and can be replaced well.

```
Deprecated: As of Go 1.16, the same functionality is now 
provided by package [io](https://pkg.go.dev/io) 
or package [os](https://pkg.go.dev/os), 
and those implementations should be preferred in new code
```