### PR TITLE
fix: update an invalid check in golangci-lint govet config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters-settings:
   govet:
     # These govet checks are disabled by default, but they're useful.
     enable:
-      - niliness
+      - nilness
       - reflectvaluecompare
       - sortslice
       - unusedwrite


### PR DESCRIPTION
This fixes an invalid check that's listed under golangci-lint's govet config, which is causing lint failures in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted configuration settings to ensure accurate code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->