### PR TITLE
Clarify example "Export boundary functions"

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -133,7 +133,9 @@ var Module = fx.Module("server",
   ),
 )
 
-type Config struct {
+type Params struct {
+  fx.In
+
   Addr string `yaml:"addr"`
 }
 
@@ -142,7 +144,7 @@ func New(p Params) (Result, error) {
 
 In this example, we don't export `parseConfig`,
 because it's a trivial `yaml.Decode` that we don't need to expose,
-but we still export `Config` so users can decode it themselves.
+but we still export `Params` so users can decode it themselves.
 
 **Rationale**:
 It should be possible to use your Fx module without using Fx itself.


### PR DESCRIPTION
The following example is confusing. 
- If `Config` is supposed to be a parameter object, it should be named `Params` since the constructor is called `New(...)` and needs defined `fx.In` within. 
- If it is not meant to be an parameter object, I think passing `Params` into the constructor without defining that in the example is confusing.
  - Maybe we should be passing a `Config` instead? i.e. `New(c Config)`

I changed the example to use a parameter object, because I think using the parameter object makes sense here. I think if its not supposed to use a parameter object, updating the names of `Params` or `Config` to align could help make the example more clear.