### PR TITLE
all: go fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
 
     # Our own extras:
     - errorlint
+    - modernize
     - nolintlint  # lints //nolint directives
     - revive
 
@@ -28,11 +29,10 @@ linters:
 
     # These govet checks are disabled by default, but they're useful.
     govet:
-      enable:
-        - nilness
-        - reflectvaluecompare
-        - sortslice
-        - unusedwrite
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
 
     goheader:
       values:

--- a/annotated.go
+++ b/annotated.go
@@ -100,13 +100,13 @@ var (
 	// field used for embedding fx.In type in generated struct.
 	_inAnnotationField = reflect.StructField{
 		Name:      "In",
-		Type:      reflect.TypeOf(In{}),
+		Type:      reflect.TypeFor[In](),
 		Anonymous: true,
 	}
 	// field used for embedding fx.Out type in generated struct.
 	_outAnnotationField = reflect.StructField{
 		Name:      "Out",
-		Type:      reflect.TypeOf(Out{}),
+		Type:      reflect.TypeFor[Out](),
 		Anonymous: true,
 	}
 )
@@ -120,7 +120,7 @@ type Annotation interface {
 }
 
 var (
-	_typeOfError = reflect.TypeOf((*error)(nil)).Elem()
+	_typeOfError = reflect.TypeFor[error]()
 	_nilError    = reflect.Zero(_typeOfError)
 )
 
@@ -661,8 +661,8 @@ func (la *lifecycleHookAnnotation) build(ann *annotated) (any, error) {
 }
 
 var (
-	_typeOfLifecycle = reflect.TypeOf((*Lifecycle)(nil)).Elem()
-	_typeOfContext   = reflect.TypeOf((*context.Context)(nil)).Elem()
+	_typeOfLifecycle = reflect.TypeFor[Lifecycle]()
+	_typeOfContext   = reflect.TypeFor[context.Context]()
 )
 
 // validateHookDeps validates the dependencies of a hook function and returns true if the dependencies are valid.
@@ -1299,7 +1299,7 @@ func (at *asAnnotation) apply(ann *annotated) error {
 			continue
 		}
 		t := reflect.TypeOf(typ)
