### PR TITLE
CI: test against go1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.21.x", "1.22.x"]
 
     steps:
     - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     - name: Test
       run: make cover COVER_MODULES=./docs
@@ -68,7 +68,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: false  # managed by golangci-lint
 
     - uses: golangci/golangci-lint-action@v4

--- a/app_121_test.go
+++ b/app_121_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Uber Technologies, Inc.
+// Copyright (c) 2024 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,33 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build (go1.21 && !go1.22)
-// +build go1.21,!go1.22
+//go:build !go1.22
+// +build !go1.22
 
-package fxreflect
+package fx_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	. "go.uber.org/fx"
 )
 
-func TestDeepStack(t *testing.T) {
-	t.Run("nest", func(t *testing.T) {
-		// Introduce a few frames.
-		frames := func() []Frame {
-			return func() []Frame {
-				return CallerStack(0, 0)
-			}()
-		}()
+func TestNopLoggerOptionString(t *testing.T) {
+	t.Parallel()
 
-		require.True(t, len(frames) > 3, "expected at least three frames")
-		for i, name := range []string{"func1.TestDeepStack.func1.1.func2", "func1.1", "func1"} {
-			f := frames[i]
-			assert.Equal(t, "go.uber.org/fx/internal/fxreflect.TestDeepStack."+name, f.Function)
-			assert.Contains(t, f.File, "internal/fxreflect/stack_121_test.go")
-			assert.NotZero(t, f.Line)
-		}
-	})
+	assert.Equal(t,
+		"fx.WithLogger(go.uber.org/fx.glob..func1())",
+		NopLogger.String(),
+	)
 }

--- a/app_122_test.go
+++ b/app_122_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Uber Technologies, Inc.
+// Copyright (c) 2024 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,33 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build (go1.21 && !go1.22)
-// +build go1.21,!go1.22
+//go:build go1.22
+// +build go1.22
 
-package fxreflect
+package fx_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	. "go.uber.org/fx"
 )
 
-func TestDeepStack(t *testing.T) {
-	t.Run("nest", func(t *testing.T) {
-		// Introduce a few frames.
-		frames := func() []Frame {
-			return func() []Frame {
-				return CallerStack(0, 0)
-			}()
-		}()
+func TestNopLoggerOptionString(t *testing.T) {
+	t.Parallel()
 
-		require.True(t, len(frames) > 3, "expected at least three frames")
-		for i, name := range []string{"func1.TestDeepStack.func1.1.func2", "func1.1", "func1"} {
-			f := frames[i]
-			assert.Equal(t, "go.uber.org/fx/internal/fxreflect.TestDeepStack."+name, f.Function)
-			assert.Contains(t, f.File, "internal/fxreflect/stack_121_test.go")
-			assert.NotZero(t, f.Line)
-		}
-	})
+	assert.Equal(t,
+		"fx.WithLogger(go.uber.org/fx.init.func1())",
+		NopLogger.String(),
+	)
 }

--- a/app_test.go
+++ b/app_test.go
@@ -2543,11 +2543,6 @@ func TestOptionString(t *testing.T) {
 			want: "fx.WithLogger(go.uber.org/fx_test.TestOptionString.func3())",
 		},
 		{
-			desc: "NopLogger",
-			give: NopLogger,
-			want: "fx.WithLogger(go.uber.org/fx.glob..func1())",
-		},
-		{
 			desc: "ErrorHook",
 			give: ErrorHook(testErrorHandler{t}),
 			want: "fx.ErrorHook(TestOptionString)",

--- a/internal/fxreflect/stack_122_test.go
+++ b/internal/fxreflect/stack_122_test.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build (go1.21 && !go1.22)
-// +build go1.21,!go1.22
+//go:build go1.22
+// +build go1.22
 
 package fxreflect
 
@@ -40,10 +40,10 @@ func TestDeepStack(t *testing.T) {
 		}()
 
 		require.True(t, len(frames) > 3, "expected at least three frames")
-		for i, name := range []string{"func1.TestDeepStack.func1.1.func2", "func1.1", "func1"} {
+		for i, name := range []string{"func1.TestDeepStack.func1.1.2", "func1.1", "func1"} {
 			f := frames[i]
 			assert.Equal(t, "go.uber.org/fx/internal/fxreflect.TestDeepStack."+name, f.Function)
-			assert.Contains(t, f.File, "internal/fxreflect/stack_121_test.go")
+			assert.Contains(t, f.File, "internal/fxreflect/stack_122_test.go")
 			assert.NotZero(t, f.Line)
 		}
 	})


### PR DESCRIPTION
This PR modifies CI to test against Go versions 1.21 and 1.22. To avoid forcing users to upgrade to 1.21, I kept `go.mod` version at `1.20.`

Some tests had to be updated to pass in 1.22.

I can remove `stack_120_test.go` if there's a good argument for it, but my thoughts are that we should have a complete & passing test suite for every version >= `go.mod`'s version.