### PR TITLE
Prepare Release v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## [1.22.1](https://github.com/uber-go/fx/compare/v1.22.0...v1.22.1) - 2024-06-25
+
+### Fixed
+- Fx apps will only listen to signals when `.Run()`, `.Wait()`, or `.Done()`
+  are called, fixing a regression introduced in v1.19.0.
 
 ## [1.22.0](https://github.com/uber-go/fx/compare/v1.21.1...v1.22.0) - 2024-05-30
 

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.23.0-dev"
+const Version = "1.22.1"


### PR DESCRIPTION
Update changelog and `version.go` for a patch release that includes #1215.