### PR TITLE
Adding a before-call-begins fxevent, to help with troubleshooting

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/dig v1.18.0 // indirect
+	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -10,8 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.uber.org/dig v1.18.0 h1:imUL1UiY0Mg4bqbFfsRQO5G4CGRBec/ZujWTvSVp3pw=
-go.uber.org/dig v1.18.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
+go.uber.org/dig v1.19.0 h1:BACLhebsYdpQ7IROQ1AGPjrXcP5dF80U3gKoFzbaq/4=
+go.uber.org/dig v1.19.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/fxevent/console.go
+++ b/fxevent/console.go
@@ -104,6 +104,12 @@ func (l *ConsoleLogger) LogEvent(event Event) {
 		if e.Err != nil {
 			l.logf("Error after options were applied: %+v", e.Err)
 		}
+	case *BeforeRun:
+		var moduleStr string
+		if e.ModuleName != "" {
+			moduleStr = fmt.Sprintf(" from module %q", e.ModuleName)
+		}
+		l.logf("BEFORE RUN\t%s: %s%s", e.Kind, e.Name, moduleStr)
 	case *Run:
 		var moduleStr string
 		if e.ModuleName != "" {

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -195,7 +195,7 @@ type Decorated struct {
 // BeforeRun is emitted before a constructor, decorator, or supply/replace stub is run by Fx.
 // When complete, a Run will be emitted.
 type BeforeRun struct {
-	// Name is the name of the function that was run.
+	// Name is the name of the function that will be run.
 	Name string
 
 	// Kind indicates which Fx option was used to pass along the function.

--- a/fxevent/event.go
+++ b/fxevent/event.go
@@ -39,6 +39,7 @@ func (*Supplied) event()          {}
 func (*Provided) event()          {}
 func (*Replaced) event()          {}
 func (*Decorated) event()         {}
+func (*BeforeRun) event()         {}
 func (*Run) event()               {}
 func (*Invoking) event()          {}
 func (*Invoked) event()           {}
@@ -189,6 +190,20 @@ type Decorated struct {
 
 	// Err is non-nil if we failed to run this decorator.
 	Err error
+}
+
+// BeforeRun is emitted before a constructor, decorator, or supply/replace stub is run by Fx.
+// When complete, a Run will be emitted.
+type BeforeRun struct {
+	// Name is the name of the function that was run.
+	Name string
+
+	// Kind indicates which Fx option was used to pass along the function.
+	// It is either "provide", "decorate", "supply", or "replace".
+	Kind string
+
+	// ModuleName is the name of the module in which the function belongs.
+	ModuleName string
 }
 
 // Run is emitted after a constructor, decorator, or supply/replace stub is run by Fx.

--- a/fxevent/event_test.go
+++ b/fxevent/event_test.go
@@ -39,6 +39,7 @@ func TestForCoverage(t *testing.T) {
 		&Provided{},
 		&Replaced{},
 		&Decorated{},
+		&BeforeRun{},
 		&Run{},
 		&Invoking{},
 		&Invoked{},

--- a/fxevent/slog.go
+++ b/fxevent/slog.go
@@ -192,6 +192,12 @@ func (l *SlogLogger) LogEvent(event Event) {
 				slogMaybeModuleField(e.ModuleName),
 				slogErr(e.Err))
 		}
+	case *BeforeRun:
+		l.logEvent("before run",
+			slog.String("name", e.Name),
+			slog.String("kind", e.Kind),
+			slogMaybeModuleField(e.ModuleName),
+		)
 	case *Run:
 		if e.Err != nil {
 			l.logError("error returned",

--- a/fxevent/slog_test.go
+++ b/fxevent/slog_test.go
@@ -341,6 +341,15 @@ func TestSlogLogger(t *testing.T) {
 			},
 		},
 		{
+			name:        "BeforeRun",
+			give:        &BeforeRun{Name: "bytes.NewBuffer()", Kind: "constructor"},
+			wantMessage: "before run",
+			wantFields: map[string]interface{}{
+				"name":    "bytes.NewBuffer()",
+				"kind":    "constructor",
+			},
+		},
+		{
 			name:        "Run",
 			give:        &Run{Name: "bytes.NewBuffer()", Kind: "constructor", Runtime: 3 * time.Millisecond},
 			wantMessage: "run",

--- a/fxevent/slog_test.go
+++ b/fxevent/slog_test.go
@@ -345,8 +345,8 @@ func TestSlogLogger(t *testing.T) {
 			give:        &BeforeRun{Name: "bytes.NewBuffer()", Kind: "constructor"},
 			wantMessage: "before run",
 			wantFields: map[string]interface{}{
-				"name":    "bytes.NewBuffer()",
-				"kind":    "constructor",
+				"name": "bytes.NewBuffer()",
+				"kind": "constructor",
 			},
 		},
 		{

--- a/fxevent/zap.go
+++ b/fxevent/zap.go
@@ -167,6 +167,12 @@ func (l *ZapLogger) LogEvent(event Event) {
 				moduleField(e.ModuleName),
 				zap.Error(e.Err))
 		}
+	case *BeforeRun:
+		l.logEvent("before run",
+			zap.String("name", e.Name),
+			zap.String("kind", e.Kind),
+			moduleField(e.ModuleName),
+		)
 	case *Run:
 		if e.Err != nil {
 			l.logError("error returned",

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// TODO: remove, points to before-callback branch
+replace go.uber.org/dig => github.com/Groxx/dig v1.18.2-0.20250324200048-72ef97acadd5

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.uber.org/dig v1.18.0
+	go.uber.org/dig v1.19.0
 	go.uber.org/goleak v1.2.0
 	go.uber.org/multierr v1.10.0
 	go.uber.org/zap v1.26.0
@@ -16,6 +16,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// TODO: remove, points to before-callback branch
-replace go.uber.org/dig => github.com/Groxx/dig v1.18.2-0.20250324200048-72ef97acadd5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Groxx/dig v1.18.2-0.20250324200048-72ef97acadd5 h1:d/J6yEItR4xbk7kC9Cz9U7nM9T7Kom5FkY1jm4cspKA=
+github.com/Groxx/dig v1.18.2-0.20250324200048-72ef97acadd5/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,8 +16,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.uber.org/dig v1.18.0 h1:imUL1UiY0Mg4bqbFfsRQO5G4CGRBec/ZujWTvSVp3pw=
-go.uber.org/dig v1.18.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Groxx/dig v1.18.2-0.20250324200048-72ef97acadd5 h1:d/J6yEItR4xbk7kC9Cz9U7nM9T7Kom5FkY1jm4cspKA=
-github.com/Groxx/dig v1.18.2-0.20250324200048-72ef97acadd5/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +14,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.uber.org/dig v1.19.0 h1:BACLhebsYdpQ7IROQ1AGPjrXcP5dF80U3gKoFzbaq/4=
+go.uber.org/dig v1.19.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -10,7 +10,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/dig v1.18.0 // indirect
+	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -10,8 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.uber.org/dig v1.18.0 h1:imUL1UiY0Mg4bqbFfsRQO5G4CGRBec/ZujWTvSVp3pw=
-go.uber.org/dig v1.18.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
+go.uber.org/dig v1.19.0 h1:BACLhebsYdpQ7IROQ1AGPjrXcP5dF80U3gKoFzbaq/4=
+go.uber.org/dig v1.19.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/module.go
+++ b/module.go
@@ -195,6 +195,13 @@ func (m *module) provide(p provide) {
 	opts := []dig.ProvideOption{
 		dig.FillProvideInfo(&info),
 		dig.Export(!p.Private),
+		dig.WithProviderBeforeCallback(func(bci dig.BeforeCallbackInfo) {
+			m.log.LogEvent(&fxevent.BeforeRun{
+				Name:       funcName,
+				Kind:       "provide",
+				ModuleName: m.name,
+			})
+		}),
 		dig.WithProviderCallback(func(ci dig.CallbackInfo) {
 			m.log.LogEvent(&fxevent.Run{
 				Name:       funcName,
@@ -229,6 +236,13 @@ func (m *module) supply(p provide) {
 	typeName := p.SupplyType.String()
 	opts := []dig.ProvideOption{
 		dig.Export(!p.Private),
+		dig.WithProviderBeforeCallback(func(bci dig.BeforeCallbackInfo) {
+			m.log.LogEvent(&fxevent.BeforeRun{
+				Name:       fmt.Sprintf("stub(%v)", typeName),
+				Kind:       "supply",
+				ModuleName: m.name,
+			})
+		}),
 		dig.WithProviderCallback(func(ci dig.CallbackInfo) {
 			m.log.LogEvent(&fxevent.Run{
 				Name:       fmt.Sprintf("stub(%v)", typeName),
@@ -352,6 +366,13 @@ func (m *module) decorate(d decorator) (err error) {
 	var info dig.DecorateInfo
 	opts := []dig.DecorateOption{
 		dig.FillDecorateInfo(&info),
+		dig.WithDecoratorBeforeCallback(func(bci dig.BeforeCallbackInfo) {
+			m.log.LogEvent(&fxevent.BeforeRun{
+				Name:       funcName,
+				Kind:       "decorate",
+				ModuleName: m.name,
+			})
+		}),
 		dig.WithDecoratorCallback(func(ci dig.CallbackInfo) {
 			m.log.LogEvent(&fxevent.Run{
 				Name:       funcName,
@@ -384,6 +405,13 @@ func (m *module) decorate(d decorator) (err error) {
 func (m *module) replace(d decorator) error {
 	typeName := d.ReplaceType.String()
 	opts := []dig.DecorateOption{
+		dig.WithDecoratorBeforeCallback(func(bci dig.BeforeCallbackInfo) {
+			m.log.LogEvent(&fxevent.BeforeRun{
+				Name:       fmt.Sprintf("stub(%v)", typeName),
+				Kind:       "replace",
+				ModuleName: m.name,
+			})
+		}),
 		dig.WithDecoratorCallback(func(ci dig.CallbackInfo) {
 			m.log.LogEvent(&fxevent.Run{
 				Name:       fmt.Sprintf("stub(%v)", typeName),

--- a/module_test.go
+++ b/module_test.go
@@ -262,15 +262,15 @@ func TestModuleSuccess(t *testing.T) {
 				giveWithLogger: fx.NopLogger,
 				wantEvents: []string{
 					"Provided", "Provided", "Provided", "Supplied",
-					"Run", "LoggerInitialized", "Invoking", "Invoked",
+					"BeforeRun", "Run", "LoggerInitialized", "Invoking", "Invoked",
 				},
 			},
 			{
 				desc:           "Not using a custom logger for module defaults to app logger",
 				giveWithLogger: fx.Options(),
 				wantEvents: []string{
-					"Provided", "Provided", "Provided", "Supplied", "Provided", "Run",
-					"LoggerInitialized", "Invoking", "Run", "Invoked", "Invoking", "Invoked",
+					"Provided", "Provided", "Provided", "Supplied", "Provided", "BeforeRun", "Run",
+					"LoggerInitialized", "Invoking", "BeforeRun", "Run", "Invoked", "Invoking", "Invoked",
 				},
 			},
 		}
@@ -353,8 +353,8 @@ func TestModuleSuccess(t *testing.T) {
 		)
 
 		assert.Equal(t, []string{
-			"Provided", "Supplied", "Replaced", "Run", "Run",
-			"LoggerInitialized", "Invoking", "Run", "Invoked",
+			"Provided", "Supplied", "Replaced", "BeforeRun", "Run", "BeforeRun", "Run",
+			"LoggerInitialized", "Invoking", "BeforeRun", "Run", "Invoked",
 		}, moduleSpy.EventTypes())
 
 		assert.Equal(t, []string{
@@ -413,9 +413,9 @@ func TestModuleSuccess(t *testing.T) {
 		)
 
 		assert.Equal(t, []string{
-			"Supplied", "Provided", "Replaced", "Run", "Run", "LoggerInitialized",
+			"Supplied", "Provided", "Replaced", "BeforeRun", "Run", "BeforeRun", "Run", "LoggerInitialized",
 			// Invoke logged twice, once from child and another from grandchild
-			"Invoking", "Run", "Invoked", "Invoking", "Invoked",
+			"Invoking", "BeforeRun", "Run", "Invoked", "Invoking", "Invoked",
 		}, childSpy.EventTypes(), "events from grandchild also logged in child logger")
 
 		assert.Equal(t, []string{
@@ -649,7 +649,7 @@ func TestModuleFailures(t *testing.T) {
 					"must provide constructor function, got  (type *bytes.Buffer)",
 				},
 				wantEvents: []string{
-					"Supplied", "Provided", "Run", "LoggerInitialized",
+					"Supplied", "Provided", "BeforeRun", "Run", "LoggerInitialized",
 				},
 			},
 			{
@@ -660,7 +660,7 @@ func TestModuleFailures(t *testing.T) {
 				giveAppOpts:     spyAsLogger,
 				wantErrContains: []string{"error building logger"},
 				wantEvents: []string{
-					"Provided", "Provided", "Provided", "Supplied", "Run",
+					"Provided", "Provided", "Provided", "Supplied", "BeforeRun", "Run",
 					"LoggerInitialized", "Provided", "LoggerInitialized",
 				},
 			},
@@ -678,8 +678,8 @@ func TestModuleFailures(t *testing.T) {
 				giveAppOpts:     spyAsLogger,
 				wantErrContains: []string{"error building logger dependency"},
 				wantEvents: []string{
-					"Provided", "Provided", "Provided", "Supplied", "Run",
-					"LoggerInitialized", "Provided", "Provided", "Run", "LoggerInitialized",
+					"Provided", "Provided", "Provided", "Supplied", "BeforeRun", "Run",
+					"LoggerInitialized", "Provided", "Provided", "BeforeRun", "Run", "LoggerInitialized",
 				},
 			},
 			{
@@ -690,7 +690,7 @@ func TestModuleFailures(t *testing.T) {
 					"fx.WithLogger", "from:", "Failed",
 				},
 				wantEvents: []string{
-					"Provided", "Provided", "Provided", "Supplied", "Run",
+					"Provided", "Provided", "Provided", "Supplied", "BeforeRun", "Run",
 					"LoggerInitialized", "Provided", "LoggerInitialized",
 				},
 			},


### PR DESCRIPTION
# What

Adds a "BeforeRun" fxevent.Event, mirroring "Run" but it is called _before_ the provided func is called by Dig, rather than after.

This relies on https://github.com/uber-go/dig/pull/431 (released as v1.19.0).

# Motivation

A recent startup-issue debugging session included logs like this:
```
{"level":"info","ts":1742516783.6106565,"caller":"fxevent/zap.go:51","message":"provided","constructor":"a", ...
...
{"level":"info","ts":1742516783.6106653,"caller":"fxevent/zap.go:51","message":"provided","constructor":"q", ...
...
{"level":"info","ts":1742516783.6106734,"caller":"fxevent/zap.go:51","message":"provided","constructor":"z", ...
...
{"level":"info","ts":1742516784.7998207,"caller":"fxevent/zap.go:51","message":"run","name":"a", ...
{"level":"info","ts":1742516784.7999196,"caller":"fxevent/zap.go:51","message":"run","name":"b", ...
{"level":"info","ts":1742516784.9025834,"caller":"application.go:123", ...
{"level":"info","ts":1742516789.5810778,"caller":"application.go:234", ... 
{"level":"info","ts":1742516790.740516,"caller":"application.go:345", ...
# EOF
```
which accurately reflected the logs the app produced: during startup, it was getting OOM-killed after the final log, several seconds after the last Fx-"run" event.

Unfortunately, Fx's `Run` event is logged _after_ a call completes, so the fxevent log immediately before the application-produced logs tells us _almost nothing_ about what is currently running.  That seems... kinda not ideal.  I've run into this quite a few times over the years, but I finally decided to do something about it.

So I added a "before run" event, so this log will be much easier to diagnose:
```
{"level":"info","ts":1742516784.7899196,"caller":"fxevent/zap.go:51","message":"before run","name":"b", ...
{"level":"info","ts":1742516784.7999196,"caller":"fxevent/zap.go:51","message":"run","name":"b", ...
{"level":"info","ts":1742516784.8000196,"caller":"fxevent/zap.go:51","message":"before run","name":"c", ...
{"level":"info","ts":1742516784.9025834,"caller":"application.go:123", ...
# ^ clearly logged during "c"
```

After a quick attempt in Fx it became pretty clear that it would be difficult or almost impossible to do without changing Dig, so this PR relies on a change to Dig: https://github.com/uber-go/dig/pull/431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the logging system to provide proactive notifications before key lifecycle events, offering clearer insight into system operations.
  
- **Tests**
  - Modified test cases to validate the improved event logging flow for greater accuracy in monitoring system behavior.
  
- **Chores**
  - Updated a core dependency to support the new logging enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->