### PR TITLE
Preparing release v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.22.3](https://github.com/uber-go/fx/compare/v1.22.2...v1.22.3) - 2024-10-11
+## [1.23.0](https://github.com/uber-go/fx/compare/v1.22.2...v1.22.3) - 2024-10-11
 
 ### Added
 - Added `Runtime` to `fxevent.Run` event, which stores the runtime of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.3](https://github.com/uber-go/fx/compare/v1.22.2...v1.22.3) - 2024-10-11
+
+### Added
+- Added `Runtime` to `fxevent.Run` event, which stores the runtime of
+  a constructor or a decorator that's run, including functions created
+  by `fx.Supply` and `fx.Replace`.
+
+### Changed
+- Overhauled the documentation website. (https://uber-go.github.io/fx/)
+
 ## [1.22.2](https://github.com/uber-go/fx/compare/v1.22.1...v1.22.2) - 2024-08-07
 
 ### Fixed

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.22.3-dev"
+const Version = "1.22.3"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package fx
 
 // Version is exported for runtime compatibility checks.
-const Version = "1.22.3"
+const Version = "1.23.0"


### PR DESCRIPTION
Update changelog and version for a 1.23.0 release.

Tip of Fx has been tested internally at Uber with no issues.