### PR TITLE
ci: Test against Go 1.24 and 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        go: ["1.23.x", "1.24.x"]
+        go: ["1.24.x", "1.25.x"]
 
     steps:
     - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
 
     - name: Test
       run: make cover COVER_MODULES=./docs
@@ -68,7 +68,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
         cache: false  # managed by golangci-lint
 
     - uses: golangci/golangci-lint-action@v6

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/fx/docs
 
-go 1.22
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/fx
 
-go 1.22
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/fx/internal/e2e
 
-go 1.22
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.8.2


### PR DESCRIPTION
With the release of Go 1.25, bump CI to run against 1.24 and 1.25,
and bump the minimum required Go version to 1.24
as this is required to use features introduced in Go 1.24.

(We should bump this to at least 1.23 to start using iterators.)