### PR TITLE
Upgrade to Go 1.23, 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        go: ["1.22.x", "1.23.x"]
+        go: ["1.23.x", "1.24.x"]
 
     steps:
     - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: Test
       run: make cover COVER_MODULES=./docs
@@ -68,7 +68,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
         cache: false  # managed by golangci-lint
 
     - uses: golangci/golangci-lint-action@v6

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/fx/docs
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/fx
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.8.1


### PR DESCRIPTION
Go 1.24 is out, so we can change supported versions to 1.23 and 1.24.
Switch CI to test against 1.23 and 1.24 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the continuous integration pipeline to use Go versions `1.23.x` and `1.24.x` for improved build, test, and lint processes.
	- Revised module dependency configurations to require Go version `1.23.0` for enhanced compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->