### PR TITLE
feat(signal): add StopDelay option

### DIFF
--- a/app.go
+++ b/app.go
@@ -158,6 +158,27 @@ func (t stopTimeoutOption) String() string {
 	return fmt.Sprintf("fx.StopTimeout(%v)", time.Duration(t))
 }
 
+// StopDelay adds a delay between the receipt of a system shutdown signal
+// and its propagation to the [OnStop] hooks.
+func StopDelay(v time.Duration) Option {
+	return stopDelayOption(v)
+}
+
+type stopDelayOption time.Duration
+
+func (t stopDelayOption) apply(m *module) {
+	if m.parent != nil {
+		m.app.err = fmt.Errorf("fx.StopDelay Option should be passed to top-level App, " +
+			"not to fx.Module")
+	} else {
+		m.app.receivers.delaySignal = time.Duration(t)
+	}
+}
+
+func (t stopDelayOption) String() string {
+	return fmt.Sprintf("fx.StopDelay(%v)", time.Duration(t))
+}
+
 // RecoverFromPanics causes panics that occur in functions given to [Provide],
 // [Decorate], and [Invoke] to be recovered from.
 // This error can be retrieved as any other error, by using (*App).Err().

--- a/module_test.go
+++ b/module_test.go
@@ -596,6 +596,10 @@ func TestModuleFailures(t *testing.T) {
 				desc: "Logger Option",
 				opt:  fx.Logger(log.New(&bytes.Buffer{}, "", 0)),
 			},
+			{
+				desc: "StopDelay Option",
+				opt:  fx.StopDelay(time.Second),
+			},
 		}
 
 		for _, tt := range tests {

--- a/signal.go
+++ b/signal.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"time"
 )
 
 // ShutdownSignal represents a signal to be written to Wait or Done.
@@ -79,6 +80,9 @@ type signalReceivers struct {
 
 	// contains channels created by Wait
 	wait []chan ShutdownSignal
+
+	// time to wait before relaying the signals.
+	delaySignal time.Duration
 }
 
 func (recv *signalReceivers) relayer() {
@@ -90,6 +94,7 @@ func (recv *signalReceivers) relayer() {
 	case <-recv.shutdown:
 		return
 	case signal := <-recv.signals:
+		time.Sleep(recv.delaySignal)
 		recv.Broadcast(ShutdownSignal{
 			Signal: signal,
 		})


### PR DESCRIPTION
Hello 👋. Fx "under the hood" handling of the shutdown signals is preventing us from fixing a race condition between sidecars and services at the k8s level.

For non-fx go programs, we handle this by using a main context with a delayed call to the CancelFunc when Notify triggers on a syscall. With fx, this could also be handled by adding some time.Sleep to every `OnStop` hook but it's not really elegant nor flexible.

This is my attempt at fixing that, another less "specific to my problem" solution would be to have a way to interact with or replace the `signalReceivers.notify` function maybe ?

I'm not super happy with `m.app.receivers.delaySignal` because it rely only on the order of operation in app.go `New()` and the fact that everything is in the same package, but I wanted to avoid changing `newSignalReceivers` signature.

Happy to hear what you think about it, what needs to be changed etc 👍 
