### PR TITLE
Support multiple `ResultTags` annotations

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -329,7 +329,7 @@ func TestNewApp(t *testing.T) {
 		//     cannot provide fx_test.t1[name="foo"] from [0].Field0:
 		//     already provided by "reflect".makeFuncStub (/.../reflect/asm_amd64.s:30)
 		assert.Contains(t, err.Error(), `fx.Provide(fx.Annotate(`)
-		assert.Contains(t, err.Error(), `fx.ResultTags(["name:\"foo\""])`)
+		assert.Contains(t, err.Error(), `fx.ResultTags([["name:\"foo\""]])`)
 		assert.Contains(t, err.Error(), "already provided")
 	})
 


### PR DESCRIPTION
Closes #1210

This commit makes it possible to specify multiple `fx.ResultTags` annotations in a single `fx.Annotate` call.

```go
fx.Provide(
    fx.Annotate(
        func() *bytes.Buffer {
            return bytes.NewBuffer([]byte("Hello!"))
        },
        fx.ResultTags(`name:"a"`),
        fx.ResultTags(`name:"b"`),
        fx.ResultTags(`name:"c"`),
    ),
)
```