### PR TITLE
docs: correct typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,7 +428,7 @@ First stable release: no breaking changes will be made in the 1.x series.
   to access sub fields.
 - Add `task.MustRegister` convenience function which fails fast by panicking
   Note that this should only be used during app initialization, and is provided
-  to avoid repetetive error checking for services which register many tasks.
+  to avoid repetitive error checking for services which register many tasks.
 - Expose options on task module to disable execution. This will allow users to
   enqueue and consume tasks on different clusters.
 - **[Breaking]** Rename Backend interface `Publish` to `Enqueue`. Created a new

--- a/annotated_test.go
+++ b/annotated_test.go
@@ -2385,7 +2385,7 @@ func TestHookAnnotationFailures(t *testing.T) {
 			),
 		},
 		{
-			name:        "with variactic hook",
+			name:        "with variadic hook",
 			errContains: "must not accept variadic",
 			annotation: fx.Annotate(
 				func() A { return nil },

--- a/app.go
+++ b/app.go
@@ -746,7 +746,7 @@ func (app *App) Done() <-chan os.Signal {
 // Wait returns a channel of [ShutdownSignal] to block on after starting the
 // application and function, similar to [App.Done], but with a minor difference:
 // if the app was shut down via [Shutdowner.Shutdown],
-// the exit code (if provied via [ExitCode]) will be available
+// the exit code (if provided via [ExitCode]) will be available
 // in the [ShutdownSignal] struct.
 // Otherwise, the signal that was received will be set.
 func (app *App) Wait() <-chan ShutdownSignal {

--- a/app_test.go
+++ b/app_test.go
@@ -615,7 +615,7 @@ func TestPrivateProvideWithDecorators(t *testing.T) {
 }
 
 func TestWithLoggerErrorUseDefault(t *testing.T) {
-	// This test cannot be run in paralllel with the others because
+	// This test cannot be run in parallel with the others because
 	// it hijacks stderr.
 
 	// Temporarily hijack stderr and restore it after this test so
@@ -1065,7 +1065,7 @@ func TestInvokes(t *testing.T) {
 		require.ErrorIs(t, invoked[0].(*fxevent.Invoked).Err, wantErr)
 	})
 
-	t.Run("ErrorsAreNotOverriden", func(t *testing.T) {
+	t.Run("ErrorsAreNotOverridden", func(t *testing.T) {
 		t.Parallel()
 
 		type A struct{}

--- a/decorate_test.go
+++ b/decorate_test.go
@@ -113,7 +113,7 @@ func TestDecorateSuccess(t *testing.T) {
 				return &Coffee{Name: "Americano", Price: 3}
 			}, fx.ResultTags(`group:"coffee"`))),
 			fx.Provide(fx.Annotate(func() *Coffee {
-				return &Coffee{Name: "Cappucino", Price: 4}
+				return &Coffee{Name: "Cappuccino", Price: 4}
 			}, fx.ResultTags(`group:"coffee"`))),
 			fx.Provide(fx.Annotate(func() *Coffee {
 				return &Coffee{Name: "Cold Brew", Price: 4}

--- a/docs/internal/apptest/run_test.go
+++ b/docs/internal/apptest/run_test.go
@@ -82,7 +82,7 @@ func TestStart_UnexpectedExit(t *testing.T) {
 	assert.Contains(t, result.Errors[0], "application exited unexpectedly")
 }
 
-func TestStart_Timoeut(t *testing.T) {
+func TestStart_Timeout(t *testing.T) {
 	result := test.WithFake(t, func(t test.T) {
 		Start(t, func() {
 			fmt.Println("Not what we want")

--- a/internal/fxclock/clock_test.go
+++ b/internal/fxclock/clock_test.go
@@ -149,7 +149,7 @@ func TestMock_Sleep(t *testing.T) {
 		// ok
 	}
 
-	// Avance to the next millisecond, the Sleep should return.
+	// Advance to the next millisecond, the Sleep should return.
 	clock.Add(1 * time.Millisecond)
 	select {
 	case <-ch:


### PR DESCRIPTION
The PR fixes typos in docs, comments, and tests.