-		if t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Interface {
+		if t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Interface {
 			return fmt.Errorf("fx.As: argument must be a pointer to an interface: got %v", t)
 		}
 		t = t.Elem()
@@ -1498,7 +1498,7 @@ func (fr *fromAnnotation) apply(ann *annotated) error {
 			return errors.New("fx.From: cannot annotate a variadic argument")
 		}
 		t := reflect.TypeOf(typ)
-		if t == nil || t.Kind() != reflect.Ptr {
+		if t == nil || t.Kind() != reflect.Pointer {
 			return fmt.Errorf("fx.From: argument must be a pointer to a type that implements some interface: got %v", t)
 		}
 		fr.types[i] = t.Elem()

--- a/app_unixes.go
+++ b/app_unixes.go
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package fx
 

--- a/app_wasm.go
+++ b/app_wasm.go
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 //go:build (js && wasm) || (wasip1 && wasm)
-// +build js,wasm wasip1,wasm
 
 package fx
 

--- a/app_windows.go
+++ b/app_windows.go
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 //go:build windows
-// +build windows
 
 package fx
 

--- a/app_windows_test.go
+++ b/app_windows_test.go
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 //go:build windows
-// +build windows
 
 package fx_test
 

--- a/docs/ex/annotate/cast_bad.go
+++ b/docs/ex/annotate/cast_bad.go
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 //go:build ignore
-// +build ignore
 
 package annotate
 

--- a/docs/ex/value-groups/consume/param.go
+++ b/docs/ex/value-groups/consume/param.go
@@ -23,7 +23,7 @@ package consume
 import "go.uber.org/fx"
 
 // Watcher watches for events.
-type Watcher interface{}
+type Watcher any
 
 // ParamsModule is the module defined in this file.
 var ParamsModule = fx.Options(

--- a/docs/ex/value-groups/feed/result.go
+++ b/docs/ex/value-groups/feed/result.go
@@ -30,7 +30,7 @@ var ResultModule = fx.Options(
 )
 
 // Watcher watches for events.
-type Watcher interface{}
+type Watcher any
 
 type watcher struct{}
 

--- a/docs/src/container.md
+++ b/docs/src/container.md
@@ -18,8 +18,8 @@ type App
   func (app *App) Run()
 
 type Option
-  func Provide(constructors ...interface{}) Option
-  func Invoke(funcs ...interface{}) Option
+  func Provide(constructors ...any) Option
+  func Invoke(funcs ...any) Option
 ```
 
 Check the [API Reference](https://pkg.go.dev/go.uber.org/fx#Option)
@@ -82,7 +82,7 @@ it can only be used for non-interface values.
     on runtime reflection to determine the type of the value.
 
     Passing an interface value to `fx.Supply` is a lossy operation:
-    it loses the original interface type, only giving us `interface{}`,
+    it loses the original interface type, only giving us `any`,
     at which point reflection will only reveal the concrete type of the value.
 
     For example, consider:

--- a/extract.go
+++ b/extract.go
@@ -27,7 +27,7 @@ import (
 	"unicode/utf8"
 )
 
-var _typeOfIn = reflect.TypeOf(In{})
+var _typeOfIn = reflect.TypeFor[In]()
 
 // Extract fills the given struct with values from the dependency injection
 // container on application initialization. The target MUST be a pointer to a
@@ -37,7 +37,7 @@ var _typeOfIn = reflect.TypeOf(In{})
 func Extract(target any) Option {
 	v := reflect.ValueOf(target)
 
-	if t := v.Type(); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+	if t := v.Type(); t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Struct {
 		return Error(fmt.Errorf("Extract expected a pointer to a struct, got a %v", t))
 	}
 
@@ -99,7 +99,7 @@ func Extract(target any) Option {
 			// https://github.com/golang/go/issues/21122
 
 			t := f.Type
-			if t.Kind() == reflect.Ptr {
+			if t.Kind() == reflect.Pointer {
 				t = t.Elem()
 			}
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -41,10 +41,10 @@ import (
 // function type that cannot be converted to an underlying function type with
 // a conventional conversion or type switch.
 var (
-	_reflFunc             = reflect.TypeOf(Func(nil))
-	_reflErrorFunc        = reflect.TypeOf(ErrorFunc(nil))
-	_reflContextFunc      = reflect.TypeOf(ContextFunc(nil))
-	_reflContextErrorFunc = reflect.TypeOf(ContextErrorFunc(nil))
+	_reflFunc             = reflect.TypeFor[Func]()
+	_reflErrorFunc        = reflect.TypeFor[ErrorFunc]()
+	_reflContextFunc      = reflect.TypeFor[ContextFunc]()
+	_reflContextErrorFunc = reflect.TypeFor[ContextErrorFunc]()
 )
 
 // Discrete function signatures that are allowed as part of a [Callable].

--- a/populate.go
+++ b/populate.go
@@ -66,7 +66,7 @@ func Populate(targets ...any) Option {
 	fields := make([]reflect.StructField, len(targets)+1)
 	fields[0] = reflect.StructField{
 		Name:      "In",
-		Type:      reflect.TypeOf(In{}),
+		Type:      reflect.TypeFor[In](),
 		Anonymous: true,
 	}
 	for i, t := range targets {
@@ -85,7 +85,7 @@ func Populate(targets ...any) Option {
 		default:
 			rt = reflect.TypeOf(t)
 		}
-		if rt.Kind() != reflect.Ptr {
+		if rt.Kind() != reflect.Pointer {
 			return Error(fmt.Errorf("failed to Populate: target %v is not a pointer type, got %T", i+1, t))
 		}
 		fields[i+1] = reflect.StructField{

--- a/provide.go
+++ b/provide.go
@@ -169,7 +169,7 @@ func runProvide(c container, p provide, opts ...dig.ProvideOption) error {
 			for i := 0; i < ft.NumOut(); i++ {
 				t := ft.Out(i)
 
-				if t == reflect.TypeOf(Annotated{}) {
+				if t == reflect.TypeFor[Annotated]() {
 					return fmt.Errorf(
 						"fx.Annotated should be passed to fx.Provide directly, "+
 							"it should not be returned by the constructor: "+

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -189,7 +189,6 @@ func TestDataRace(t *testing.T) {
 	// the signal received.
 	wg.Add(N)
 	for i := range N {
-		i := i
 		go func() {
 			defer wg.Done()
 			<-ready

--- a/tools/analysis/passes/allfxevents/analysis.go
+++ b/tools/analysis/passes/allfxevents/analysis.go
@@ -58,7 +58,7 @@ var _filter = []ast.Node{
 	&ast.TypeAssertExpr{},
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	fxeventPkg, ok := findPackage(pass.Pkg, "go.uber.org/fx/fxevent")
 	if !ok {
 		// If the package doesn't import fxevent, and itself isn't
@@ -261,7 +261,7 @@ func (ts *typeSet) Remove(t types.Type) (found bool) {
 
 // Iterate iterates through the type set in an unspecified order.
 func (ts *typeSet) Iterate(f func(types.Type)) {
-	ts.m.Iterate(func(t types.Type, _ interface{}) {
+	ts.m.Iterate(func(t types.Type, _ any) {
 		f(t)
 	})
 }


### PR DESCRIPTION
Modernize code with [gofix](https://go.dev/blog/gofix) using the following commands:

```console
find . -name go.mod -not -path '*/vendor/*' -execdir sh -c 'go list -m && go fix ./...' \;
```

Enable `modernize` linter and all `govet` analyzers to prevent these issues in the future.

Similar to #1276, which forgot to enable `modernize`.

Closes #1292