### PR TITLE
Fix changelog duplicate entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade Dig dependency to v1.18.0
 
-## [1.22.2](https://github.com/uber-go/fx/compare/v1.22.1...v1.22.2) - 2024-08-07
-
-### Fixed
-- A deadlock with the relayer in signal receivers.
-
-### Changed
-- Upgrade Dig dependency to v1.18.0
-
 ## [1.22.1](https://github.com/uber-go/fx/compare/v1.22.0...v1.22.1) - 2024-06-25
 
 ### Fixed

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.22.2"
+const Version = "1.22.3-dev"


### PR DESCRIPTION
For some reason #1229 added duplicate entry for 1.22.2