### PR TITLE
Prepare Release 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.22.0](https://github.com/uber-go/fx/compare/v1.21.1...v1.22.0) - 2024-05-29
+
+### Added
+- Add `fx.Self` which can be passed to the `fx.As` annotation to signify
+  that a type should be provided as itself.
+- Add `fxtest.EnforceTimeout` that can be passed to `fxtest.NewLifecycle`
+  to force `Start` and `Stop` to return context errors when hook context expires.
+
+### Changed
+- `fx.Private` can now be used with `fx.Supply`.
+
+### Fixed
+- Fx apps will no longer listen to OS signals when they are stopped,
+  solving blocking issues in programs that depended on OS signals
+  after an Fx app stops.
 
 ## [1.21.1](https://github.com/uber-go/fx/compare/v1.21.0...v1.21.1) - 2024-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.22.0](https://github.com/uber-go/fx/compare/v1.21.1...v1.22.0) - 2024-05-29
+## [1.22.0](https://github.com/uber-go/fx/compare/v1.21.1...v1.22.0) - 2024-05-30
 
 ### Added
 - Add `fx.Self` which can be passed to the `fx.As` annotation to signify

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.22.0-dev"
+const Version = "1.22.0"


### PR DESCRIPTION
This updates the changelog and the version for a 1.22.0 release.

I will wait to merge this until #1207 is reviewed.

I tested Fx tip within Uber's Go codebase and saw no issues.

Ref: #1204